### PR TITLE
feat(privileges): add triage gating + UI cascade (Phase A of GitHub-style permissions)

### DIFF
--- a/app/src/app/core/auth/auth.service.ts
+++ b/app/src/app/core/auth/auth.service.ts
@@ -47,7 +47,19 @@ export class AuthService {
 
   public refresh(): Observable<UserInfo> {
     if (environment.yupiEnabled) {
-      return of({username: 'yupi', privileges: ['*.*.*']}).pipe(tap(u => this.user = u));
+      // Fetch the real session from the backend so server-side yupi configuration
+      // (auth.dev.yupi.privileges) is honoured. Previously we returned a hardcoded
+      // ['*.*.*'] here, which bypassed the backend and made privilege overrides
+      // invisible to the frontend.
+      return this.loadUserInfo().pipe(
+        tap(resp => this.user = resp),
+        catchError(() => {
+          // Backend not running, not in dev mode, or yupi disabled there: fall back
+          // to a permissive guest so the UI shell still renders for design work.
+          this.user = {username: 'yupi', privileges: ['*.*.*']};
+          return of(this.user);
+        })
+      );
     }
 
     return this.refreshUserInfo().pipe(

--- a/app/src/app/privileges/_lib/model/privilege-resource.ts
+++ b/app/src/app/privileges/_lib/model/privilege-resource.ts
@@ -8,6 +8,7 @@ export class PrivilegeResource {
 
 export class PrivilegeResourceActions {
   public view?: boolean;
+  public triage?: boolean;
   public edit?: boolean;
   public publish?: boolean;
 }

--- a/app/src/app/privileges/containers/privilege-edit.component.html
+++ b/app/src/app/privileges/containers/privilege-edit.component.html
@@ -48,6 +48,7 @@
               <th>{{'entities.privilege-resource.type' | translate}}</th>
               <th>{{'entities.privilege-resource.resource-id' | translate}}</th>
               <th>{{'entities.privilege-resource.view' | translate}}</th>
+              <th>{{'entities.privilege-resource.triage' | translate}}</th>
               <th>{{'entities.privilege-resource.edit' | translate}}</th>
               <th>{{'entities.privilege-resource.publish' | translate}}</th>
               <th class="tw-table-actions"></th>
@@ -65,6 +66,11 @@
                   </td>
                   <td>
                     @if (resource.actions?.view) {
+                      <m-icon mCode="check"></m-icon>
+                    }
+                  </td>
+                  <td>
+                    @if (resource.actions?.triage) {
                       <m-icon mCode="check"></m-icon>
                     }
                   </td>
@@ -182,15 +188,24 @@
             {{'web.privileges.resources.modal.actions.view' | translate}}
           </m-checkbox>
         </ng-template>
+        <m-form-item [mLabel]="triage"></m-form-item>
+        <ng-template #triage>
+          <m-checkbox name="action-triage" [ngModel]="modalData.resource.actions.triage"
+                      (ngModelChange)="onActionToggle('triage', $event)">
+            {{'web.privileges.resources.modal.actions.triage' | translate}}
+          </m-checkbox>
+        </ng-template>
         <m-form-item [mLabel]="edit"></m-form-item>
         <ng-template #edit>
-          <m-checkbox name="action-edit" [(ngModel)]="modalData.resource.actions.edit">
+          <m-checkbox name="action-edit" [ngModel]="modalData.resource.actions.edit"
+                      (ngModelChange)="onActionToggle('edit', $event)">
             {{'web.privileges.resources.modal.actions.edit' | translate}}
           </m-checkbox>
         </ng-template>
         <m-form-item [mLabel]="publish"></m-form-item>
         <ng-template #publish>
-          <m-checkbox name="action-publish" [(ngModel)]="modalData.resource.actions.publish">
+          <m-checkbox name="action-publish" [ngModel]="modalData.resource.actions.publish"
+                      (ngModelChange)="onActionToggle('publish', $event)">
             {{'web.privileges.resources.modal.actions.publish' | translate}}
           </m-checkbox>
         </ng-template>

--- a/app/src/app/privileges/containers/privilege-edit.component.ts
+++ b/app/src/app/privileges/containers/privilege-edit.component.ts
@@ -166,4 +166,22 @@ export class PrivilegeEditComponent implements OnInit {
   public asNumber(val: string): number {
     return val ? Number(val) : undefined;
   };
+
+  public onActionToggle(action: 'triage' | 'edit' | 'publish', value: boolean): void {
+    const actions = this.modalData.resource!.actions!;
+    actions[action] = value;
+    if (!value) {
+      return;
+    }
+    if (action === 'triage') {
+      actions.view = true;
+    } else if (action === 'edit') {
+      actions.view = true;
+      actions.triage = true;
+    } else if (action === 'publish') {
+      actions.view = true;
+      actions.triage = true;
+      actions.edit = true;
+    }
+  }
 }

--- a/app/src/app/resources/code-system/containers/concepts/edit/code-system-concept-edit.component.html
+++ b/app/src/app/resources/code-system/containers/concepts/edit/code-system-concept-edit.component.html
@@ -87,8 +87,8 @@ mode="concept-edit"></tw-resource-context>
         </m-card>
       }
 
-      <!-- Opened tasks -->
-      @if (conceptVersion?.id && ('*.Task.view' | twPrivileged)) {
+      <!-- Opened tasks (visible only when user has triage on the parent code system) -->
+      @if (conceptVersion?.id && ('*.CodeSystem.triage' | twPrivileged)) {
         <m-card>
           <div *m-card-header class="m-justify-between">
             <div class="m-items-middle">

--- a/app/src/app/resources/code-system/containers/concepts/edit/code-system-concept-view.component.html
+++ b/app/src/app/resources/code-system/containers/concepts/edit/code-system-concept-view.component.html
@@ -39,6 +39,35 @@
         </m-card>
       }
 
+      <!-- Opened tasks (visible only when user has triage on the parent code system) -->
+      @if (conceptVersion?.id && ('*.CodeSystem.triage' | twPrivileged)) {
+        <m-card>
+          <div *m-card-header class="m-justify-between">
+            <div class="m-items-middle">
+              @if (!showOnlyOpenedTasks) {
+                <a (mClick)="showOnlyOpenedTasks = !showOnlyOpenedTasks">
+                  <m-title mTitle="web.code-system-concept.form.opened-tasks"></m-title>
+                </a>
+              }
+              @if (showOnlyOpenedTasks) {
+                <m-title mTitle="web.code-system-concept.form.opened-tasks"></m-title>
+              }
+              <span>|</span>
+              @if (showOnlyOpenedTasks) {
+                <a (mClick)="showOnlyOpenedTasks = !showOnlyOpenedTasks">
+                  <m-title mTitle="web.code-system-concept.form.all-tasks"></m-title>
+                </a>
+              }
+              @if (!showOnlyOpenedTasks) {
+                <m-title mTitle="web.code-system-concept.form.all-tasks"></m-title>
+              }
+            </div>
+          </div>
+          <tw-resource-tasks-widget resourceType="CodeSystemEntityVersion"
+            [resourceId]="conceptVersion.id | toString"
+          [taskFilters]="showOnlyOpenedTasks ? {statuses: ['requested']} : undefined"></tw-resource-tasks-widget>
+        </m-card>
+      }
     </div>
     <div style="display: flex; gap: 1rem; flex-direction: column; flex: 2; min-width: 0">
 

--- a/app/src/app/resources/code-system/containers/concepts/edit/code-system-concept-view.component.ts
+++ b/app/src/app/resources/code-system/containers/concepts/edit/code-system-concept-view.component.ts
@@ -5,6 +5,7 @@ import {CodeSystem, CodeSystemConcept, CodeSystemEntityVersion, CodeSystemVersio
 import {forkJoin, of} from 'rxjs';
 import {CodeSystemService} from 'term-web/resources/code-system/services/code-system.service';
 import { ResourceContextComponent } from 'term-web/resources/resource/components/resource-context.component';
+import { ResourceTasksWidgetComponent } from 'term-web/resources/resource/components/resource-tasks-widget.component';
 import { MarinPageLayoutModule, MuiCardModule, MuiListModule, MuiDividerModule } from '@termx-health/ui';
 
 import { FormsModule } from '@angular/forms';
@@ -15,6 +16,7 @@ import { CodeSystemPropertyValueEditComponent } from 'term-web/resources/code-sy
 import { CodeSystemAssociationEditComponent } from 'term-web/resources/code-system/containers/concepts/edit/association/code-system-association-edit.component';
 import { TranslatePipe } from '@ngx-translate/core';
 import { MarinaUtilModule } from '@termx-health/util';
+import { PrivilegedPipe } from 'term-web/core/auth/privileges/privileged.pipe';
 
 @Component({
     templateUrl: './code-system-concept-view.component.html',
@@ -29,7 +31,7 @@ import { MarinaUtilModule } from '@termx-health/util';
       margin-top: 1rem
     }
   `],
-    imports: [ResourceContextComponent, MarinPageLayoutModule, MuiCardModule, MuiListModule, FormsModule, MuiDividerModule, StatusTagComponent, ResourceRelatedArtifactWidgetComponent, CodeSystemDesignationEditComponent, CodeSystemPropertyValueEditComponent, CodeSystemAssociationEditComponent, TranslatePipe, MarinaUtilModule, LocalDatePipe, LocalDateTimePipe, ToStringPipe]
+    imports: [ResourceContextComponent, MarinPageLayoutModule, MuiCardModule, MuiListModule, FormsModule, MuiDividerModule, StatusTagComponent, ResourceRelatedArtifactWidgetComponent, ResourceTasksWidgetComponent, CodeSystemDesignationEditComponent, CodeSystemPropertyValueEditComponent, CodeSystemAssociationEditComponent, TranslatePipe, MarinaUtilModule, LocalDatePipe, LocalDateTimePipe, ToStringPipe, PrivilegedPipe]
 })
 export class CodeSystemConceptViewComponent implements OnInit {
   private codeSystemService = inject(CodeSystemService);
@@ -43,6 +45,7 @@ export class CodeSystemConceptViewComponent implements OnInit {
   public codeSystemVersions?: CodeSystemVersion[];
   public concept?: CodeSystemConcept;
   public conceptVersion?: CodeSystemEntityVersion;
+  protected showOnlyOpenedTasks = true;
 
   protected loader = new LoadingManager();
 

--- a/app/src/app/resources/code-system/containers/concepts/list/code-system-concepts-list.component.html
+++ b/app/src/app/resources/code-system/containers/concepts/list/code-system-concepts-list.component.html
@@ -179,7 +179,7 @@
         <tw-code-system-concepts-list-concept-preview [codeSystemId]="codeSystem.id"
           [version]="selectedConcept.version"
           [editRoute]="(selectedConcept.code | apply: getConceptEditRoute)?.path"/>
-          <m-card mDisplay="bordered" *twPrivileged="'*.Task.view'">
+          <m-card mDisplay="bordered" *twPrivileged="'*.CodeSystem.triage'">
             <div *m-card-header class="m-justify-between">
               <label>{{'entities.task.plural' | translate}}</label>
               @if ([codeSystem.id + '.CodeSystem.edit', '*.Task.edit'] | twHasAllPrivileges) {

--- a/app/src/app/resources/code-system/containers/summary/code-system-summary.component.html
+++ b/app/src/app/resources/code-system/containers/summary/code-system-summary.component.html
@@ -68,8 +68,8 @@
           </m-card>
         }
 
-        <!-- Tasks -->
-        <m-card *twPrivileged="'*.Task.view'">
+        <!-- Tasks (visible only when user has triage on this code system) -->
+        <m-card *twPrivileged="'triage'">
           <div *m-card-header class="m-justify-between">
             <div class="m-items-middle">
               @if (!showOnlyOpenedTasks) {

--- a/app/src/app/resources/code-system/containers/version/summary/code-system-version-summary.component.html
+++ b/app/src/app/resources/code-system/containers/version/summary/code-system-version-summary.component.html
@@ -24,7 +24,7 @@
 
     </div>
     <div *mFormCol style="display: flex; gap: 1rem; flex-direction: column">
-      <m-card *twPrivileged="'*.Task.view'">
+      <m-card *twPrivileged="'triage'">
         <div *m-card-header class="m-justify-between">
           <div class="m-items-middle">
             @if (!showOnlyOpenedTasks) {

--- a/app/src/app/resources/code-system/containers/version/summary/widgets/code-system-version-info-widget.component.html
+++ b/app/src/app/resources/code-system/containers/version/summary/widgets/code-system-version-info-widget.component.html
@@ -33,7 +33,7 @@
         }
       </div>
     }
-    <div class="m-items-middle">
+    <div class="m-items-middle" *twPrivileged="'triage'">
       <m-icon mCode="download"></m-icon>
       <span>{{'web.code-system-version.summary.info.download' | translate}}
         (@for (format of ['json', 'xml', 'fsh', 'csv', 'xlsx']; track format; let i = $index) {

--- a/app/src/app/resources/map-set/containers/summary/map-set-summary.component.html
+++ b/app/src/app/resources/map-set/containers/summary/map-set-summary.component.html
@@ -25,8 +25,8 @@
 
     </div>
     <div *mFormCol style="display: flex; gap: 1rem; flex-direction: column">
-      <!-- Tasks -->
-      <m-card *twPrivileged="'*.Task.view'">
+      <!-- Tasks (visible only when user has triage on this map set) -->
+      <m-card *twPrivileged="'triage'">
         <div *m-card-header class="m-justify-between">
           <div class="m-items-middle">
             @if (!showOnlyOpenedTasks) {

--- a/app/src/app/resources/map-set/containers/version/summary/widgets/map-set-version-info-widget.component.html
+++ b/app/src/app/resources/map-set/containers/version/summary/widgets/map-set-version-info-widget.component.html
@@ -68,7 +68,7 @@
       }
     </div>
     <div>{{version.description | localName}}</div>
-    <div class="m-items-middle">
+    <div class="m-items-middle" *twPrivileged="'triage'">
       <m-icon mCode="download"></m-icon>
       <span>{{'web.map-set-version.summary.info.download' | translate}}
         (@for (format of ['json', 'xml', 'fsh', 'csv', 'xlsx']; track format; let i = $index) {

--- a/app/src/app/resources/resource/components/resource-form.component.html
+++ b/app/src/app/resources/resource/components/resource-form.component.html
@@ -15,7 +15,12 @@
           @for (n of resource.otherTitle; track n; let i = $index) {
             <div class="m-items-middle">
               <m-form-control style="width: 100%" mName="otherTitle-name-{{i}}">
-                <m-textarea name="otherTitle-name-{{i}}" [(ngModel)]="n.name"></m-textarea>
+                @if (!viewMode) {
+                  <m-textarea name="otherTitle-name-{{i}}" [(ngModel)]="n.name"></m-textarea>
+                }
+                @if (viewMode) {
+                  <span>{{n.name}}@if (n.preferred) { <m-icon class="m-text-secondary" [mOptions]="{nzTheme: 'fill'}" mCode="star"/> }</span>
+                }
               </m-form-control>
               @if (!viewMode) {
                 <m-button (mClick)="n.preferred = !n.preferred">
@@ -50,7 +55,12 @@
         }
       </m-form-item>
       <m-form-item *mFormCol mLabel="entities.resource.name" mName="name">
-        <m-textarea name="name" [(ngModel)]="resource.name"></m-textarea>
+        @if (!viewMode) {
+          <m-textarea name="name" [(ngModel)]="resource.name"></m-textarea>
+        }
+        @if (viewMode) {
+          <span>{{resource.name}}</span>
+        }
       </m-form-item>
     </m-form-row>
     <m-form-row>
@@ -74,7 +84,12 @@
       </m-form-item>
       <m-form-item *mFormCol mLabel="entities.resource.uri" mName="uri" [required]="!viewMode">
         <div class="m-items-middle">
-          <m-textarea style="width: 100%" name="uri" [(ngModel)]="resource.uri" [required]="!viewMode"/>
+          @if (!viewMode) {
+            <m-textarea style="width: 100%" name="uri" [(ngModel)]="resource.uri" [required]="!viewMode"/>
+          }
+          @if (viewMode) {
+            <span style="word-break: break-all">{{resource.uri}}</span>
+          }
           @if (resource.uri | validateUrl) {
             <a [href]="resource.uri" target="_blank">
               <m-button m-tooltip mTitle="web.resource-form.open-uri">
@@ -107,7 +122,12 @@
       <m-form-item *mFormCol mLabel="entities.resource.topic">
         <div class="m-items-middle">
           <m-form-control style="width: 100%" mName="topic-text">
-            <m-textarea name="topic-text" [(ngModel)]="resource.topic.text"></m-textarea>
+            @if (!viewMode) {
+              <m-textarea name="topic-text" [(ngModel)]="resource.topic.text"></m-textarea>
+            }
+            @if (viewMode) {
+              <span>{{resource.topic?.text}}</span>
+            }
           </m-form-control>
           <m-form-control style="width: 100%" mName="topic-tags">
             @if (!viewMode) {
@@ -136,7 +156,12 @@
                 }
               </m-form-control>
               <m-form-control style="width: 100%" mName="useContext-value-{{i}}">
-                <m-textarea name="useContext-value-{{i}}" [(ngModel)]="c.value"></m-textarea>
+                @if (!viewMode) {
+                  <m-textarea name="useContext-value-{{i}}" [(ngModel)]="c.value"></m-textarea>
+                }
+                @if (viewMode) {
+                  <span>{{c.value}}</span>
+                }
               </m-form-control>
               @if (!viewMode) {
                 <m-icon class="m-clickable" [mCode]="'close'" (click)="deleteContext(c)"></m-icon>
@@ -151,7 +176,12 @@
     </m-form-row>
     <m-form-row>
       <m-form-item *mFormCol mLabel="entities.resource.source-reference" mName="sourceReference">
-        <m-textarea name="sourceReference" [(ngModel)]="resource.sourceReference"/>
+        @if (!viewMode) {
+          <m-textarea name="sourceReference" [(ngModel)]="resource.sourceReference"/>
+        }
+        @if (viewMode) {
+          <span style="word-break: break-all">{{resource.sourceReference}}</span>
+        }
       </m-form-item>
       <div *mFormCol>
         @if (['CodeSystem', 'ValueSet', 'MapSet'] | includes:resourceType) {

--- a/app/src/app/resources/resource/components/resource-side-info.component.html
+++ b/app/src/app/resources/resource/components/resource-side-info.component.html
@@ -3,7 +3,12 @@
   @if (copyright) {
     <nz-collapse-panel nzActive [nzHeader]="'entities.resource.copyright.single' | translate">
       <m-form-item mName="copyright-holder" mLabel="entities.resource.copyright.holder">
-        <m-input name="copyright-holder" [(ngModel)]="copyright.holder"></m-input>
+        @if (!viewMode) {
+          <m-input name="copyright-holder" [(ngModel)]="copyright.holder"></m-input>
+        }
+        @if (viewMode) {
+          <span>{{copyright.holder}}</span>
+        }
       </m-form-item>
       <m-form-item mName="jurisdiction" mLabel="entities.resource.copyright.jurisdiction">
         @if (!viewMode) {
@@ -14,23 +19,48 @@
         }
       </m-form-item>
       <m-form-item mName="copyright-statement" mLabel="entities.resource.copyright.statement">
-        <m-textarea name="copyright-statement" [(ngModel)]="copyright.statement"></m-textarea>
+        @if (!viewMode) {
+          <m-textarea name="copyright-statement" [(ngModel)]="copyright.statement"></m-textarea>
+        }
+        @if (viewMode) {
+          <span class="m-whitespace">{{copyright.statement}}</span>
+        }
       </m-form-item>
     </nz-collapse-panel>
   }
   @if (permissions) {
     <nz-collapse-panel nzActive [nzHeader]="'entities.resource.permissions.multiple' | translate">
       <m-form-item mName="admin" mLabel="entities.resource.permissions.admin">
-        <m-input name="admin" [(ngModel)]="permissions.admin"></m-input>
+        @if (!viewMode) {
+          <m-input name="admin" [(ngModel)]="permissions.admin"></m-input>
+        }
+        @if (viewMode) {
+          <span>{{permissions.admin}}</span>
+        }
       </m-form-item>
       <m-form-item mName="editor" mLabel="entities.resource.permissions.editor">
-        <m-input name="editor" [(ngModel)]="permissions.editor"></m-input>
+        @if (!viewMode) {
+          <m-input name="editor" [(ngModel)]="permissions.editor"></m-input>
+        }
+        @if (viewMode) {
+          <span>{{permissions.editor}}</span>
+        }
       </m-form-item>
       <m-form-item mName="viewer" mLabel="entities.resource.permissions.viewer">
-        <m-input name="viewer" [(ngModel)]="permissions.viewer"></m-input>
+        @if (!viewMode) {
+          <m-input name="viewer" [(ngModel)]="permissions.viewer"></m-input>
+        }
+        @if (viewMode) {
+          <span>{{permissions.viewer}}</span>
+        }
       </m-form-item>
-      <m-form-item mName="viewer" mLabel="entities.resource.permissions.endorser">
-        <m-input name="viewer" [(ngModel)]="permissions.endorser"></m-input>
+      <m-form-item mName="endorser" mLabel="entities.resource.permissions.endorser">
+        @if (!viewMode) {
+          <m-input name="endorser" [(ngModel)]="permissions.endorser"></m-input>
+        }
+        @if (viewMode) {
+          <span>{{permissions.endorser}}</span>
+        }
       </m-form-item>
     </nz-collapse-panel>
   }

--- a/app/src/app/resources/value-set/containers/summary/value-set-summary.component.html
+++ b/app/src/app/resources/value-set/containers/summary/value-set-summary.component.html
@@ -24,8 +24,8 @@
     </div>
     <div *mFormCol style="display: flex; gap: 1rem; flex-direction: column">
 
-      <!-- Tasks -->
-      <m-card *twPrivileged="'*.Task.view'">
+      <!-- Tasks (visible only when user has triage on this value set) -->
+      <m-card *twPrivileged="'triage'">
         <div *m-card-header class="m-justify-between">
           <div class="m-items-middle">
             @if (!showOnlyOpenedTasks) {

--- a/app/src/app/resources/value-set/containers/version/widgets/value-set-version-info-widget.component.html
+++ b/app/src/app/resources/value-set/containers/version/widgets/value-set-version-info-widget.component.html
@@ -24,7 +24,7 @@
         }
       </div>
     }
-    <div class="m-items-middle">
+    <div class="m-items-middle" *twPrivileged="'triage'">
       <m-icon mCode="download"></m-icon>
       <span>{{'web.value-set-version.summary.info.download' | translate}}
         (@for (format of ['json', 'xml', 'fsh', 'csv', 'xlsx']; track format; let i = $index) {

--- a/app/src/app/wiki/_lib/texteditor/comments/wiki-comment-popover.component.ts
+++ b/app/src/app/wiki/_lib/texteditor/comments/wiki-comment-popover.component.ts
@@ -1,5 +1,6 @@
 import { Component, EventEmitter, Output, inject } from '@angular/core';
 import {AuthService} from 'term-web/core/auth';
+import {PrivilegedDirective} from 'term-web/core/auth/privileges/privileged.directive';
 
 import { MuiIconButtonModule, MuiCardModule, MuiTextareaModule, MuiButtonModule } from '@termx-health/ui';
 import { FormsModule } from '@angular/forms';
@@ -8,7 +9,7 @@ import { FormsModule } from '@angular/forms';
     selector: 'tw-wiki-comment-popover',
     template: `
     @if (!commentData.edit) {
-      <m-icon-button class="btn" mIcon="comment" mSize="small" (mClick)="open()"/>
+      <m-icon-button *twPrivileged="'triage'" class="btn" mIcon="comment" mSize="small" (mClick)="open()"/>
     }
     
     @if (commentData.edit) {
@@ -38,7 +39,7 @@ import { FormsModule } from '@angular/forms';
       border-radius: 50%;
     }
   `],
-    imports: [MuiIconButtonModule, MuiCardModule, MuiTextareaModule, FormsModule, MuiButtonModule]
+    imports: [MuiIconButtonModule, MuiCardModule, MuiTextareaModule, FormsModule, MuiButtonModule, PrivilegedDirective]
 })
 export class WikiCommentPopoverComponent {
   protected auth = inject(AuthService);

--- a/app/src/app/wiki/page/components/wiki-page-comment.component.html
+++ b/app/src/app/wiki/page/components/wiki-page-comment.component.html
@@ -109,7 +109,7 @@
 
 
 @if ({active: !!pageComment.children?.length}; as inf) {
-  <m-list>
+  <m-list *twPrivileged="'triage'">
     <!-- Main comment -->
     <m-list-item class="comment" [mClickable]="!inf.active" (mClick)="!_editState[pageComment.id] ? inf.active = true : undefined">
       <ng-container *ngTemplateOutlet="section, context: {$implicit: pageComment}"/>
@@ -121,7 +121,7 @@
       </m-list-item>
     }
     <!-- Send reply -->
-    @if (inf.active && ('edit' | twPrivileged)) {
+    @if (inf.active) {
       <m-list-item class="comment-reply-section">
         @if ({msg: ''}; as d) {
           <div class="m-items-top">

--- a/app/src/app/wiki/page/components/wiki-page-comment.component.ts
+++ b/app/src/app/wiki/page/components/wiki-page-comment.component.ts
@@ -7,7 +7,7 @@ import { MuiTooltipModule, MuiCoreModule, MuiTextareaModule, MuiButtonModule, Mu
 import { NgTemplateOutlet } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { TranslatePipe } from '@ngx-translate/core';
-import { PrivilegedPipe } from 'term-web/core/auth/privileges/privileged.pipe';
+import { PrivilegedDirective } from 'term-web/core/auth/privileges/privileged.directive';
 
 export interface ExtendedPageComment extends PageComment {
   children?: PageComment[]
@@ -67,7 +67,7 @@ interface CommentPrivileges {
         '[attr.page-comment-id]': `pageComment?.id`,
         '[attr.line-number]': `pageComment?.options?.lineNumber`,
     },
-    imports: [MuiTooltipModule, MuiCoreModule, MuiTextareaModule, AutofocusDirective, FormsModule, MuiButtonModule, NgTemplateOutlet, MuiIconButtonModule, MuiIconModule, MuiDropdownModule, MuiListModule, TranslatePipe, AbbreviatePipe, ApplyPipe, LocalDateTimePipe, PrivilegedPipe]
+    imports: [MuiTooltipModule, MuiCoreModule, MuiTextareaModule, AutofocusDirective, FormsModule, MuiButtonModule, NgTemplateOutlet, MuiIconButtonModule, MuiIconModule, MuiDropdownModule, MuiListModule, TranslatePipe, AbbreviatePipe, ApplyPipe, LocalDateTimePipe, PrivilegedDirective]
 })
 export class WikiPageCommentComponent {
   private pageCommentService = inject(PageCommentService);

--- a/app/src/assets/i18n/cs.json
+++ b/app/src/assets/i18n/cs.json
@@ -495,6 +495,7 @@
       "edit": "Upravit",
       "publish": "Publikovat",
       "resource-id": "Zdroj",
+      "triage": "Triáž",
       "type": "Typ",
       "view": "Zobrazit"
     },
@@ -1979,6 +1980,7 @@
           "actions": {
             "edit": "Upravit",
             "publish": "Publikovat",
+            "triage": "Triáž",
             "view": "Zobrazit"
           },
           "add-header": "Přidat zdroj",

--- a/app/src/assets/i18n/de.json
+++ b/app/src/assets/i18n/de.json
@@ -477,6 +477,7 @@
       "edit": "Bearbeiten",
       "publish": "Publish",
       "resource-id": "Resource",
+      "triage": "Triage",
       "type": "Type",
       "view": "View"
     },
@@ -1883,6 +1884,7 @@
           "actions": {
             "edit": "Bearbeiten",
             "publish": "Publish",
+            "triage": "Triage",
             "view": "View"
           },
           "add-header": "Add resource",

--- a/app/src/assets/i18n/en.json
+++ b/app/src/assets/i18n/en.json
@@ -542,6 +542,7 @@
 			"edit": "Edit",
 			"publish": "Publish",
 			"resource-id": "Resource",
+			"triage": "Triage",
 			"type": "Type",
 			"view": "View"
 		},
@@ -2025,6 +2026,7 @@
 					"actions": {
 						"edit": "Edit",
 						"publish": "Publish",
+						"triage": "Triage",
 						"view": "View"
 					},
 					"add-header": "Add resource",

--- a/app/src/assets/i18n/et.json
+++ b/app/src/assets/i18n/et.json
@@ -489,6 +489,7 @@
 			"edit": "Muuda",
 			"publish": "Avalda",
 			"resource-id": "Ressurss",
+			"triage": "Triaaž",
 			"type": "Tüüp",
 			"view": "Vaata"
 		},
@@ -1790,6 +1791,7 @@
 					"actions": {
 						"edit": "Muuda",
 						"publish": "Avalda",
+						"triage": "Triaaž",
 						"view": "Vaata"
 					},
 					"add-header": "Lisa ressurss",

--- a/app/src/assets/i18n/fr.json
+++ b/app/src/assets/i18n/fr.json
@@ -477,6 +477,7 @@
       "edit": "Modifier",
       "publish": "Publish",
       "resource-id": "Resource",
+      "triage": "Triage",
       "type": "Type",
       "view": "View"
     },
@@ -1883,6 +1884,7 @@
           "actions": {
             "edit": "Modifier",
             "publish": "Publish",
+            "triage": "Triage",
             "view": "View"
           },
           "add-header": "Add resource",

--- a/app/src/assets/i18n/lt.json
+++ b/app/src/assets/i18n/lt.json
@@ -485,6 +485,7 @@
       "edit": "Redaguoti",
       "publish": "Publikuoti",
       "resource-id": "Išteklio ID",
+      "triage": "Triažas",
       "type": "Tipas",
       "view": "Peržiūrėti"
     },
@@ -1930,6 +1931,7 @@
           "actions": {
             "edit": "Redaguoti",
             "publish": "Publikuoti",
+            "triage": "Triažas",
             "view": "Peržiūrėti"
           },
           "add-header": "Pridėti išteklių",

--- a/app/src/assets/i18n/nl.json
+++ b/app/src/assets/i18n/nl.json
@@ -481,6 +481,7 @@
       "edit": "Bewerken",
       "publish": "Publish",
       "resource-id": "Resource",
+      "triage": "Triage",
       "type": "Type",
       "view": "View"
     },
@@ -1887,6 +1888,7 @@
           "actions": {
             "edit": "Bewerken",
             "publish": "Publish",
+            "triage": "Triage",
             "view": "View"
           },
           "add-header": "Add resource",


### PR DESCRIPTION
## Summary

Frontend half of the **GitHub-style permissions Phase A** rollout. Pairs with [termx-server PR #107](https://github.com/termx-health/termx-server/pull/107) — the new `triage` action server-side; **must ship in the same release** for wire-format coherence (the dotted privilege strings cross the `/auth/userinfo` boundary; non-atomic deploy produces silent 403s).

`triage` is an **additive, backward-compatible** new action between `view` and `edit`. It gates: download exports (CSV/XLSX), wiki comment read/write, and per-resource Tasks widget visibility. A future Phase B release will rename `view` → `read` and `publish` → `maintain`.

## Privilege editor (/privileges)

- `PrivilegeResourceActions` model: new `triage` boolean field
- Resource table: new **Triage** column header + cell between View and Edit
- Add Resource modal: new **Triage** checkbox
- New `onActionToggle()` implements **one-directional UI cascade** per spec Q2: ticking `triage` auto-ticks `view`; ticking `edit` auto-ticks `view`+`triage`; ticking `publish` auto-ticks `view`+`triage`+`edit`. Untick is manual (admins can produce non-cascaded states by editing stored JSON, which is supported but unusual).
- 7 locale JSONs (`cs`/`de`/`en`/`et`/`fr`/`lt`/`nl`): added `entities.privilege-resource.triage` and `web.privileges.resources.modal.actions.triage` in both blocks.

## UI gating

### Downloads
- CS/VS/MS version-info-widget templates: download row wrapped in `*twPrivileged="'triage'"` (contextual short form via the `twPrivilegeContext` ancestor on the `<m-page>`)

### Tasks widget (per-resource)
Replaced `*twPrivileged="'*.Task.view'"` (which over-matched against `*.*.view` due to wildcard semantics) with triage-based gates:
- CS / VS / MS summary + CS version summary: `'triage'` short form
- CS concept-edit + concepts-list: `'*.CodeSystem.triage'` full form (no privilege context on those pages)
- **NEW** Tasks card on the read-only `/concepts/:code/view` route — triage users can now see tasks on the only concept page they can reach (the edit route requires `*.CodeSystem.edit`)

### Wiki comments
- `wiki-page-comment` template: the entire `<m-list>` comment thread wrapped in `*twPrivileged="'triage'"` (whole thread hidden for non-triage users per spec Q4)
- `wiki-comment-popover`: the comment-creation icon button gated by triage
- Updated imports: `PrivilegedDirective` swapped in for the now-redundant `PrivilegedPipe`

## View-mode polish on resource detail pages

A handful of fields on the CS/VS/MS metadata details pages used to render as **disabled inputs** in viewMode — relying on the `<fieldset [disabled]="viewMode">` wrapper rather than the `@if (viewMode)` swap pattern used elsewhere. They now render as plain text matching `title` / `description` / `publisher` / etc.:

- `resource-form.component.html`: 6 fields (computable name, URI, topic text, useContext value, source reference, otherTitle name)
- `resource-side-info.component.html`: copyright holder, copyright statement, and the 4 permissions inputs (admin/editor/viewer/endorser)

**Drive-by bug fix in `resource-side-info`**: the form-control `name="viewer"` was duplicated for the **Endorser** field (copy-paste error from the row above). Two controls sharing a name silently break Angular form validation. Now correctly `name="endorser"`.

## AuthService

Removed the yupi short-circuit in `refresh()` that returned a hardcoded `['*.*.*']` and skipped the `/auth/userinfo` call. The frontend now respects whatever the backend's `auth.dev.yupi.privileges` configuration says. Falls back to a permissive guest **only** if `/auth/userinfo` is unreachable (so the UI shell still renders for offline design work).

## Test plan

- [x] `npx tsc --noEmit -p app/tsconfig.app.json` — clean (exit 0)
- [x] All 7 locale JSON files parse valid
- [x] Manual smoke with `-PyupiPrivileges='*.*.view'` (server side) — confirmed: download row, comments, Tasks widgets all hidden across CS / VS / MS pages
- [x] Manual smoke with `-PyupiPrivileges='*.*.view,*.*.triage'` — confirmed: everything reappears, including the new Tasks card on the concept view route
- [x] Privilege editor visually verified: Triage column appears, cascade works (ticking triage also ticks view, etc.)
- [ ] Reviewer to verify CI passes