### PR TITLE
fix(snomed): repair RF2 dry-run build errors

### DIFF
--- a/app/src/app/integration/snomed/containers/management/codesystem/snomed-rf2-scan-result.component.ts
+++ b/app/src/app/integration/snomed/containers/management/codesystem/snomed-rf2-scan-result.component.ts
@@ -112,7 +112,7 @@ export class SnomedRF2ScanResultComponent implements OnInit {
   protected proceeding = false;
 
   public ngOnInit(): void {
-    const state = (this.router.lastSuccessfulNavigation?.extras?.state ?? history.state) as
+    const state = (this.router.lastSuccessfulNavigation()?.extras?.state ?? history.state) as
       {envelope?: ScanEnvelope, shortName?: string} | undefined;
     if (!state?.envelope) {
       this.notificationService.warning('web.snomed.scan-result.no-data');

--- a/app/src/app/integration/snomed/containers/usage/snomed-concept-usage.component.html
+++ b/app/src/app/integration/snomed/containers/usage/snomed-concept-usage.component.html
@@ -7,7 +7,7 @@
           <m-form-item *mFormCol mLabel="web.snomed.concept-usage.codes-input">
             <m-textarea
               name="codes"
-              rows="10"
+              [rows]="10"
               [(ngModel)]="rawInput"
               (ngModelChange)="onInputChange()"
               placeholder="{{'web.snomed.concept-usage.codes-input-placeholder' | translate}}"></m-textarea>

--- a/app/src/app/integration/snomed/containers/usage/snomed-concept-usage.component.ts
+++ b/app/src/app/integration/snomed/containers/usage/snomed-concept-usage.component.ts
@@ -1,6 +1,6 @@
 import {Component, OnInit, inject} from '@angular/core';
 import {FormsModule} from '@angular/forms';
-import {Router} from '@angular/router';
+import {Router, RouterLink} from '@angular/router';
 import {LoadingManager} from '@termx-health/core-util';
 import {
   MarinPageLayoutModule,
@@ -40,6 +40,7 @@ interface SnomedConceptUsage {
     MuiSpinnerModule,
     MuiTableModule,
     MuiTextareaModule,
+    RouterLink,
     TranslatePipe
   ]
 })
@@ -55,7 +56,7 @@ export class SnomedConceptUsageComponent implements OnInit {
   protected results?: SnomedConceptUsage[];
 
   public ngOnInit(): void {
-    const state = (this.router.lastSuccessfulNavigation?.extras?.state ?? history.state) as {codes?: string[], scan?: any} | undefined;
+    const state = (this.router.lastSuccessfulNavigation()?.extras?.state ?? history.state) as {codes?: string[], scan?: any} | undefined;
     if (state?.codes?.length) {
       this.rawInput = state.codes.join('\n');
       this.recomputeDetected();


### PR DESCRIPTION
## Summary

The merge of [#50](https://github.com/termx-health/termx-web/pull/50) (`feat(snomed): RF2 dry-run scan UI + concept-usage page`) failed CI with four Angular 21 compile errors. This PR resolves them:

1. `router.lastSuccessfulNavigation` is a `Signal<Navigation>` in Angular 21 — must be invoked with `()` to read the value. Fixed in both `snomed-rf2-scan-result.component.ts` and `snomed-concept-usage.component.ts`.
2. `m-textarea` `rows` input is typed `number`; the template attribute `rows=\"10\"` is rejected as a string. Switched to `[rows]=\"10\"`.
3. The concept-usage template uses `[routerLink]`, but the standalone component didn't import `RouterLink`. Added it to the component's imports list.

## Verification

`npm run build` succeeds locally (Hash `78b0316b654e902a`, build time 55s, no errors — only unrelated warnings from `node_modules/fhir`).

## Test plan

- [ ] CI build passes
- [ ] Once merged, the `Build` GitHub Actions workflow publishes the new `ghcr.io/termx-health/termx-web:latest` image so deployments can pick up the dry-run feature.