### PR TITLE
fix(value-set): NullPointer in Telecom collection (cherry-picked from TERMX-17)

### DIFF
--- a/app/src/app/resources/value-set/containers/summary/widgets/value-set-info-widget.component.ts
+++ b/app/src/app/resources/value-set/containers/summary/widgets/value-set-info-widget.component.ts
@@ -16,6 +16,7 @@ export class ValueSetInfoWidgetComponent {
   @Input() public valueSet: ValueSet;
 
   protected getTelecoms = (vs: ValueSet):  {[dType: string]: Telecom[]} => {
-    return collect(vs.contacts?.flatMap(c => c.telecoms), t => t.system);
+    const telecoms = vs.contacts ? vs.contacts.flatMap(c => c.telecoms || []) : [];
+    return collect(telecoms, t => t.system);
   };
 }


### PR DESCRIPTION
## Summary

Cherry-picked **1 of 3** commits from the abandoned `TERMX-17` branch (3 commits ahead, 271 commits behind main as of last week). The other two were superseded by later main work and intentionally skipped.

## What's included

**`063a767c` — Fix NullPointer with Telecom** (`value-set-info-widget.component.ts`)

Defensive null-handling for `vs.contacts` and `c.telecoms`. The original code:
```ts
return collect(vs.contacts?.flatMap(c => c.telecoms), t => t.system);
```
threw an NPE if any contact had no telecoms (`c.telecoms` undefined → `flatMap` over undefined → crash). New version:
```ts
const telecoms = vs.contacts ? vs.contacts.flatMap(c => c.telecoms || []) : [];
return collect(telecoms, t => t.system);
```

The bug still exists on main (the file hasn't been touched since), so this is still a real fix.

## What's NOT included (and why)

**`e9cad1a9` — Use same ng-zorro icons** (`fhir-code-system.component.html`)
The branch wanted to swap hardcoded `▶`/`▼` Unicode characters with `<i nz-icon>` elements in a hierarchical tree-view UI. **The tree-view UI no longer exists on main** — the file was simplified to a flat `<m-table>`. The icon swap has nothing to gate. Moot.

**`1341cbd3` — Fix of estonian labels** (`et.json`)
The branch wanted to fix typos: `Assotsioon` → `Assotsiatsioon` (adding the missing "ts"). **Main has since done a deeper editorial pass** and replaced the term entirely with `seos` (a more natural Estonian word) for the same labels. The fix is superseded by better translations already in main.

## Test plan

- [x] `npx tsc --noEmit` — clean (exit 0)
- [ ] Reviewer to verify CI passes
- [ ] Smoke: load any value-set summary page where a contact has no telecoms — should not throw