### PR TITLE
feat(snomed): full-mode toggle for the RF2 dry-run scan

### DIFF
--- a/app/src/app/integration/snomed/containers/management/codesystem/snomed-codesystem-edit.component.html
+++ b/app/src/app/integration/snomed/containers/management/codesystem/snomed-codesystem-edit.component.html
@@ -112,6 +112,13 @@
             {{'web.snomed.branch.management.import-modal.dry-run' | translate}}
           </m-checkbox>
         </m-form-item>
+        @if (importModalData.dryRun) {
+          <m-form-item mName="fullMode">
+            <m-checkbox name="fullMode" [(ngModel)]="importModalData.fullMode">
+              {{'web.snomed.branch.management.import-modal.full-mode' | translate}}
+            </m-checkbox>
+          </m-form-item>
+        }
         @if (importModalData.phase === 'uploading' && importModalData.progress) {
           <m-form-item>
             <div class="m-bold">{{'web.snomed.branch.management.import-modal.uploading' | translate}}</div>

--- a/app/src/app/integration/snomed/containers/management/codesystem/snomed-codesystem-edit.component.ts
+++ b/app/src/app/integration/snomed/containers/management/codesystem/snomed-codesystem-edit.component.ts
@@ -32,7 +32,7 @@ export class SnomedCodesystemEditComponent implements OnInit {
 
   protected upgradeModalData: {visible?: boolean, dependantVersion?: string} = {};
   protected exportModalData: {visible?: boolean, type?: string} = {type: 'SNAPSHOT'};
-  protected importModalData: {visible?: boolean, type?: string, file?: any, progress?: number, progressNote?: string, dryRun?: boolean, phase?: 'uploading' | 'scanning'} = {type: 'SNAPSHOT'};
+  protected importModalData: {visible?: boolean, type?: string, file?: any, progress?: number, progressNote?: string, dryRun?: boolean, fullMode?: boolean, phase?: 'uploading' | 'scanning'} = {type: 'SNAPSHOT'};
 
 
   @ViewChild("form") public form?: NgForm;
@@ -115,7 +115,7 @@ export class SnomedCodesystemEditComponent implements OnInit {
 
     const file: File | undefined = this.fileInput?.nativeElement?.files?.[0];
     const filename = file?.name;
-    const request = {
+    const request: {branchPath: string, type: string, createCodeSystemVersion: boolean, mode?: 'summary' | 'full'} = {
       branchPath: this.snomedCodeSystem.branchPath,
       type: this.importModalData.type,
       createCodeSystemVersion: true
@@ -125,6 +125,7 @@ export class SnomedCodesystemEditComponent implements OnInit {
     this.importModalData.progress = 0;
 
     if (this.importModalData.dryRun) {
+      request.mode = this.importModalData.fullMode ? 'full' : 'summary';
       this.loader.wrap('import', this.snomedService.scanRF2(request, file, filename)).subscribe(resp => {
         if (resp.finished) {
           this.importModalData.phase = 'scanning';

--- a/app/src/app/integration/snomed/services/snomed-service.ts
+++ b/app/src/app/integration/snomed/services/snomed-service.ts
@@ -93,7 +93,8 @@ export class SnomedService extends SnomedLibService {
     request: {
       branchPath: string,
       createCodeSystemVersion: boolean,
-      type: string
+      type: string,
+      mode?: 'summary' | 'full'
     },
     file: Blob,
     filename?: string

--- a/app/src/assets/i18n/cs.json
+++ b/app/src/assets/i18n/cs.json
@@ -2152,7 +2152,8 @@
             "dry-run": "Suchý běh (pouze skenovat, neimportovat)",
             "dry-run-warning": "Suchý běh vytvoří zprávu o změnách z RF2 zip souboru bez nahrání do Snowstorm. Po dokončení zprávy použijte na obrazovce výsledků tlačítko \"Pokračovat v importu\" pro nahrání stejného souboru.",
             "uploading": "Nahrávání souboru…",
-            "scanning": "Skenování RF2 souboru…"
+            "scanning": "Skenování RF2 souboru…",
+            "full-mode": "Podrobná analýza (pomalejší; zahrnuje vztahy a přijatelnost)"
           },
           "import-succeeded": "Import z RF2 zip byl úspěšný",
           "import-warning": "Tento import vytvoří pracovní větev. Nebude vytvořena žádná verze kódového systému. Nahrávání může trvat více než 30-60 minut v závislosti na velikosti balíčku SNOMED.",

--- a/app/src/assets/i18n/de.json
+++ b/app/src/assets/i18n/de.json
@@ -2056,7 +2056,8 @@
             "dry-run": "Probelauf (nur scannen, nicht importieren)",
             "dry-run-warning": "Der Probelauf erstellt einen Änderungsbericht aus der RF2-Zip-Datei ohne Upload zu Snowstorm. Sobald der Bericht fertig ist, verwenden Sie auf der Ergebnisseite die Schaltfläche \"Mit Import fortfahren\", um dieselbe Datei hochzuladen.",
             "uploading": "Datei wird hochgeladen…",
-            "scanning": "RF2-Datei wird gescannt…"
+            "scanning": "RF2-Datei wird gescannt…",
+            "full-mode": "Vollständige Analyse (langsamer; einschließlich Beziehungen und Akzeptabilität)"
           },
           "import-succeeded": "Import from RF2 zip succeeded",
           "import-warning": "This import will create a working branch. No code system version will be created. The upload may take more than 30-60 minutes depending on the size of SNOMED package.",

--- a/app/src/assets/i18n/en.json
+++ b/app/src/assets/i18n/en.json
@@ -2182,7 +2182,8 @@
 						"dry-run": "Dry run (scan only, do not import)",
 						"dry-run-warning": "Dry run produces a change report from the RF2 zip without uploading it to Snowstorm. Once the report is ready, use the \"Proceed with import\" button on the result screen to push the same file.",
 						"uploading": "Uploading file…",
-						"scanning": "Scanning RF2 file…"
+						"scanning": "Scanning RF2 file…",
+						"full-mode": "Full analysis (slower; include relationships and acceptability)"
 					},
 					"import-succeeded": "Import from RF2 zip succeeded",
 					"import-warning": "This import will create a working branch. No code system version will be created. The upload may take more than 30-60 minutes depending on the size of SNOMED package.",

--- a/app/src/assets/i18n/et.json
+++ b/app/src/assets/i18n/et.json
@@ -1943,7 +1943,8 @@
 						"dry-run": "Kuiv käivitus (ainult skanneerimine, ei impordi)",
 						"dry-run-warning": "Kuiv käivitus loob RF2 zip-failist muudatuste raporti, kuid ei lae faili Snowstormi. Kui raport on valmis, kasuta tulemuste lehel \"Jätka importimisega\" nuppu sama faili Snowstormi laadimiseks.",
 						"uploading": "Faili üleslaadimine…",
-						"scanning": "RF2 faili skanneerimine…"
+						"scanning": "RF2 faili skanneerimine…",
+						"full-mode": "Põhjalik analüüs (aeglasem; kaasab seosed ja aktsepteeritavuse)"
 					},
 					"import-succeeded": "Import RF2 zip failist õnnestus!",
 					"import-warning": "Antud import loob uue haru (branch).  Koodisüsteemi versiooni ei looda.  Üleslaadimine võib sõltuvalt SNOMED paketi suurusest kesta kauem kui 30-60 minutit.",

--- a/app/src/assets/i18n/fr.json
+++ b/app/src/assets/i18n/fr.json
@@ -2056,7 +2056,8 @@
             "dry-run": "Simulation (analyse seule, sans import)",
             "dry-run-warning": "La simulation génère un rapport des changements à partir du fichier RF2 zip sans l'envoyer à Snowstorm. Une fois le rapport prêt, utilisez le bouton \"Procéder à l'import\" sur l'écran des résultats pour pousser le même fichier.",
             "uploading": "Téléversement du fichier…",
-            "scanning": "Analyse du fichier RF2…"
+            "scanning": "Analyse du fichier RF2…",
+            "full-mode": "Analyse complète (plus lente ; inclut les relations et l'acceptabilité)"
           },
           "import-succeeded": "Import from RF2 zip succeeded",
           "import-warning": "This import will create a working branch. No code system version will be created. The upload may take more than 30-60 minutes depending on the size of SNOMED package.",

--- a/app/src/assets/i18n/lt.json
+++ b/app/src/assets/i18n/lt.json
@@ -2104,7 +2104,8 @@
             "dry-run": "Bandomasis paleidimas (tik nuskaityti, neimportuoti)",
             "dry-run-warning": "Bandomasis paleidimas iš RF2 zip failo sukuria pakeitimų ataskaitą neįkeliant į Snowstorm. Kai ataskaita paruošta, rezultatų ekrane naudokite mygtuką \"Tęsti importą\", kad įkeltumėte tą patį failą.",
             "uploading": "Failas įkeliamas…",
-            "scanning": "RF2 failas nuskaitomas…"
+            "scanning": "RF2 failas nuskaitomas…",
+            "full-mode": "Pilna analizė (lėtesnė; įtraukia ryšius ir priimtinumą)"
           },
           "import-succeeded": "Importavimas iš RF2 zip archyvo sėkmingas",
           "import-warning": "Importavimo metu bus sukurta redagavimui skirta nomenklatūros atšaka. Kodų sistema sukurta nebus. Priklausomai nuo naudojamo SNOMED paketo dydžio, įkėlimas gali užtrukti virš 30-60 min.",

--- a/app/src/assets/i18n/nl.json
+++ b/app/src/assets/i18n/nl.json
@@ -2060,7 +2060,8 @@
             "dry-run": "Proefdraai (alleen scannen, niet importeren)",
             "dry-run-warning": "Proefdraai genereert een wijzigingsrapport uit het RF2-zipbestand zonder upload naar Snowstorm. Zodra het rapport klaar is, gebruik op het resultatenscherm de knop \"Doorgaan met importeren\" om hetzelfde bestand te uploaden.",
             "uploading": "Bestand uploaden…",
-            "scanning": "RF2-bestand scannen…"
+            "scanning": "RF2-bestand scannen…",
+            "full-mode": "Volledige analyse (langzamer; inclusief relaties en acceptabiliteit)"
           },
           "import-succeeded": "Import from RF2 zip succeeded",
           "import-warning": "This import will create a working branch. No code system version will be created. The upload may take more than 30-60 minutes depending on the size of SNOMED package.",


### PR DESCRIPTION
## Summary

Pairs with [termx-server#102](https://github.com/termx-health/termx-server/pull/102).

- Import modal exposes a *Full analysis* checkbox while *Dry run* is ticked. Off (default) → \`mode=summary\`; on → \`mode=full\`.
- \`SnomedService.scanRF2\` request type updated to allow the new field.
- \`snomed-codesystem-edit\` threads the flag through into the multipart request payload.
- New i18n key \`web.snomed.branch.management.import-modal.full-mode\` in all 7 locales (en, et, cs, de, fr, lt, nl). The label explains the trade-off: *Full analysis (slower; include relationships and acceptability)* (or equivalent in each language).

## Verification

\`npm run build\` — clean local build (Hash \`ba70ca6b87574e2e\`, 45s). User confirmed the UI flow end-to-end before merge.

## Test plan

- [ ] CI build passes
- [ ] Dry-run with the box unticked → fast scan, no relationships in result.
- [ ] Dry-run with the box ticked → full scan, attributes populated on new/modified concepts.