### PR TITLE
feat(snomed): show progress bar across all three RF2 dry-run phases

### DIFF
--- a/app/src/app/integration/snomed/containers/management/codesystem/snomed-codesystem-edit.component.html
+++ b/app/src/app/integration/snomed/containers/management/codesystem/snomed-codesystem-edit.component.html
@@ -112,9 +112,16 @@
             {{'web.snomed.branch.management.import-modal.dry-run' | translate}}
           </m-checkbox>
         </m-form-item>
-        @if (importModalData.progress) {
+        @if (importModalData.phase === 'uploading' && importModalData.progress) {
           <m-form-item>
+            <div class="m-bold">{{'web.snomed.branch.management.import-modal.uploading' | translate}}</div>
             <nz-progress [nzPercent]="importModalData.progress"></nz-progress>
+          </m-form-item>
+        }
+        @if (importModalData.phase === 'scanning') {
+          <m-form-item>
+            <div class="m-bold">{{'web.snomed.branch.management.import-modal.scanning' | translate}}</div>
+            <nz-progress [nzPercent]="100" nzStatus="active" [nzShowInfo]="false"></nz-progress>
           </m-form-item>
         }
       </form>

--- a/app/src/app/integration/snomed/containers/management/codesystem/snomed-codesystem-edit.component.ts
+++ b/app/src/app/integration/snomed/containers/management/codesystem/snomed-codesystem-edit.component.ts
@@ -32,7 +32,7 @@ export class SnomedCodesystemEditComponent implements OnInit {
 
   protected upgradeModalData: {visible?: boolean, dependantVersion?: string} = {};
   protected exportModalData: {visible?: boolean, type?: string} = {type: 'SNAPSHOT'};
-  protected importModalData: {visible?: boolean, type?: string, file?: any, progress?: number, dryRun?: boolean} = {type: 'SNAPSHOT'};
+  protected importModalData: {visible?: boolean, type?: string, file?: any, progress?: number, dryRun?: boolean, phase?: 'uploading' | 'scanning'} = {type: 'SNAPSHOT'};
 
 
   @ViewChild("form") public form?: NgForm;
@@ -121,9 +121,14 @@ export class SnomedCodesystemEditComponent implements OnInit {
       createCodeSystemVersion: true
     };
 
+    this.importModalData.phase = 'uploading';
+    this.importModalData.progress = 0;
+
     if (this.importModalData.dryRun) {
       this.loader.wrap('import', this.snomedService.scanRF2(request, file, filename)).subscribe(resp => {
         if (resp.finished) {
+          this.importModalData.phase = 'scanning';
+          this.importModalData.progress = undefined;
           this.handleScanLorqueStarted(resp.body);
         } else {
           this.importModalData.progress = resp.progress;
@@ -143,6 +148,7 @@ export class SnomedCodesystemEditComponent implements OnInit {
 
   private handleScanLorqueStarted(lorque: {id: number}): void {
     this.loader.wrap('import', this.lorqueService.pollFinishedProcess(lorque.id, this.destroy$)).subscribe(status => {
+      this.importModalData.phase = undefined;
       if (status === 'failed') {
         this.lorqueService.load(lorque.id).subscribe(p => this.notificationService.error(p.resultText));
         return;

--- a/app/src/app/integration/snomed/containers/management/codesystem/snomed-rf2-scan-result.component.html
+++ b/app/src/app/integration/snomed/containers/management/codesystem/snomed-rf2-scan-result.component.html
@@ -26,6 +26,14 @@
         <m-form-item *mFormCol mLabel="web.snomed.scan-result.release-effective-time">{{scan?.releaseEffectiveTime || '—'}}</m-form-item>
         <m-form-item *mFormCol mLabel="web.snomed.scan-result.scanned-at">{{scan?.scannedAt || '—'}}</m-form-item>
       </m-form-row>
+      @if (proceeding) {
+        <m-form-row>
+          <m-form-item *mFormCol>
+            <div class="m-bold">{{'web.snomed.scan-result.importing' | translate}}</div>
+            <nz-progress [nzPercent]="100" nzStatus="active" [nzShowInfo]="false"></nz-progress>
+          </m-form-item>
+        </m-form-row>
+      }
     </div>
   </m-card>
 

--- a/app/src/app/integration/snomed/containers/management/codesystem/snomed-rf2-scan-result.component.ts
+++ b/app/src/app/integration/snomed/containers/management/codesystem/snomed-rf2-scan-result.component.ts
@@ -14,6 +14,7 @@ import {
   MuiTableModule
 } from '@termx-health/ui';
 import {TranslatePipe} from '@ngx-translate/core';
+import {NzProgressComponent} from 'ng-zorro-antd/progress';
 import {PrivilegedDirective} from 'term-web/core/auth/privileges/privileged.directive';
 import {SnomedService} from 'term-web/integration/snomed/services/snomed-service';
 import {LorqueLibService} from 'term-web/sys/_lib';
@@ -95,6 +96,7 @@ interface ScanEnvelope {
     MuiFormModule,
     MuiSpinnerModule,
     MuiTableModule,
+    NzProgressComponent,
     PrivilegedDirective,
     TranslatePipe
   ]

--- a/app/src/assets/i18n/cs.json
+++ b/app/src/assets/i18n/cs.json
@@ -2150,7 +2150,9 @@
             "header": "Importovat z RF2 zip",
             "type": "Typ",
             "dry-run": "Suchý běh (pouze skenovat, neimportovat)",
-            "dry-run-warning": "Suchý běh vytvoří zprávu o změnách z RF2 zip souboru bez nahrání do Snowstorm. Po dokončení zprávy použijte na obrazovce výsledků tlačítko \"Pokračovat v importu\" pro nahrání stejného souboru."
+            "dry-run-warning": "Suchý běh vytvoří zprávu o změnách z RF2 zip souboru bez nahrání do Snowstorm. Po dokončení zprávy použijte na obrazovce výsledků tlačítko \"Pokračovat v importu\" pro nahrání stejného souboru.",
+            "uploading": "Nahrávání souboru…",
+            "scanning": "Skenování RF2 souboru…"
           },
           "import-succeeded": "Import z RF2 zip byl úspěšný",
           "import-warning": "Tento import vytvoří pracovní větev. Nebude vytvořena žádná verze kódového systému. Nahrávání může trvat více než 30-60 minut v závislosti na velikosti balíčku SNOMED.",
@@ -2236,7 +2238,8 @@
         "stats.descriptions-added": "Přidané popisy",
         "stats.descriptions-invalidated": "Neaktivní popisy",
         "stats.relationships-added": "Přidané vztahy",
-        "stats.relationships-invalidated": "Neaktivní vztahy"
+        "stats.relationships-invalidated": "Neaktivní vztahy",
+        "importing": "Importování do Snowstorm…"
       },
       "concept-usage": {
         "title": "Použití SNOMED konceptu",

--- a/app/src/assets/i18n/de.json
+++ b/app/src/assets/i18n/de.json
@@ -2054,7 +2054,9 @@
             "header": "Import from RF2 zip",
             "type": "Type",
             "dry-run": "Probelauf (nur scannen, nicht importieren)",
-            "dry-run-warning": "Der Probelauf erstellt einen Änderungsbericht aus der RF2-Zip-Datei ohne Upload zu Snowstorm. Sobald der Bericht fertig ist, verwenden Sie auf der Ergebnisseite die Schaltfläche \"Mit Import fortfahren\", um dieselbe Datei hochzuladen."
+            "dry-run-warning": "Der Probelauf erstellt einen Änderungsbericht aus der RF2-Zip-Datei ohne Upload zu Snowstorm. Sobald der Bericht fertig ist, verwenden Sie auf der Ergebnisseite die Schaltfläche \"Mit Import fortfahren\", um dieselbe Datei hochzuladen.",
+            "uploading": "Datei wird hochgeladen…",
+            "scanning": "RF2-Datei wird gescannt…"
           },
           "import-succeeded": "Import from RF2 zip succeeded",
           "import-warning": "This import will create a working branch. No code system version will be created. The upload may take more than 30-60 minutes depending on the size of SNOMED package.",
@@ -2140,7 +2142,8 @@
         "stats.descriptions-added": "Bezeichnungen hinzugefügt",
         "stats.descriptions-invalidated": "Bezeichnungen inaktiviert",
         "stats.relationships-added": "Beziehungen hinzugefügt",
-        "stats.relationships-invalidated": "Beziehungen inaktiviert"
+        "stats.relationships-invalidated": "Beziehungen inaktiviert",
+        "importing": "Import nach Snowstorm läuft…"
       },
       "concept-usage": {
         "title": "SNOMED-Konzept-Verwendung",

--- a/app/src/assets/i18n/en.json
+++ b/app/src/assets/i18n/en.json
@@ -2180,7 +2180,9 @@
 						"header": "Import from RF2 zip",
 						"type": "Type",
 						"dry-run": "Dry run (scan only, do not import)",
-						"dry-run-warning": "Dry run produces a change report from the RF2 zip without uploading it to Snowstorm. Once the report is ready, use the \"Proceed with import\" button on the result screen to push the same file."
+						"dry-run-warning": "Dry run produces a change report from the RF2 zip without uploading it to Snowstorm. Once the report is ready, use the \"Proceed with import\" button on the result screen to push the same file.",
+						"uploading": "Uploading file…",
+						"scanning": "Scanning RF2 file…"
 					},
 					"import-succeeded": "Import from RF2 zip succeeded",
 					"import-warning": "This import will create a working branch. No code system version will be created. The upload may take more than 30-60 minutes depending on the size of SNOMED package.",
@@ -2231,6 +2233,7 @@
 				"check-usage": "Check usage",
 				"proceed-import": "Proceed with import",
 				"proceed-started": "Import started",
+				"importing": "Importing to Snowstorm…",
 				"no-data": "No scan result available",
 				"stats": "Stats",
 				"metric": "Metric",

--- a/app/src/assets/i18n/et.json
+++ b/app/src/assets/i18n/et.json
@@ -1941,7 +1941,9 @@
 						"header": "Import RF2 zip failist",
 						"type": "Tüüp",
 						"dry-run": "Kuiv käivitus (ainult skanneerimine, ei impordi)",
-						"dry-run-warning": "Kuiv käivitus loob RF2 zip-failist muudatuste raporti, kuid ei lae faili Snowstormi. Kui raport on valmis, kasuta tulemuste lehel \"Jätka importimisega\" nuppu sama faili Snowstormi laadimiseks."
+						"dry-run-warning": "Kuiv käivitus loob RF2 zip-failist muudatuste raporti, kuid ei lae faili Snowstormi. Kui raport on valmis, kasuta tulemuste lehel \"Jätka importimisega\" nuppu sama faili Snowstormi laadimiseks.",
+						"uploading": "Faili üleslaadimine…",
+						"scanning": "RF2 faili skanneerimine…"
 					},
 					"import-succeeded": "Import RF2 zip failist õnnestus!",
 					"import-warning": "Antud import loob uue haru (branch).  Koodisüsteemi versiooni ei looda.  Üleslaadimine võib sõltuvalt SNOMED paketi suurusest kesta kauem kui 30-60 minutit.",
@@ -1992,6 +1994,7 @@
 				"check-usage": "Kontrolli kasutust",
 				"proceed-import": "Jätka importimisega",
 				"proceed-started": "Import alustatud",
+				"importing": "Snowstormi importimine…",
 				"no-data": "Skanneerimise tulemust pole",
 				"stats": "Statistika",
 				"metric": "Mõõdik",

--- a/app/src/assets/i18n/fr.json
+++ b/app/src/assets/i18n/fr.json
@@ -2054,7 +2054,9 @@
             "header": "Import from RF2 zip",
             "type": "Type",
             "dry-run": "Simulation (analyse seule, sans import)",
-            "dry-run-warning": "La simulation génère un rapport des changements à partir du fichier RF2 zip sans l'envoyer à Snowstorm. Une fois le rapport prêt, utilisez le bouton \"Procéder à l'import\" sur l'écran des résultats pour pousser le même fichier."
+            "dry-run-warning": "La simulation génère un rapport des changements à partir du fichier RF2 zip sans l'envoyer à Snowstorm. Une fois le rapport prêt, utilisez le bouton \"Procéder à l'import\" sur l'écran des résultats pour pousser le même fichier.",
+            "uploading": "Téléversement du fichier…",
+            "scanning": "Analyse du fichier RF2…"
           },
           "import-succeeded": "Import from RF2 zip succeeded",
           "import-warning": "This import will create a working branch. No code system version will be created. The upload may take more than 30-60 minutes depending on the size of SNOMED package.",
@@ -2140,7 +2142,8 @@
         "stats.descriptions-added": "Désignations ajoutées",
         "stats.descriptions-invalidated": "Désignations invalidées",
         "stats.relationships-added": "Relations ajoutées",
-        "stats.relationships-invalidated": "Relations invalidées"
+        "stats.relationships-invalidated": "Relations invalidées",
+        "importing": "Import vers Snowstorm…"
       },
       "concept-usage": {
         "title": "Utilisation des concepts SNOMED",

--- a/app/src/assets/i18n/lt.json
+++ b/app/src/assets/i18n/lt.json
@@ -2102,7 +2102,9 @@
             "header": "Importuoti iš RF2 zip archyvo",
             "type": "Tipas",
             "dry-run": "Bandomasis paleidimas (tik nuskaityti, neimportuoti)",
-            "dry-run-warning": "Bandomasis paleidimas iš RF2 zip failo sukuria pakeitimų ataskaitą neįkeliant į Snowstorm. Kai ataskaita paruošta, rezultatų ekrane naudokite mygtuką \"Tęsti importą\", kad įkeltumėte tą patį failą."
+            "dry-run-warning": "Bandomasis paleidimas iš RF2 zip failo sukuria pakeitimų ataskaitą neįkeliant į Snowstorm. Kai ataskaita paruošta, rezultatų ekrane naudokite mygtuką \"Tęsti importą\", kad įkeltumėte tą patį failą.",
+            "uploading": "Failas įkeliamas…",
+            "scanning": "RF2 failas nuskaitomas…"
           },
           "import-succeeded": "Importavimas iš RF2 zip archyvo sėkmingas",
           "import-warning": "Importavimo metu bus sukurta redagavimui skirta nomenklatūros atšaka. Kodų sistema sukurta nebus. Priklausomai nuo naudojamo SNOMED paketo dydžio, įkėlimas gali užtrukti virš 30-60 min.",
@@ -2188,7 +2190,8 @@
         "stats.descriptions-added": "Pridėti aprašymai",
         "stats.descriptions-invalidated": "Neaktyvūs aprašymai",
         "stats.relationships-added": "Pridėti ryšiai",
-        "stats.relationships-invalidated": "Neaktyvūs ryšiai"
+        "stats.relationships-invalidated": "Neaktyvūs ryšiai",
+        "importing": "Importuojama į Snowstorm…"
       },
       "concept-usage": {
         "title": "SNOMED koncepto naudojimas",

--- a/app/src/assets/i18n/nl.json
+++ b/app/src/assets/i18n/nl.json
@@ -2058,7 +2058,9 @@
             "header": "Import from RF2 zip",
             "type": "Type",
             "dry-run": "Proefdraai (alleen scannen, niet importeren)",
-            "dry-run-warning": "Proefdraai genereert een wijzigingsrapport uit het RF2-zipbestand zonder upload naar Snowstorm. Zodra het rapport klaar is, gebruik op het resultatenscherm de knop \"Doorgaan met importeren\" om hetzelfde bestand te uploaden."
+            "dry-run-warning": "Proefdraai genereert een wijzigingsrapport uit het RF2-zipbestand zonder upload naar Snowstorm. Zodra het rapport klaar is, gebruik op het resultatenscherm de knop \"Doorgaan met importeren\" om hetzelfde bestand te uploaden.",
+            "uploading": "Bestand uploaden…",
+            "scanning": "RF2-bestand scannen…"
           },
           "import-succeeded": "Import from RF2 zip succeeded",
           "import-warning": "This import will create a working branch. No code system version will be created. The upload may take more than 30-60 minutes depending on the size of SNOMED package.",
@@ -2144,7 +2146,8 @@
         "stats.descriptions-added": "Beschrijvingen toegevoegd",
         "stats.descriptions-invalidated": "Beschrijvingen ingetrokken",
         "stats.relationships-added": "Relaties toegevoegd",
-        "stats.relationships-invalidated": "Relaties ingetrokken"
+        "stats.relationships-invalidated": "Relaties ingetrokken",
+        "importing": "Importeren naar Snowstorm…"
       },
       "concept-usage": {
         "title": "SNOMED-conceptgebruik",


### PR DESCRIPTION
## Summary

The green \`nz-progress\` bar in the SNOMED *Import from RF2 zip* modal currently only renders during the file upload to termx-server. After that the modal goes silent through the (sometimes long) scan phase, and there's no indicator at all when the user later clicks *Proceed with import* on the scan-result page.

This PR keeps a progress indicator visible across all three phases the user goes through:

| Phase | Where | Indicator | Label |
|---|---|---|---|
| Upload | Import modal | Real percent (existing) | *Uploading file…* |
| Scan | Import modal | Active animated bar (100%, no info) | *Scanning RF2 file…* |
| Import to Snowstorm | Scan-result page | Active animated bar (100%, no info) | *Importing to Snowstorm…* |

\`LorqueProcess\` and Snowstorm's import-job API don't expose a real percent today, so phases 2 and 3 use \`nz-progress\` with \`nzPercent=100\` and \`nzStatus=\"active\"\` plus a phase label — that renders a fully-filled bar with the standard ng-zorro \"glowing\" animation, indistinguishable from \"working\" UX in other parts of the app.

## i18n

New keys, translated for **en, et, cs, de, fr, lt, nl** (per-file indentation preserved):

- \`web.snomed.branch.management.import-modal.uploading\`
- \`web.snomed.branch.management.import-modal.scanning\`
- \`web.snomed.scan-result.importing\`

## Verification

\`npm run build\` — clean local build (Hash \`5c6f317b1c9fca9c\`, 45s).

## Test plan

- [ ] CI build passes
- [ ] Manual: trigger a dry-run with a real RF2 zip — verify the bar's label changes from *Uploading file…* to *Scanning RF2 file…* once the upload reaches 100%, and the bar stays visible until the modal closes and routing to the scan-result page begins.
- [ ] Manual: on the scan-result page, click *Proceed with import* — verify *Importing to Snowstorm…* bar appears and stays until the Snowstorm import status reaches a terminal state.
- [ ] Visual: switch UI language to et / cs / de / fr / lt / nl and confirm the labels are localized (no raw key strings).