### PR TITLE
feat(snomed): consume lorque progress for the dry-run scan bar

### DIFF
--- a/app/src/app/integration/snomed/containers/management/codesystem/snomed-codesystem-edit.component.html
+++ b/app/src/app/integration/snomed/containers/management/codesystem/snomed-codesystem-edit.component.html
@@ -120,8 +120,17 @@
         }
         @if (importModalData.phase === 'scanning') {
           <m-form-item>
-            <div class="m-bold">{{'web.snomed.branch.management.import-modal.scanning' | translate}}</div>
-            <nz-progress [nzPercent]="100" nzStatus="active" [nzShowInfo]="false"></nz-progress>
+            <div class="m-bold">
+              {{'web.snomed.branch.management.import-modal.scanning' | translate}}
+              @if (importModalData.progressNote) {
+                <span style="font-weight: normal"> — {{importModalData.progressNote}}</span>
+              }
+            </div>
+            @if (importModalData.progress) {
+              <nz-progress [nzPercent]="importModalData.progress" nzStatus="active"></nz-progress>
+            } @else {
+              <nz-progress [nzPercent]="100" nzStatus="active" [nzShowInfo]="false"></nz-progress>
+            }
           </m-form-item>
         }
       </form>

--- a/app/src/app/integration/snomed/containers/management/codesystem/snomed-codesystem-edit.component.ts
+++ b/app/src/app/integration/snomed/containers/management/codesystem/snomed-codesystem-edit.component.ts
@@ -32,7 +32,7 @@ export class SnomedCodesystemEditComponent implements OnInit {
 
   protected upgradeModalData: {visible?: boolean, dependantVersion?: string} = {};
   protected exportModalData: {visible?: boolean, type?: string} = {type: 'SNAPSHOT'};
-  protected importModalData: {visible?: boolean, type?: string, file?: any, progress?: number, dryRun?: boolean, phase?: 'uploading' | 'scanning'} = {type: 'SNAPSHOT'};
+  protected importModalData: {visible?: boolean, type?: string, file?: any, progress?: number, progressNote?: string, dryRun?: boolean, phase?: 'uploading' | 'scanning'} = {type: 'SNAPSHOT'};
 
 
   @ViewChild("form") public form?: NgForm;
@@ -147,10 +147,19 @@ export class SnomedCodesystemEditComponent implements OnInit {
   }
 
   private handleScanLorqueStarted(lorque: {id: number}): void {
-    this.loader.wrap('import', this.lorqueService.pollFinishedProcess(lorque.id, this.destroy$)).subscribe(status => {
+    this.loader.wrap('import', this.lorqueService.pollProcessProgress(lorque.id, this.destroy$)).subscribe(p => {
+      if (p?.progressPercent != null) {
+        this.importModalData.progress = p.progressPercent;
+      }
+      if (p?.progressNote) {
+        this.importModalData.progressNote = p.progressNote;
+      }
+      if (!p?.status || p.status === 'running') {
+        return;
+      }
       this.importModalData.phase = undefined;
-      if (status === 'failed') {
-        this.lorqueService.load(lorque.id).subscribe(p => this.notificationService.error(p.resultText));
+      if (p.status === 'failed') {
+        this.lorqueService.load(lorque.id).subscribe(loaded => this.notificationService.error(loaded.resultText));
         return;
       }
       this.snomedService.loadScanResult(lorque.id).subscribe(envelope => {

--- a/app/src/app/sys/_lib/lorque/model/lorque-process.ts
+++ b/app/src/app/sys/_lib/lorque/model/lorque-process.ts
@@ -8,4 +8,6 @@ export class LorqueProcess {
   public result?: any;
   public resultText?: string;
   public resultType?: string;
+  public progressPercent?: number;
+  public progressNote?: string;
 }

--- a/app/src/app/sys/_lib/lorque/services/lorque-lib.service.ts
+++ b/app/src/app/sys/_lib/lorque/services/lorque-lib.service.ts
@@ -30,4 +30,17 @@ export class LorqueLibService {
       filter(status => status !== 'running')
     ).pipe(tap(() => stopPolling$.next()));
   }
+
+  public pollProcessProgress(id: number, destroy$: Observable<any> = timer(600_000)): Observable<LorqueProcess> {
+    const stopPolling$ = new Subject<void>();
+    return timer(0, 1500).pipe(
+      takeUntil(merge(destroy$, stopPolling$)),
+      switchMap(() => this.load(id)),
+      tap(p => {
+        if (p?.status && p.status !== 'running') {
+          stopPolling$.next();
+        }
+      })
+    );
+  }
 }


### PR DESCRIPTION
## Summary

Pairs with [termx-server#99](https://github.com/termx-health/termx-server/pull/99). Once the server publishes \`progress_percent\` + \`progress_note\` on \`sys.lorque_process\`, this PR makes the SNOMED dry-run scan bar reflect that real progress instead of the indeterminate active bar.

- \`LorqueProcess\` model gets \`progressPercent\` / \`progressNote\`.
- New \`LorqueLibService.pollProcessProgress(id, destroy$)\` polls the full process every 1.5s and emits \`LorqueProcess\` until the status is terminal. The existing \`pollFinishedProcess\` is left untouched for callers that only need the status.
- \`snomed-codesystem-edit.handleScanLorqueStarted\` switches to the new poll, mirrors \`progressPercent\` into \`importModalData.progress\` and \`progressNote\` into a new \`progressNote\` field.
- Import modal scanning bar is now **determinate** when the server has reported a percent (with the phase note appended to the label — e.g. *Scanning RF2 file… — parsing descriptions*). Falls back to the indeterminate active bar until the first progress arrives, so very short scans still look responsive.

## Verification

\`npm run build\` — clean local build (Hash \`d70dedf8e3479547\`, 47s).

## Test plan

- [ ] CI build passes
- [ ] Manual: dry-run a real RF2 zip — verify the bar transitions from upload-percent → scanning-with-phase-note (e.g. *parsing descriptions* → *computing diff* → *rendering report*) before the result page opens.
- [ ] Manual: confirm the bar stays alive for short Delta scans (sub-second backend) — it should briefly show the indeterminate active bar then go to 100%.