### PR TITLE
fix(snomed): show real import error and close the modal on failure

### DIFF
--- a/app/src/app/integration/snomed/containers/management/codesystem/snomed-codesystem-edit.component.ts
+++ b/app/src/app/integration/snomed/containers/management/codesystem/snomed-codesystem-edit.component.ts
@@ -157,11 +157,40 @@ export class SnomedCodesystemEditComponent implements OnInit {
   }
 
   private handleImportError(err: any): void {
-    this.importModalData.phase = undefined;
-    this.importModalData.progress = undefined;
-    this.importModalData.progressNote = undefined;
-    const message = err?.error?.message ?? err?.message ?? 'web.snomed.branch.management.import-failed';
-    this.notificationService.error(message);
+    // Close the modal entirely — clearing file/state so the user can't accidentally
+    // click Confirm again and re-upload the same archive into the same broken backend.
+    this.importModalData = {type: 'SNAPSHOT'};
+    this.notificationService.error(this.extractErrorMessage(err));
+  }
+
+  private extractErrorMessage(err: any): string {
+    // termx-server's DefaultExceptionHandler returns either a JSON array of Issue
+    // objects ({code, message, severity, params}) or a single Issue, depending on
+    // the upstream failure. Empty bodies (e.g. an upstream 403 with Content-Length:0)
+    // come through as null/[]. Walk all the shapes; fall back to "<status> <statusText>".
+    const body = err?.error;
+    if (Array.isArray(body) && body.length > 0) {
+      const messages = body
+        .map((i: any) => (typeof i === 'string' ? i : (i?.message || i?.code)))
+        .filter((m: any) => !!m);
+      if (messages.length > 0) {
+        return messages.join('; ');
+      }
+    }
+    if (body?.message) {
+      return body.message;
+    }
+    if (body?.detail) {
+      return body.detail;
+    }
+    if (typeof body === 'string' && body.trim()) {
+      return body;
+    }
+    if (err?.status) {
+      const status = err.statusText ? `${err.status} ${err.statusText}` : `HTTP ${err.status}`;
+      return err.url ? `${status} (${err.url})` : status;
+    }
+    return err?.message || 'web.snomed.branch.management.import-failed';
   }
 
   private handleScanLorqueStarted(lorque: {id: number}): void {


### PR DESCRIPTION
## Summary

Two follow-ups to the import-error handler from [#57](https://github.com/termx-health/termx-web/pull/57) after it surfaced in real-world testing.

### 1. Error message extraction was wrong

\`err.error.message\` was the wrong path. termx-server's \`DefaultExceptionHandler.handleHttpClientError\` returns a JSON **array** of \`Issue\` objects (\`{code, message, severity, params}\`) — not a top-level \`{message}\`. And when the upstream 403 has an empty body (e.g. Snowstorm's bare Spring Security refusal, \`Content-Length: 0\`) the array is \`null\` or \`[]\`. Frontend fell through to Angular's generic \`Http failure response…\` string and the user saw nothing useful.

\`extractErrorMessage\` now walks all the shapes the kodality handler can produce:
- array of \`{code,message}\` → joined with \`;\`
- single \`Issue\` object with \`message\` or \`detail\`
- plain string body
- empty body → falls back to \`"<status> <statusText> (<url>)"\` so the user always sees the actual HTTP status of the upstream call instead of a vague default.

### 2. Modal stayed open on error → invited re-uploads

The modal kept the file selected on error, so a second Confirm click triggered another full upload of the same archive against the same broken backend. \`handleImportError\` now sets \`importModalData = {type: 'SNAPSHOT'}\`, which closes the modal AND clears the file selection. The user has to deliberately re-pick the file to retry — no more accidental re-uploads.

## Verification

\`npm run build\` — clean local build (Hash \`de5184f5e03865e6\`, 44s).

## Test plan

- [ ] CI build passes
- [ ] Trigger the Snowstorm-403 path again — confirm a notification appears showing **403 Forbidden** (or whatever the upstream actually returned), not a generic Http-failure message.
- [ ] Confirm the modal closes after the failure notification, and that opening the import modal again shows the file picker empty.