### PR TITLE
Bugfix/TERMX-20: Pattern validation for terminology server resource ID

### DIFF
--- a/app/src/app/resources/code-system/containers/version/edit/code-system-version-edit.component.html
+++ b/app/src/app/resources/code-system/containers/version/edit/code-system-version-edit.component.html
@@ -13,7 +13,8 @@
               <tw-semantic-version-select name="version"
                   [(ngModel)]="version.version"
                   [versions]="codeSystemId | apply: versions | async"
-                  required></tw-semantic-version-select>
+                  required
+                  [pattern]="versionPattern"></tw-semantic-version-select>
             </m-form-item>
             <m-form-item *mFormCol mName="uri" mLabel="entities.code-system-version.uri">
               <m-input name="uri" [(ngModel)]="version.uri"/>

--- a/app/src/app/resources/code-system/containers/version/edit/code-system-version-edit.component.ts
+++ b/app/src/app/resources/code-system/containers/version/edit/code-system-version-edit.component.ts
@@ -16,6 +16,8 @@ export class CodeSystemVersionEditComponent implements OnInit {
   protected loader = new LoadingManager();
   protected mode: 'add' | 'edit' = 'add';
 
+  public readonly versionPattern: string = '[A-Za-z0-9\\-\\.]{1,64}';
+
   @ViewChild("form") public form?: NgForm;
 
   public constructor(

--- a/app/src/app/resources/map-set/containers/version/edit/map-set-version-edit.component.html
+++ b/app/src/app/resources/map-set/containers/version/edit/map-set-version-edit.component.html
@@ -10,7 +10,11 @@
         <form #form="ngForm" *ngIf="version">
           <m-form-row>
             <m-form-item *mFormCol mName="version" mLabel="entities.map-set-version.version" required>
-              <tw-semantic-version-select name="version" [(ngModel)]="version.version" [versions]="mapSetId | apply: versions | async" required></tw-semantic-version-select>
+              <tw-semantic-version-select name="version" 
+                [(ngModel)]="version.version"
+                [versions]="mapSetId | apply: versions | async"
+                required
+                [pattern]="versionPattern"></tw-semantic-version-select>
             </m-form-item>
             <m-form-item *mFormCol mName="algorithm" mLabel="entities.map-set-version.algorithm">
               <tw-value-set-concept-select name="algorithm" [(ngModel)]="version.algorithm" valueSet="version-algorithm"></tw-value-set-concept-select>

--- a/app/src/app/resources/map-set/containers/version/edit/map-set-version-edit.component.ts
+++ b/app/src/app/resources/map-set/containers/version/edit/map-set-version-edit.component.ts
@@ -17,6 +17,8 @@ export class MapSetVersionEditComponent implements OnInit {
   protected loader = new LoadingManager();
   protected mode: 'add' | 'edit' = 'add';
 
+  public readonly versionPattern: string = '[A-Za-z0-9\\-\\.]{1,64}';
+
   @ViewChild("form") public form?: NgForm;
 
   public constructor(

--- a/app/src/app/resources/resource/components/resource-form.component.html
+++ b/app/src/app/resources/resource/components/resource-form.component.html
@@ -21,7 +21,7 @@
 
   <m-form-row>
     <m-form-item *mFormCol mLabel="entities.resource.id" mName="id" [required]="mode === 'add'">
-      <m-input *ngIf="mode === 'add'" name="id" [(ngModel)]="resource.id" required></m-input>
+      <m-input *ngIf="mode === 'add'" name="id" [(ngModel)]="resource.id" required [pattern]="idPattern"></m-input>
       <div class="m-items-middle" *ngIf="mode !== 'add'">
         <span>{{resource.id}}</span>
         <m-button m-tooltip mTitle="core.btn.edit" (mClick)="idChangeModalData.visible = true">

--- a/app/src/app/resources/resource/components/resource-form.component.html
+++ b/app/src/app/resources/resource/components/resource-form.component.html
@@ -124,7 +124,7 @@
   <ng-container *mModalContent>
     <form #idChangeModalForm="ngForm">
       <m-form-item mName="id" mLabel="web.resource-form.id-change-modal.id" required>
-        <m-input name="id" [(ngModel)]="idChangeModalData.id" required></m-input>
+        <m-input name="id" [(ngModel)]="idChangeModalData.id" required [pattern]="idPattern"></m-input>
       </m-form-item>
     </form>
   </ng-container>

--- a/app/src/app/resources/resource/components/resource-form.component.ts
+++ b/app/src/app/resources/resource/components/resource-form.component.ts
@@ -22,6 +22,8 @@ export class ResourceFormComponent implements OnChanges {
   @Input() public resource?: Resource;
   @Input() public mode?: 'add' | 'edit';
 
+  public readonly idPattern: string = '[A-Za-z0-9\\-.]{1,64}';
+
   protected loader = new LoadingManager();
   protected customPublisher: boolean = false;
   protected publishers: ValueSetVersionConcept[];

--- a/app/src/app/resources/resource/components/resource-form.component.ts
+++ b/app/src/app/resources/resource/components/resource-form.component.ts
@@ -22,7 +22,7 @@ export class ResourceFormComponent implements OnChanges {
   @Input() public resource?: Resource;
   @Input() public mode?: 'add' | 'edit';
 
-  public readonly idPattern: string = '[A-Za-z0-9\\-.]{1,64}';
+  public readonly idPattern: string = '[A-Za-z0-9\\-\\.]{1,64}';
 
   protected loader = new LoadingManager();
   protected customPublisher: boolean = false;

--- a/app/src/app/resources/value-set/containers/version/edit/value-set-version-edit.component.html
+++ b/app/src/app/resources/value-set/containers/version/edit/value-set-version-edit.component.html
@@ -11,7 +11,8 @@
         <tw-semantic-version-select name="version"
             [(ngModel)]="version.version"
             [versions]="valueSetId | apply: versions | async"
-            required></tw-semantic-version-select>
+            required
+            [pattern]="versionPattern"></tw-semantic-version-select>
       </m-form-item>
 
 

--- a/app/src/app/resources/value-set/containers/version/edit/value-set-version-edit.component.ts
+++ b/app/src/app/resources/value-set/containers/version/edit/value-set-version-edit.component.ts
@@ -20,6 +20,7 @@ export class ValueSetVersionEditComponent implements OnInit {
   public mode: 'add' | 'edit' = 'add';
   public loader = new LoadingManager();
 
+  public readonly versionPattern: string = '[A-Za-z0-9\\-\\.]{1,64}';
 
   @ViewChild("form") public form?: NgForm;
 


### PR DESCRIPTION
Issue: https://github.com/termx-health/termx-web/issues/20

Problem was with '/' characters in the code/id field of resources, messing up navigation URLs.
To fix this, a regex pattern validation was implemented for this field in accordance to FHIR ID data type constraints: https://build.fhir.org/datatypes.html#id

The constraint implemented for: CodeSystem, ValueSet, MapSet and ImplementationGuide. 