### PR TITLE
fix(snomed): surface import errors and add Importing-to-Snowstorm phase

### DIFF
--- a/app/src/app/integration/snomed/containers/management/codesystem/snomed-codesystem-edit.component.html
+++ b/app/src/app/integration/snomed/containers/management/codesystem/snomed-codesystem-edit.component.html
@@ -140,6 +140,12 @@
             }
           </m-form-item>
         }
+        @if (importModalData.phase === 'importing') {
+          <m-form-item>
+            <div class="m-bold">{{'web.snomed.branch.management.import-modal.importing' | translate}}</div>
+            <nz-progress [nzPercent]="100" nzStatus="active" [nzShowInfo]="false"></nz-progress>
+          </m-form-item>
+        }
       </form>
       @if (importModalData.dryRun) {
         <m-alert mType="info" mShowIcon>{{'web.snomed.branch.management.import-modal.dry-run-warning' | translate}}</m-alert>

--- a/app/src/app/integration/snomed/containers/management/codesystem/snomed-codesystem-edit.component.ts
+++ b/app/src/app/integration/snomed/containers/management/codesystem/snomed-codesystem-edit.component.ts
@@ -32,7 +32,7 @@ export class SnomedCodesystemEditComponent implements OnInit {
 
   protected upgradeModalData: {visible?: boolean, dependantVersion?: string} = {};
   protected exportModalData: {visible?: boolean, type?: string} = {type: 'SNAPSHOT'};
-  protected importModalData: {visible?: boolean, type?: string, file?: any, progress?: number, progressNote?: string, dryRun?: boolean, fullMode?: boolean, phase?: 'uploading' | 'scanning'} = {type: 'SNAPSHOT'};
+  protected importModalData: {visible?: boolean, type?: string, file?: any, progress?: number, progressNote?: string, dryRun?: boolean, fullMode?: boolean, phase?: 'uploading' | 'scanning' | 'importing'} = {type: 'SNAPSHOT'};
 
 
   @ViewChild("form") public form?: NgForm;
@@ -126,25 +126,42 @@ export class SnomedCodesystemEditComponent implements OnInit {
 
     if (this.importModalData.dryRun) {
       request.mode = this.importModalData.fullMode ? 'full' : 'summary';
-      this.loader.wrap('import', this.snomedService.scanRF2(request, file, filename)).subscribe(resp => {
-        if (resp.finished) {
-          this.importModalData.phase = 'scanning';
-          this.importModalData.progress = undefined;
-          this.handleScanLorqueStarted(resp.body);
-        } else {
-          this.importModalData.progress = resp.progress;
-        }
+      this.loader.wrap('import', this.snomedService.scanRF2(request, file, filename)).subscribe({
+        next: resp => {
+          if (resp.finished) {
+            this.importModalData.phase = 'scanning';
+            this.importModalData.progress = undefined;
+            this.handleScanLorqueStarted(resp.body);
+          } else {
+            this.importModalData.progress = resp.progress;
+          }
+        },
+        error: err => this.handleImportError(err)
       });
       return;
     }
 
-    this.loader.wrap('import', this.snomedService.createImportJob(request, file)).subscribe(resp => {
-      if (resp.finished) {
-        this.pollJobStatus(resp.body.jobId);
-      } else {
-        this.importModalData.progress = resp.progress;
-      }
+    this.loader.wrap('import', this.snomedService.createImportJob(request, file)).subscribe({
+      next: resp => {
+        if (resp.finished) {
+          this.importModalData.phase = 'importing';
+          this.importModalData.progress = undefined;
+          this.importModalData.progressNote = undefined;
+          this.pollJobStatus(resp.body.jobId);
+        } else {
+          this.importModalData.progress = resp.progress;
+        }
+      },
+      error: err => this.handleImportError(err)
     });
+  }
+
+  private handleImportError(err: any): void {
+    this.importModalData.phase = undefined;
+    this.importModalData.progress = undefined;
+    this.importModalData.progressNote = undefined;
+    const message = err?.error?.message ?? err?.message ?? 'web.snomed.branch.management.import-failed';
+    this.notificationService.error(message);
   }
 
   private handleScanLorqueStarted(lorque: {id: number}): void {
@@ -187,14 +204,17 @@ export class SnomedCodesystemEditComponent implements OnInit {
   }
 
   private pollJobStatus(jobId: string): void {
-    this.loader.wrap('import', this.snomedService.pollImportJob(jobId, this.destroy$)).subscribe(jobResp => {
-      this.importModalData = {type: 'SNAPSHOT'};
-      if (jobResp.status === 'FAILED') {
-        this.notificationService.error(jobResp.errorMessage || 'web.snomed.branch.management.import-failed');
-      }
-      if (jobResp.status === 'COMPLETED') {
-        this.notificationService.success('web.snomed.branch.management.import-succeeded');
-      }
+    this.loader.wrap('import', this.snomedService.pollImportJob(jobId, this.destroy$)).subscribe({
+      next: jobResp => {
+        this.importModalData = {type: 'SNAPSHOT'};
+        if (jobResp.status === 'FAILED') {
+          this.notificationService.error(jobResp.errorMessage || 'web.snomed.branch.management.import-failed');
+        }
+        if (jobResp.status === 'COMPLETED') {
+          this.notificationService.success('web.snomed.branch.management.import-succeeded');
+        }
+      },
+      error: err => this.handleImportError(err)
     });
   }
 

--- a/app/src/assets/i18n/cs.json
+++ b/app/src/assets/i18n/cs.json
@@ -2153,6 +2153,7 @@
             "dry-run-warning": "Suchý běh vytvoří zprávu o změnách z RF2 zip souboru bez nahrání do Snowstorm. Po dokončení zprávy použijte na obrazovce výsledků tlačítko \"Pokračovat v importu\" pro nahrání stejného souboru.",
             "uploading": "Nahrávání souboru…",
             "scanning": "Skenování RF2 souboru…",
+            "importing": "Importování do Snowstorm…",
             "full-mode": "Podrobná analýza (pomalejší; zahrnuje vztahy a přijatelnost)"
           },
           "import-succeeded": "Import z RF2 zip byl úspěšný",

--- a/app/src/assets/i18n/de.json
+++ b/app/src/assets/i18n/de.json
@@ -2057,6 +2057,7 @@
             "dry-run-warning": "Der Probelauf erstellt einen Änderungsbericht aus der RF2-Zip-Datei ohne Upload zu Snowstorm. Sobald der Bericht fertig ist, verwenden Sie auf der Ergebnisseite die Schaltfläche \"Mit Import fortfahren\", um dieselbe Datei hochzuladen.",
             "uploading": "Datei wird hochgeladen…",
             "scanning": "RF2-Datei wird gescannt…",
+            "importing": "Import nach Snowstorm läuft…",
             "full-mode": "Vollständige Analyse (langsamer; einschließlich Beziehungen und Akzeptabilität)"
           },
           "import-succeeded": "Import from RF2 zip succeeded",

--- a/app/src/assets/i18n/en.json
+++ b/app/src/assets/i18n/en.json
@@ -2183,6 +2183,7 @@
 						"dry-run-warning": "Dry run produces a change report from the RF2 zip without uploading it to Snowstorm. Once the report is ready, use the \"Proceed with import\" button on the result screen to push the same file.",
 						"uploading": "Uploading file…",
 						"scanning": "Scanning RF2 file…",
+						"importing": "Importing to Snowstorm…",
 						"full-mode": "Full analysis (slower; include relationships and acceptability)"
 					},
 					"import-succeeded": "Import from RF2 zip succeeded",

--- a/app/src/assets/i18n/et.json
+++ b/app/src/assets/i18n/et.json
@@ -1944,6 +1944,7 @@
 						"dry-run-warning": "Kuiv käivitus loob RF2 zip-failist muudatuste raporti, kuid ei lae faili Snowstormi. Kui raport on valmis, kasuta tulemuste lehel \"Jätka importimisega\" nuppu sama faili Snowstormi laadimiseks.",
 						"uploading": "Faili üleslaadimine…",
 						"scanning": "RF2 faili skanneerimine…",
+						"importing": "Snowstormi importimine…",
 						"full-mode": "Põhjalik analüüs (aeglasem; kaasab seosed ja aktsepteeritavuse)"
 					},
 					"import-succeeded": "Import RF2 zip failist õnnestus!",

--- a/app/src/assets/i18n/fr.json
+++ b/app/src/assets/i18n/fr.json
@@ -2057,6 +2057,7 @@
             "dry-run-warning": "La simulation génère un rapport des changements à partir du fichier RF2 zip sans l'envoyer à Snowstorm. Une fois le rapport prêt, utilisez le bouton \"Procéder à l'import\" sur l'écran des résultats pour pousser le même fichier.",
             "uploading": "Téléversement du fichier…",
             "scanning": "Analyse du fichier RF2…",
+            "importing": "Import vers Snowstorm…",
             "full-mode": "Analyse complète (plus lente ; inclut les relations et l'acceptabilité)"
           },
           "import-succeeded": "Import from RF2 zip succeeded",

--- a/app/src/assets/i18n/lt.json
+++ b/app/src/assets/i18n/lt.json
@@ -2105,6 +2105,7 @@
             "dry-run-warning": "Bandomasis paleidimas iš RF2 zip failo sukuria pakeitimų ataskaitą neįkeliant į Snowstorm. Kai ataskaita paruošta, rezultatų ekrane naudokite mygtuką \"Tęsti importą\", kad įkeltumėte tą patį failą.",
             "uploading": "Failas įkeliamas…",
             "scanning": "RF2 failas nuskaitomas…",
+            "importing": "Importuojama į Snowstorm…",
             "full-mode": "Pilna analizė (lėtesnė; įtraukia ryšius ir priimtinumą)"
           },
           "import-succeeded": "Importavimas iš RF2 zip archyvo sėkmingas",

--- a/app/src/assets/i18n/nl.json
+++ b/app/src/assets/i18n/nl.json
@@ -2061,6 +2061,7 @@
             "dry-run-warning": "Proefdraai genereert een wijzigingsrapport uit het RF2-zipbestand zonder upload naar Snowstorm. Zodra het rapport klaar is, gebruik op het resultatenscherm de knop \"Doorgaan met importeren\" om hetzelfde bestand te uploaden.",
             "uploading": "Bestand uploaden…",
             "scanning": "RF2-bestand scannen…",
+            "importing": "Importeren naar Snowstorm…",
             "full-mode": "Volledige analyse (langzamer; inclusief relaties en acceptabiliteit)"
           },
           "import-succeeded": "Import from RF2 zip succeeded",


### PR DESCRIPTION
## Summary

Two related UX issues reported by the user when triggering a **non-dry-run** import:

### 1. Import errors were silently swallowed

The \`subscribe()\` callbacks for both \`scanRF2\` and \`createImportJob\` had no \`error\` handler. If the upstream call failed (e.g. termx-server returns 500 because Snowstorm rejected the auth — the user reported a 403 from \`/snowstorm/snomed-ct/imports\`), the error was silently dropped. The modal returned to a clean-looking state with the file still selected, so the user thought nothing happened and clicked *Confirm* again, triggering a duplicate upload.

**Fix**: new \`handleImportError(err)\` method that clears the modal phase/progress and shows the server's error message (or a translated fallback) via \`MuiNotificationService\`. Wired into \`scanRF2\` and \`createImportJob\` subscribes plus the \`pollImportJob\` subscribe.

### 2. Modal looked frozen during the long Snowstorm import

Even on the success path, after the upload reached 100% the modal stayed pinned at *Uploading file…* for the entire Snowstorm import (often 30+ minutes).

**Fix**: after the upload finishes for a non-dry-run import, switch the modal to \`phase='importing'\` with an indeterminate active progress bar labelled *Importing to Snowstorm…* until \`pollImportJob\` hits a terminal status.

## i18n

New key \`web.snomed.branch.management.import-modal.importing\` added to all 7 locales (en, et, cs, de, fr, lt, nl).

## Verification

\`npm run build\` — clean local build (Hash \`48a97705a0be5da9\`, 47s).

## Note on the 403

The 403 the user is seeing is an environment problem, not a code bug — Snowstorm needs auth for write operations. Check the \`snowstorm.*\` block in \`application.yml\` / \`application-local.yml\` for the username/password or token. The dry-run path doesn't talk to Snowstorm at all and works fine, which is consistent with auth being the issue.

## Test plan

- [ ] CI build passes
- [ ] Once the 403 is resolved on the server, confirm the modal transitions: *Uploading file… (n%)* → *Importing to Snowstorm…* (indeterminate) → notification on terminal status.
- [ ] Trigger a deliberate failure (wrong branch path or kill Snowstorm) — confirm an error toast appears with the server message instead of silent failure.