### PR TITLE
fix(snomed): auto-download Markdown alongside JSON on scan-result

### DIFF
--- a/app/src/app/integration/snomed/containers/management/codesystem/snomed-rf2-scan-result.component.ts
+++ b/app/src/app/integration/snomed/containers/management/codesystem/snomed-rf2-scan-result.component.ts
@@ -121,7 +121,10 @@ export class SnomedRF2ScanResultComponent implements OnInit {
     }
     this.envelope = state.envelope;
     this.shortName = state.shortName ?? this.route.snapshot.paramMap.get('shortName') ?? undefined;
-    setTimeout(() => this.downloadJson(), 0);
+    setTimeout(() => {
+      this.downloadJson();
+      this.downloadMarkdown();
+    }, 0);
   }
 
   protected get scan(): ScanResultJson | undefined {


### PR DESCRIPTION
## Summary

Pairs with [termx-server#98](https://github.com/termx-health/termx-server/pull/98).

The original spec for the dry-run scan called for the result to be **shown on screen and saved to file (auto-download)** in both JSON (machine-readable) and Markdown (human-readable) formats. The first cut only auto-fired \`downloadJson()\` on init — users had to click the *Download Markdown* button manually.

This PR triggers both downloads on scan-result open. The toolbar buttons still work for re-triggering.

## Verification

\`npm run build\` — clean local build, no errors.