### PR TITLE
Refresh references UI for CodeSystem coding-value version bumps

### DIFF
--- a/app/src/app/resources/_lib/code-system/index.ts
+++ b/app/src/app/resources/_lib/code-system/index.ts
@@ -5,6 +5,7 @@ export * from 'term-web/resources/_lib/code-system/containers/code-system-widget
 export * from 'term-web/resources/_lib/code-system/containers/concept-search.component';
 export * from 'term-web/resources/_lib/code-system/model/code-system';
 export * from 'term-web/resources/_lib/code-system/model/code-system-association';
+export * from 'term-web/resources/_lib/code-system/model/coding-value-update-candidate';
 export * from 'term-web/resources/_lib/code-system/model/code-system-concept';
 export * from 'term-web/resources/_lib/code-system/model/code-system-concept-tree-item';
 export * from 'term-web/resources/_lib/code-system/model/code-system-concept-tree-search-result';

--- a/app/src/app/resources/_lib/code-system/model/coding-value-update-candidate.ts
+++ b/app/src/app/resources/_lib/code-system/model/coding-value-update-candidate.ts
@@ -1,0 +1,10 @@
+export class CodingValueUpdateCandidate {
+  public propertyValueId?: number;
+  public codeSystemEntityVersionId?: number;
+  public entityProperty?: string;
+  public targetCodeSystem?: string;
+  public targetCode?: string;
+  public currentVersion?: string;
+  public candidateVersion?: string;
+  public candidateStatus?: string;
+}

--- a/app/src/app/resources/code-system/components/coding-value-refresh-modal.component.html
+++ b/app/src/app/resources/code-system/components/coding-value-refresh-modal.component.html
@@ -1,0 +1,60 @@
+<m-modal #modal [(mVisible)]="modalVisible" (mClose)="close()">
+  <ng-container *m-modal-header>
+    {{'web.code-system.coding-refresh.header' | translate}}
+  </ng-container>
+
+  <ng-container *m-modal-content>
+    @if (step === 'select') {
+      <m-form-item mLabel="web.code-system.coding-refresh.allowed-statuses">
+        <div class="m-items-middle">
+          <m-checkbox name="active" [(ngModel)]="allow.active">
+            <tw-status-tag status="active"></tw-status-tag>
+          </m-checkbox>
+          <m-checkbox name="draft" [(ngModel)]="allow.draft">
+            <tw-status-tag status="draft"></tw-status-tag>
+          </m-checkbox>
+        </div>
+        <div class="m-subtitle">{{'web.code-system.coding-refresh.allowed-statuses-desc' | translate}}</div>
+      </m-form-item>
+    }
+    @if (step === 'preview') {
+      <div>
+        <p>{{'web.code-system.coding-refresh.preview-desc' | translate: {count: candidates.length} }}</p>
+        <m-table>
+          <thead>
+            <tr>
+              <th>{{'web.code-system.coding-refresh.property' | translate}}</th>
+              <th>{{'web.code-system.coding-refresh.target' | translate}}</th>
+              <th>{{'web.code-system.coding-refresh.current' | translate}}</th>
+              <th>{{'web.code-system.coding-refresh.candidate' | translate}}</th>
+            </tr>
+          </thead>
+          <tbody>
+            @for (c of candidates; track c.propertyValueId) {
+              <tr>
+                <td>{{c.entityProperty}}</td>
+                <td>{{c.targetCodeSystem}} | {{c.targetCode}}</td>
+                <td>{{c.currentVersion || '—'}}</td>
+                <td><tw-status-tag [status]="c.candidateStatus" [extraText]="c.candidateVersion ? '| ' + c.candidateVersion : undefined" compact /></td>
+              </tr>
+            }
+          </tbody>
+        </m-table>
+      </div>
+    }
+  </ng-container>
+
+  <div *m-modal-footer class="m-items-middle">
+    <m-button mDisplay="text" (click)="modal.close()">{{'core.btn.cancel' | translate}}</m-button>
+    @if (step === 'select') {
+      <m-button mDisplay="primary" [mLoading]="loader.state['candidates']" [disabled]="!allow.active && !allow.draft" (click)="previewCandidates()">
+        {{'web.code-system.coding-refresh.preview-btn' | translate}}
+      </m-button>
+    }
+    @if (step === 'preview') {
+      <m-button mDisplay="primary" [mLoading]="loader.state['apply']" (click)="applyRefresh()">
+        {{'web.code-system.coding-refresh.apply-btn' | translate}}
+      </m-button>
+    }
+  </div>
+</m-modal>

--- a/app/src/app/resources/code-system/components/coding-value-refresh-modal.component.ts
+++ b/app/src/app/resources/code-system/components/coding-value-refresh-modal.component.ts
@@ -1,0 +1,106 @@
+import {Component, EventEmitter, Input, Output, ViewChild, inject} from '@angular/core';
+import {FormsModule} from '@angular/forms';
+import {LoadingManager} from '@termx-health/core-util';
+import {TranslatePipe} from '@ngx-translate/core';
+import {MuiButtonModule, MuiCheckboxModule, MuiFormModule, MuiModalModule, MuiNotificationService, MuiTableModule, MuiTagModule} from '@termx-health/ui';
+import {Observable} from 'rxjs';
+import {StatusTagComponent} from 'term-web/core/ui/components/publication-status-tag/status-tag.component';
+import {CodingValueUpdateCandidate} from 'term-web/resources/_lib/code-system/model/coding-value-update-candidate';
+
+export type CodingRefreshScope =
+  | {kind: 'entity-version'; csevId: number}
+  | {kind: 'cs-version'; codeSystemId: string; version: string};
+
+export interface CodingRefreshApi {
+  findCandidates(scope: CodingRefreshScope, allowedStatuses: string[]): Observable<CodingValueUpdateCandidate[]>;
+  refresh(scope: CodingRefreshScope, allowedStatuses: string[]): Observable<{applied?: number; queued?: number}>;
+}
+
+@Component({
+  selector: 'tw-coding-value-refresh-modal',
+  templateUrl: './coding-value-refresh-modal.component.html',
+  imports: [
+    MuiModalModule,
+    MuiFormModule,
+    MuiCheckboxModule,
+    MuiButtonModule,
+    MuiTableModule,
+    MuiTagModule,
+    FormsModule,
+    StatusTagComponent,
+    TranslatePipe
+  ]
+})
+export class CodingValueRefreshModalComponent {
+  private notificationService = inject(MuiNotificationService);
+
+  @Input() public api?: CodingRefreshApi;
+  @Output() public refreshed: EventEmitter<{applied?: number; queued?: number}> = new EventEmitter();
+
+  protected modalVisible = false;
+  protected step: 'select' | 'preview' = 'select';
+  protected scope?: CodingRefreshScope;
+  protected allow = {active: true, draft: true};
+  protected candidates: CodingValueUpdateCandidate[] = [];
+  protected loader = new LoadingManager();
+
+  public open(scope: CodingRefreshScope): void {
+    this.scope = scope;
+    this.step = 'select';
+    this.allow = {active: true, draft: true};
+    this.candidates = [];
+    this.modalVisible = true;
+  }
+
+  protected close(): void {
+    this.modalVisible = false;
+    this.scope = undefined;
+    this.candidates = [];
+  }
+
+  protected previewCandidates(): void {
+    if (!this.api || !this.scope) {
+      return;
+    }
+    const statuses = this.selectedStatuses();
+    if (statuses.length === 0) {
+      return;
+    }
+    this.loader.wrap('candidates', this.api.findCandidates(this.scope, statuses)).subscribe(list => {
+      this.candidates = list ?? [];
+      if (this.candidates.length === 0) {
+        this.notificationService.success('web.code-system.coding-refresh.up-to-date', 'web.code-system.coding-refresh.up-to-date-desc');
+        this.close();
+        return;
+      }
+      this.step = 'preview';
+    });
+  }
+
+  protected applyRefresh(): void {
+    if (!this.api || !this.scope) {
+      return;
+    }
+    const statuses = this.selectedStatuses();
+    this.loader.wrap('apply', this.api.refresh(this.scope, statuses)).subscribe(result => {
+      this.refreshed.emit(result);
+      if (result?.queued) {
+        this.notificationService.success('web.code-system.coding-refresh.queued', String(result.queued));
+      } else {
+        this.notificationService.success('web.code-system.coding-refresh.applied', String(result?.applied ?? 0));
+      }
+      this.close();
+    });
+  }
+
+  private selectedStatuses(): string[] {
+    const s: string[] = [];
+    if (this.allow.active) {
+      s.push('active');
+    }
+    if (this.allow.draft) {
+      s.push('draft');
+    }
+    return s;
+  }
+}

--- a/app/src/app/resources/code-system/containers/concepts/edit/code-system-concept-edit.component.html
+++ b/app/src/app/resources/code-system/containers/concepts/edit/code-system-concept-edit.component.html
@@ -160,6 +160,11 @@ mode="concept-edit"></tw-resource-context>
                 <a *m-dropdown-item (mClick)="openFhir(concept.code)">
                   {{'web.code-system-concept.list.open-fhir' | translate}}
                 </a>
+                @if (conceptVersion.id && ('*.CodeSystem.write' | twPrivileged)) {
+                  <a *m-dropdown-item (mClick)="openRefreshReferences()">
+                    {{'web.code-system.coding-refresh.action' | translate}}
+                  </a>
+                }
               </m-dropdown>
             </div>
           </div>
@@ -267,6 +272,8 @@ mode="concept-edit"></tw-resource-context>
   </div>
 </m-page>
 
+
+<tw-coding-value-refresh-modal #refreshModal [api]="refreshApi" (refreshed)="onReferencesRefreshed()"></tw-coding-value-refresh-modal>
 
 <m-modal [(mVisible)]="taskModalData.visible" (mClose)="taskModalData = {visible: false}">
   <m-title *mModalHeader>

--- a/app/src/app/resources/code-system/containers/concepts/edit/code-system-concept-edit.component.ts
+++ b/app/src/app/resources/code-system/containers/concepts/edit/code-system-concept-edit.component.ts
@@ -22,6 +22,7 @@ import {CodeSystemService} from 'term-web/resources/code-system/services/code-sy
 import {CodeSystemAssociationEditComponent} from 'term-web/resources/code-system/containers/concepts/edit/association/code-system-association-edit.component';
 import {CodeSystemDesignationEditComponent} from 'term-web/resources/code-system/containers/concepts/edit/designation/code-system-designation-edit.component';
 import {CodeSystemPropertyValueEditComponent} from 'term-web/resources/code-system/containers/concepts/edit/propertyvalue/code-system-property-value-edit.component';
+import {CodingRefreshApi, CodingRefreshScope, CodingValueRefreshModalComponent} from 'term-web/resources/code-system/components/coding-value-refresh-modal.component';
 import { ResourceContextComponent as ResourceContextComponent_1 } from 'term-web/resources/resource/components/resource-context.component';
 import { MarinPageLayoutModule, MuiCardModule, MuiDropdownModule, MuiCoreModule, MuiPopconfirmModule, MuiFormModule, MuiInputModule, MuiTextareaModule, MuiListModule, MuiDividerModule, MuiIconModule, MuiTooltipModule, MuiButtonModule, MuiTagModule, MuiModalModule } from '@termx-health/ui';
 import { SequenceValueGeneratorComponent } from 'term-web/sequence/_lib/components/sequence-value-generator.component';
@@ -49,7 +50,7 @@ import { PrivilegedPipe } from 'term-web/core/auth/privileges/privileged.pipe';
       margin-top: 1rem
     }
   `],
-    imports: [ResourceContextComponent_1, MarinPageLayoutModule, MuiCardModule, MuiDropdownModule, MuiCoreModule, MuiPopconfirmModule, FormsModule, MuiFormModule, MuiInputModule, AutofocusDirective, SequenceValueGeneratorComponent, MuiTextareaModule, AddButtonComponent, MuiListModule, MuiDividerModule, StatusTagComponent, MuiIconModule, MuiTooltipModule, ResourceRelatedArtifactWidgetComponent, PrivilegedDirective, MuiButtonModule, ResourceTasksWidgetComponent_1, MuiTagModule, CodeSystemDesignationEditComponent, CodeSystemPropertyValueEditComponent, CodeSystemAssociationEditComponent, CodeSystemConceptReferenceComponent, MuiModalModule, UserSelectComponent, TranslatePipe, MarinaUtilModule, FilterPipe, LocalDatePipe, LocalDateTimePipe, ToStringPipe, PrivilegedPipe]
+    imports: [ResourceContextComponent_1, MarinPageLayoutModule, MuiCardModule, MuiDropdownModule, MuiCoreModule, MuiPopconfirmModule, FormsModule, MuiFormModule, MuiInputModule, AutofocusDirective, SequenceValueGeneratorComponent, MuiTextareaModule, AddButtonComponent, MuiListModule, MuiDividerModule, StatusTagComponent, MuiIconModule, MuiTooltipModule, ResourceRelatedArtifactWidgetComponent, PrivilegedDirective, MuiButtonModule, ResourceTasksWidgetComponent_1, MuiTagModule, CodeSystemDesignationEditComponent, CodeSystemPropertyValueEditComponent, CodeSystemAssociationEditComponent, CodeSystemConceptReferenceComponent, CodingValueRefreshModalComponent, MuiModalModule, UserSelectComponent, TranslatePipe, MarinaUtilModule, FilterPipe, LocalDatePipe, LocalDateTimePipe, ToStringPipe, PrivilegedPipe]
 })
 export class CodeSystemConceptEditComponent implements OnInit {
   private codeSystemService = inject(CodeSystemService);
@@ -77,6 +78,46 @@ export class CodeSystemConceptEditComponent implements OnInit {
   @ViewChild("designationEdit") public designationEdit?: CodeSystemDesignationEditComponent;
   @ViewChild("propertyValueEdit") public propertyValueEdit?: CodeSystemPropertyValueEditComponent;
   @ViewChild("associationEdit") public associationEdit?: CodeSystemAssociationEditComponent;
+  @ViewChild("refreshModal") public refreshModal?: CodingValueRefreshModalComponent;
+
+  protected refreshApi: CodingRefreshApi = {
+    findCandidates: (scope, statuses) => {
+      if (scope.kind !== 'entity-version') {
+        throw new Error('Unexpected scope');
+      }
+      return this.codeSystemService.findConceptRefCandidates(scope.csevId, statuses);
+    },
+    refresh: (scope, statuses) => {
+      if (scope.kind !== 'entity-version') {
+        throw new Error('Unexpected scope');
+      }
+      return this.codeSystemService.refreshConceptRefs(scope.csevId, statuses);
+    }
+  };
+
+  protected openRefreshReferences(): void {
+    if (!this.conceptVersion?.id) {
+      return;
+    }
+    this.refreshModal?.open({kind: 'entity-version', csevId: this.conceptVersion.id});
+  }
+
+  protected onReferencesRefreshed(): void {
+    if (this.concept?.code) {
+      this.loadConceptAgain();
+    }
+  }
+
+  private loadConceptAgain(): void {
+    this.loader.wrap('load', this.codeSystemService.loadConcept(this.codeSystemId, this.concept.code))
+      .subscribe(c => {
+        this.concept = c;
+        const v = c.versions?.find(v => v.id === this.conceptVersion?.id);
+        if (v) {
+          this.selectVersion(v);
+        }
+      });
+  }
   @ViewChild(ResourceContextComponent) public resourceContextComponent?: ResourceContextComponent;
   @ViewChild(ResourceTasksWidgetComponent) public resourceTasksWidgetComponent?: ResourceTasksWidgetComponent;
 

--- a/app/src/app/resources/code-system/containers/version/validator/code-system-validator.component.html
+++ b/app/src/app/resources/code-system/containers/version/validator/code-system-validator.component.html
@@ -50,7 +50,18 @@
           [disabled]="!codeSystem || true"
         [mLoading]="loader.state['detect']">{{'web.code-system-validator.circular-dependencies-detector.detect' | translate}}</m-button>
       </m-card>
+
+      <m-card [mTitle]="'web.code-system.coding-refresh.action'">
+        <div>{{'web.code-system.coding-refresh.validator-desc' | translate}}</div>
+        <m-button *m-card-footer
+          mDisplay="primary"
+          (click)="openRefreshReferences()"
+          [disabled]="!codeSystem || !version"
+        [mLoading]="loader.state['refresh-load']">{{'web.code-system.coding-refresh.action' | translate}}</m-button>
+      </m-card>
     </div>
+
+    <tw-coding-value-refresh-modal #refreshModal [api]="refreshApi"></tw-coding-value-refresh-modal>
 
 
     @if (!!uniquenessResult) {

--- a/app/src/app/resources/code-system/containers/version/validator/code-system-validator.component.ts
+++ b/app/src/app/resources/code-system/containers/version/validator/code-system-validator.component.ts
@@ -1,5 +1,5 @@
 import {HttpClient} from '@angular/common/http';
-import { Component, OnInit, inject } from '@angular/core';
+import { Component, OnInit, ViewChild, inject } from '@angular/core';
 import { ActivatedRoute, RouterLink } from '@angular/router';
 import { DestroyService, isDefined, LoadingManager, AutofocusDirective, ApplyPipe, KeysPipe } from '@termx-health/core-util';
 import { MuiNotificationService, MuiFormModule, MuiCardModule, MuiCheckboxModule, MuiButtonModule, MuiListModule, MuiTagModule, MuiCoreModule } from '@termx-health/ui';
@@ -11,6 +11,8 @@ import { NzRowDirective, NzColDirective } from 'ng-zorro-antd/grid';
 import { CodeSystemSearchComponent } from 'term-web/resources/_lib/code-system/containers/code-system-search.component';
 import { FormsModule } from '@angular/forms';
 import { CodeSystemVersionSelectComponent } from 'term-web/resources/_lib/code-system/containers/code-system-version-select.component';
+import { CodeSystemService } from 'term-web/resources/code-system/services/code-system.service';
+import { CodingRefreshApi, CodingValueRefreshModalComponent } from 'term-web/resources/code-system/components/coding-value-refresh-modal.component';
 
 import { HasAnyPrivilegePipe } from 'term-web/core/auth/privileges/has-any-privilege.pipe';
 
@@ -27,7 +29,7 @@ class CodeSystemUniquenessRequest {
 @Component({
     templateUrl: './code-system-validator.component.html',
     providers: [DestroyService],
-    imports: [NzRowDirective, NzColDirective, MuiFormModule, CodeSystemSearchComponent, AutofocusDirective, FormsModule, CodeSystemVersionSelectComponent, MuiCardModule, MuiCheckboxModule, MuiButtonModule, MuiListModule, MuiTagModule, MuiCoreModule, RouterLink, TranslatePipe, ApplyPipe, KeysPipe, HasAnyPrivilegePipe]
+    imports: [NzRowDirective, NzColDirective, MuiFormModule, CodeSystemSearchComponent, AutofocusDirective, FormsModule, CodeSystemVersionSelectComponent, MuiCardModule, MuiCheckboxModule, MuiButtonModule, MuiListModule, MuiTagModule, MuiCoreModule, RouterLink, TranslatePipe, ApplyPipe, KeysPipe, HasAnyPrivilegePipe, CodingValueRefreshModalComponent]
 })
 export class CodeSystemValidatorComponent implements OnInit {
   private lorqueService = inject(LorqueLibService);
@@ -36,12 +38,45 @@ export class CodeSystemValidatorComponent implements OnInit {
   private http = inject(HttpClient);
   private route = inject(ActivatedRoute);
   private destroy$ = inject(DestroyService);
+  private codeSystemService = inject(CodeSystemService);
 
   protected codeSystem: string;
   protected version: number;
   protected uniquenessRequest: CodeSystemUniquenessRequest = {designations: true, properties: true};
   protected uniquenessResult: CodeSystemUniquenessResult;
   protected loader = new LoadingManager();
+
+  @ViewChild('refreshModal') public refreshModal?: CodingValueRefreshModalComponent;
+
+  protected refreshApi: CodingRefreshApi = {
+    findCandidates: (scope, statuses) => {
+      if (scope.kind !== 'cs-version') {
+        throw new Error('Unexpected scope');
+      }
+      return this.codeSystemService.findVersionRefCandidates(scope.codeSystemId, scope.version, statuses);
+    },
+    refresh: (scope, statuses) => {
+      if (scope.kind !== 'cs-version') {
+        throw new Error('Unexpected scope');
+      }
+      return this.codeSystemService.refreshVersionRefs(scope.codeSystemId, scope.version, statuses);
+    }
+  };
+
+  protected openRefreshReferences(): void {
+    if (!this.codeSystem || !this.version) {
+      return;
+    }
+    this.loader.wrap('refresh-load', this.codeSystemService.searchVersions(this.codeSystem, {ids: String(this.version), limit: 1}))
+      .subscribe(r => {
+        const v = r?.data?.[0];
+        if (!v?.version) {
+          this.notificationService.error('Version not found');
+          return;
+        }
+        this.refreshModal?.open({kind: 'cs-version', codeSystemId: this.codeSystem, version: v.version});
+      });
+  }
 
   public ngOnInit(): void {
     this.codeSystem = this.route.snapshot.paramMap.get('code-system');

--- a/app/src/app/resources/code-system/services/code-system.service.ts
+++ b/app/src/app/resources/code-system/services/code-system.service.ts
@@ -1,11 +1,13 @@
-import {HttpHeaders} from '@angular/common/http';
+import {HttpHeaders, HttpParams} from '@angular/common/http';
 import {Injectable} from '@angular/core';
 import {isDefined, serializeDate} from '@termx-health/core-util';
+import {environment} from 'environments/environment';
 import {saveAs} from 'file-saver';
 import {Observable, of} from 'rxjs';
 import {map} from 'rxjs/operators';
 import {UriUtil} from 'term-web/core/utils/uri-util';
 import {CodeSystemConcept, CodeSystemLibService, CodeSystemTransactionRequest, CodeSystemVersion, ConceptTransactionRequest} from 'term-web/resources/_lib';
+import {CodingValueUpdateCandidate} from 'term-web/resources/_lib/code-system/model/coding-value-update-candidate';
 import {LorqueProcess} from 'term-web/sys/_lib';
 
 @Injectable()
@@ -140,5 +142,35 @@ export class CodeSystemService extends CodeSystemLibService {
 
   public deleteEntityPropertyUsages(codeSystemId: string, propertyId: number): Observable<void> {
     return this.http.post<void>(`${this.baseUrl}/${codeSystemId}/entity-properties/${propertyId}/delete-usages`, {});
+  }
+
+  public findConceptRefCandidates(csevId: number, allowedStatuses: string[]): Observable<CodingValueUpdateCandidate[]> {
+    const params = new HttpParams().set('allowedStatuses', (allowedStatuses ?? []).join(','));
+    return this.http.get<CodingValueUpdateCandidate[]>(
+      `${environment.termxApi}/ts/code-system-entity-versions/${csevId}/coding-value-update-candidates`,
+      {params}
+    );
+  }
+
+  public refreshConceptRefs(csevId: number, allowedStatuses: string[]): Observable<{applied: number}> {
+    return this.http.post<{applied: number}>(
+      `${environment.termxApi}/ts/code-system-entity-versions/${csevId}/refresh-coding-values`,
+      {allowedStatuses}
+    );
+  }
+
+  public findVersionRefCandidates(codeSystemId: string, version: string, allowedStatuses: string[]): Observable<CodingValueUpdateCandidate[]> {
+    const params = new HttpParams().set('allowedStatuses', (allowedStatuses ?? []).join(','));
+    return this.http.get<CodingValueUpdateCandidate[]>(
+      `${this.baseUrl}/${codeSystemId}/versions/${version}/coding-value-update-candidates`,
+      {params}
+    );
+  }
+
+  public refreshVersionRefs(codeSystemId: string, version: string, allowedStatuses: string[]): Observable<{applied?: number; queued?: number}> {
+    return this.http.post<{applied?: number; queued?: number}>(
+      `${this.baseUrl}/${codeSystemId}/versions/${version}/refresh-coding-values`,
+      {allowedStatuses}
+    );
   }
 }

--- a/app/src/assets/i18n/en.json
+++ b/app/src/assets/i18n/en.json
@@ -1034,6 +1034,24 @@
 				},
 				"view-header": "View code system"
 			},
+			"coding-refresh": {
+				"action": "Refresh references",
+				"header": "Refresh references to other code systems",
+				"allowed-statuses": "Allowed target statuses",
+				"allowed-statuses-desc": "Only versions matching one of these statuses are considered when picking the latest version.",
+				"preview-btn": "Preview changes",
+				"apply-btn": "Apply",
+				"preview-desc": "{{count}} reference(s) will be updated:",
+				"property": "Property",
+				"target": "Target",
+				"current": "Current version",
+				"candidate": "New version",
+				"up-to-date": "All references are up to date",
+				"up-to-date-desc": "No property values were found that point to an older version.",
+				"applied": "References updated",
+				"queued": "References queued for update",
+				"validator-desc": "Scan property values in this code system version and update references to the newest available version of their target code systems."
+			},
 			"list": {
 				"add-code-system": "Add code system",
 				"count": "Count",


### PR DESCRIPTION
## Summary

Front-end for [the matching backend PR](https://github.com/termx-health/termx-server/pull/109): exposes the new "refresh coding-value version references" operation in two places — per-concept (concept edit page) and per-CodeSystem-version (Validator page).

- **Shared modal** (`CodingValueRefreshModalComponent`): two-step *select allowed target statuses → preview candidates → apply* flow. Reused by both entry points via a small `CodingRefreshApi` shape.
- **Service layer**: four new methods on `CodeSystemService` calling the new `/ts` endpoints (entity-version and CS-version scopes).
- **Per-concept**: a "Refresh references" item in the version actions dropdown on the concept edit page; reloads the concept after apply.
- **Per-CS-version**: a new card on the Validator page (next to Uniqueness validator / Circular dependencies detector), placed there at the user's request rather than on the version summary widget.
- **Privileges**: both triggers gated by `*.CodeSystem.write`; backend endpoints require `CS_WRITE`.
- **i18n**: English strings under `web.code-system.coding-refresh.*`.

## Commits
- `feat(coding-refresh): add shared modal, candidate model, service methods, i18n`
- `feat(coding-refresh): wire Refresh references action into concept edit and validator`

## Test plan
- [ ] Backend PR https://github.com/termx-health/termx-server/pull/109 is deployed.
- [ ] Open a concept that references LOINC at an older version; "Refresh references" action appears in the version actions dropdown. Both `active`+`draft` checked by default; clicking Preview shows the proposed change; Apply updates the property version and reloads the concept.
- [ ] If all references are already up-to-date, the modal shows a "no changes" toast and closes.
- [ ] Toggle only `active`: candidates that would resolve to a draft disappear from the preview.
- [ ] Open `resources/code-systems/validator;code-system=...;version=...`: the new "Refresh references" card is disabled until both fields are selected, then opens the same modal. Async response (`queued: N`) surfaces as a toast.
- [ ] User without `*.CodeSystem.write` does not see the trigger in either place.