### PR TITLE
feat(bob): Stored archives UI + SNOMED from-archive import (Phase 1d)

### DIFF
--- a/app/src/app/integration/import/loinc/loinc-import.component.html
+++ b/app/src/app/integration/import/loinc/loinc-import.component.html
@@ -90,3 +90,12 @@
     <m-button mDisplay="primary" (click)="importLoinc()">{{'core.btn.confirm' | translate}}</m-button>
   </div>
 </m-modal>
+
+<!--
+  Stored LOINC release archives — uploaded to the Bob "loinc" container via the streaming
+  /bob/objects endpoint. The per-row Import action is not wired yet (LOINC's multi-file
+  import flow needs a server-side zip-entry dispatcher; see termx-server PR #121).
+-->
+<div style="margin-top: 1rem;">
+  <tw-bob-archives container="loinc"/>
+</div>

--- a/app/src/app/integration/import/loinc/loinc-import.component.ts
+++ b/app/src/app/integration/import/loinc/loinc-import.component.ts
@@ -5,7 +5,7 @@ import {Router} from '@angular/router';
 import {DestroyService} from '@termx-health/core-util';
 import { MuiNotificationService, MuiCardModule, MuiFormModule, MuiInputModule, MuiButtonModule, MuiAlertModule, MuiCoreModule, MuiModalModule, MarinPageLayoutModule } from '@termx-health/ui';
 import {environment} from 'environments/environment';
-import {JobLibService, JobLog, JobLogResponse} from 'term-web/sys/_lib';
+import {BobArchivesComponent, JobLibService, JobLog, JobLogResponse} from 'term-web/sys/_lib';
 import { NzBreadCrumbComponent, NzBreadCrumbItemComponent } from 'ng-zorro-antd/breadcrumb';
 import { ValueSetConceptSelectComponent } from 'term-web/resources/_lib/value-set/containers/value-set-concept-select.component';
 
@@ -16,7 +16,7 @@ import { HasAnyPrivilegePipe } from 'term-web/core/auth/privileges/has-any-privi
 @Component({
     templateUrl: 'loinc-import.component.html',
     providers: [DestroyService],
-    imports: [MuiCardModule, NzBreadCrumbComponent, NzBreadCrumbItemComponent, FormsModule, MuiFormModule, MuiInputModule, ValueSetConceptSelectComponent, MuiButtonModule, MuiAlertModule, MuiCoreModule, MuiModalModule, MarinPageLayoutModule, TranslatePipe, HasAnyPrivilegePipe]
+    imports: [MuiCardModule, NzBreadCrumbComponent, NzBreadCrumbItemComponent, FormsModule, MuiFormModule, MuiInputModule, ValueSetConceptSelectComponent, MuiButtonModule, MuiAlertModule, MuiCoreModule, MuiModalModule, MarinPageLayoutModule, TranslatePipe, HasAnyPrivilegePipe, BobArchivesComponent]
 })
 export class LoincImportComponent {
   private http = inject(HttpClient);

--- a/app/src/app/integration/snomed/containers/management/codesystem/snomed-codesystem-edit.component.html
+++ b/app/src/app/integration/snomed/containers/management/codesystem/snomed-codesystem-edit.component.html
@@ -185,3 +185,16 @@
     </div>
   </m-modal>
 </m-form-row>
+
+<!--
+  Stored RF2 archives — uploaded to the Bob "snomed" container via the streaming /bob/objects
+  endpoint, so JVM heap stays flat even on full International editions (~1 GB). The per-row
+  "Import" button calls /snomed/imports/from-archive which streams Minio → Snowstorm.
+-->
+<ng-container *twPrivileged="'snomed-ct.CodeSystem.read'">
+  <m-form-row>
+    <div *m-form-col>
+      <tw-bob-archives container="snomed" actionLabel="Import" (action)="importFromArchive($event)"/>
+    </div>
+  </m-form-row>
+</ng-container>

--- a/app/src/app/integration/snomed/containers/management/codesystem/snomed-codesystem-edit.component.ts
+++ b/app/src/app/integration/snomed/containers/management/codesystem/snomed-codesystem-edit.component.ts
@@ -6,7 +6,7 @@ import { compareStrings, DestroyService, isDefined, LoadingManager, validateForm
 import { MuiNotificationService, MuiFormModule, MuiSpinnerModule, MuiCardModule, MarinPageLayoutModule, MuiDropdownModule, MuiCoreModule, MuiPopconfirmModule, MuiTextareaModule, MuiCheckboxModule, MuiButtonModule, MuiModalModule, MuiSelectModule, MuiAlertModule } from '@termx-health/ui';
 import {SnomedCodeSystem, SnomedCodeSystemVersion} from 'term-web/integration/_lib';
 import {SnomedService} from 'term-web/integration/snomed/services/snomed-service';
-import {LorqueLibService} from 'term-web/sys/_lib';
+import {BobArchivesComponent, BobObject, LorqueLibService} from 'term-web/sys/_lib';
 import { PrivilegedDirective } from 'term-web/core/auth/privileges/privileged.directive';
 import { NzProgressComponent } from 'ng-zorro-antd/progress';
 import { TranslatePipe } from '@ngx-translate/core';
@@ -15,7 +15,7 @@ import { TranslatePipe } from '@ngx-translate/core';
 @Component({
     templateUrl: 'snomed-codesystem-edit.component.html',
     providers: [DestroyService],
-    imports: [MuiFormModule, MuiSpinnerModule, FormsModule, MuiCardModule, MarinPageLayoutModule, MuiDropdownModule, PrivilegedDirective, MuiCoreModule, MuiPopconfirmModule, MuiTextareaModule, MuiCheckboxModule, MuiButtonModule, MuiModalModule, MuiSelectModule, NzProgressComponent, MuiAlertModule, TranslatePipe, FilterPipe, JoinPipe, LocalDateTimePipe, ToStringPipe, ValuesPipe]
+    imports: [MuiFormModule, MuiSpinnerModule, FormsModule, MuiCardModule, MarinPageLayoutModule, MuiDropdownModule, PrivilegedDirective, MuiCoreModule, MuiPopconfirmModule, MuiTextareaModule, MuiCheckboxModule, MuiButtonModule, MuiModalModule, MuiSelectModule, NzProgressComponent, MuiAlertModule, TranslatePipe, FilterPipe, JoinPipe, LocalDateTimePipe, ToStringPipe, ValuesPipe, BobArchivesComponent]
 })
 export class SnomedCodesystemEditComponent implements OnInit {
   private snomedService = inject(SnomedService);
@@ -153,6 +153,41 @@ export class SnomedCodesystemEditComponent implements OnInit {
         }
       },
       error: err => this.handleImportError(err)
+    });
+  }
+
+  /**
+   * Kicks off a streaming SNOMED import against a previously-uploaded archive in Bob —
+   * invoked by the per-row "Import" button on <tw-bob-archives>. The full upload has already
+   * happened (no re-upload from the browser); we only POST the uuid + import params and poll
+   * the Lorque process for completion.
+   */
+  protected importFromArchive(archive: BobObject): void {
+    if (!archive?.uuid || !this.snomedCodeSystem) {
+      return;
+    }
+    const branchPath = this.snomedCodeSystem.branchPath;
+    this.loader.wrap('importFromArchive', this.snomedService.createImportJobFromArchive({
+      archiveUuid: archive.uuid,
+      branchPath,
+      type: 'SNAPSHOT',
+      createCodeSystemVersion: true
+    })).subscribe({
+      next: lorque => {
+        this.notificationService.success('Import started');
+        // The polling pattern matches the existing scan flow — Snowstorm runs the actual import
+        // server-side; the Lorque process here completes once the archive has been uploaded to
+        // Snowstorm and the tracking row is written. Snowstorm import status is then polled via
+        // the existing tracking record.
+        this.lorqueService.pollProcessProgress(lorque.id, this.destroy$).subscribe(p => {
+          if (p?.status === 'failed') {
+            this.lorqueService.load(lorque.id).subscribe(loaded => this.notificationService.error(loaded.resultText));
+          } else if (p?.status === 'completed') {
+            this.notificationService.success('Archive uploaded to Snowstorm; import running');
+          }
+        });
+      },
+      error: err => this.notificationService.error(this.extractErrorMessage(err)),
     });
   }
 

--- a/app/src/app/integration/snomed/services/snomed-service.ts
+++ b/app/src/app/integration/snomed/services/snomed-service.ts
@@ -122,6 +122,29 @@ export class SnomedService extends SnomedLibService {
     return this.http.get(`${this.baseUrl}/imports/scan/result/${lorqueProcessId}`);
   }
 
+  /**
+   * Streaming counterpart of {@link createImportJob} — the archive already lives in the Bob
+   * "snomed" container (uploaded via {@link BobLibService#upload}). Returns a Lorque process
+   * the caller polls for progress / completion.
+   */
+  public createImportJobFromArchive(request: {
+    archiveUuid: string;
+    branchPath: string;
+    type: string;
+    createCodeSystemVersion: boolean;
+  }): Observable<{id: number}> {
+    return this.http.post(`${this.baseUrl}/imports/from-archive`, request).pipe(map(r => r as {id: number}));
+  }
+
+  public scanRF2FromArchive(request: {
+    archiveUuid: string;
+    branchPath: string;
+    type: string;
+    mode?: 'summary' | 'full';
+  }): Observable<{id: number}> {
+    return this.http.post(`${this.baseUrl}/imports/scan/from-archive`, request).pipe(map(r => r as {id: number}));
+  }
+
   public proceedScanImport(cacheId: number): Observable<{jobId: string}> {
     return this.http.post(`${this.baseUrl}/imports/scan/${cacheId}/proceed`, {}).pipe(map(r => r as {jobId: string}));
   }

--- a/app/src/app/sys/_lib/bob/bob-lib.module.ts
+++ b/app/src/app/sys/_lib/bob/bob-lib.module.ts
@@ -1,0 +1,18 @@
+import {CommonModule} from '@angular/common';
+import {NgModule} from '@angular/core';
+import {FormsModule} from '@angular/forms';
+import {CoreUtilModule} from '@termx-health/core-util';
+import {BobLibService} from 'term-web/sys/_lib/bob/services/bob-lib.service';
+
+@NgModule({
+  imports: [
+    FormsModule,
+    CommonModule,
+    CoreUtilModule
+  ],
+  providers: [
+    BobLibService,
+  ]
+})
+export class BobLibModule {
+}

--- a/app/src/app/sys/_lib/bob/components/bob-archives.component.html
+++ b/app/src/app/sys/_lib/bob/components/bob-archives.component.html
@@ -1,0 +1,41 @@
+<m-card>
+  <div *m-card-header class="m-justify-between">
+    <h3 style="margin: 0;">Stored archives ({{container}})</h3>
+    <m-button mDisplay="text" (mClick)="load()" [mLoading]="loader.state['load']">↻</m-button>
+  </div>
+  <div *mCardContent="!loader.state['load']">
+    <m-table [mData]="archives" mEmptyText="No archives yet">
+      <tr *mTableHead>
+        <th>File</th>
+        <th>Description</th>
+        <th style="width: 1%; white-space: nowrap;"></th>
+      </tr>
+      <tr *mTableRow="let o">
+        <td>
+          <a (click)="download(o)">{{o.storage?.filename || o.uuid}}</a>
+          <div class="m-subtitle">{{o.contentType}}</div>
+        </td>
+        <td>{{o.description || '-'}}</td>
+        <td>
+          @if (actionLabel) {
+            <m-button mDisplay="primary" mSize="small" (mClick)="action.emit(o)">{{actionLabel}}</m-button>
+          }
+          <m-button mDisplay="text" mSize="small" m-popconfirm mPopconfirmTitle="core.delete-confirm" (mOnConfirm)="remove(o)">
+            {{'core.btn.delete' | translate}}
+          </m-button>
+        </td>
+      </tr>
+    </m-table>
+
+    <div style="margin-top: 1rem; display: flex; gap: 0.5rem; align-items: center;">
+      <input #fileInput type="file" (change)="onPickFile(fileInput)">
+      <input type="text" placeholder="Description (optional)" [(ngModel)]="uploadDescription" style="flex: 1;">
+      <m-button mDisplay="primary" [disabled]="!uploadFile" [mLoading]="loader.state['upload']" (mClick)="upload()">
+        Upload
+      </m-button>
+    </div>
+    @if (uploadProgress !== undefined) {
+      <div style="margin-top: 0.5rem;">Uploading: {{uploadProgress}}%</div>
+    }
+  </div>
+</m-card>

--- a/app/src/app/sys/_lib/bob/components/bob-archives.component.ts
+++ b/app/src/app/sys/_lib/bob/components/bob-archives.component.ts
@@ -1,0 +1,121 @@
+import {CommonModule} from '@angular/common';
+import {Component, EventEmitter, inject, Input, OnInit, Output} from '@angular/core';
+import {FormsModule} from '@angular/forms';
+import {LoadingManager, QueryParams} from '@termx-health/core-util';
+import {MuiButtonModule, MuiCardModule, MuiCoreModule, MuiNotificationService, MuiPopconfirmModule, MuiTableModule} from '@termx-health/ui';
+import {TranslateModule} from '@ngx-translate/core';
+import {finalize} from 'rxjs/operators';
+import {BobObject} from 'term-web/sys/_lib/bob/model/bob-object';
+import {BobLibService} from 'term-web/sys/_lib/bob/services/bob-lib.service';
+
+/**
+ * Container-scoped list of {@link BobObject} archives stored on the server. Lets admins
+ * upload, download, delete, and (optionally) trigger a per-row action — e.g. "Import" on a
+ * SNOMED RF2 zip. The upload uses the streaming {@code POST /bob/objects} endpoint, so
+ * multi-hundred-MB files never live in JVM heap.
+ *
+ * Usage:
+ *   <tw-bob-archives container="snomed" actionLabel="Import" (action)="importFromArchive($event)" />
+ */
+@Component({
+  selector: 'tw-bob-archives',
+  templateUrl: './bob-archives.component.html',
+  standalone: true,
+  imports: [CommonModule, FormsModule, TranslateModule, MuiButtonModule, MuiCardModule, MuiCoreModule, MuiPopconfirmModule, MuiTableModule]
+})
+export class BobArchivesComponent implements OnInit {
+  @Input() public container!: string;
+  /** Optional per-row action button label. Hidden if not set. */
+  @Input() public actionLabel?: string;
+  @Output() public action = new EventEmitter<BobObject>();
+
+  protected archives: BobObject[] = [];
+  protected loader = new LoadingManager();
+  protected uploadProgress?: number;
+  protected uploadFile?: File;
+  protected uploadDescription?: string;
+
+  private bobService = inject(BobLibService);
+  private notificationService = inject(MuiNotificationService);
+
+  public ngOnInit(): void {
+    this.load();
+  }
+
+  protected load(): void {
+    this.loader.wrap('load', this.bobService.query(this.container, Object.assign(new QueryParams(), {limit: 100}) as any))
+      .subscribe(resp => this.archives = resp.data || []);
+  }
+
+  protected onPickFile(input: HTMLInputElement): void {
+    this.uploadFile = input.files?.[0];
+  }
+
+  protected upload(): void {
+    if (!this.uploadFile) {
+      return;
+    }
+    const file = this.uploadFile;
+    this.uploadProgress = 0;
+    this.loader.start('upload');
+    this.bobService.upload({container: this.container, file, description: this.uploadDescription})
+      .pipe(finalize(() => {
+        this.loader.stop('upload');
+        this.uploadProgress = undefined;
+      }))
+      .subscribe({
+        next: ev => {
+          if (ev.finished) {
+            this.uploadFile = undefined;
+            this.uploadDescription = undefined;
+            this.notificationService.success('Archive uploaded');
+            this.load();
+          } else {
+            this.uploadProgress = ev.progress;
+          }
+        },
+        error: err => this.notificationService.error(this.extractError(err)),
+      });
+  }
+
+  protected download(o: BobObject): void {
+    window.open(this.bobService.contentUrl(o.uuid!), '_blank');
+  }
+
+  protected remove(o: BobObject): void {
+    this.loader.wrap('delete', this.bobService.delete(o.uuid!)).subscribe({
+      next: () => {
+        this.notificationService.success('Archive deleted');
+        this.load();
+      },
+      error: err => this.notificationService.error(this.extractError(err)),
+    });
+  }
+
+  protected formatSize(n?: number): string {
+    if (!n && n !== 0) {
+      return '';
+    }
+    if (n < 1024) {
+      return `${n} B`;
+    }
+    if (n < 1024 * 1024) {
+      return `${(n / 1024).toFixed(1)} KB`;
+    }
+    if (n < 1024 * 1024 * 1024) {
+      return `${(n / 1024 / 1024).toFixed(1)} MB`;
+    }
+    return `${(n / 1024 / 1024 / 1024).toFixed(2)} GB`;
+  }
+
+  private extractError(err: any): string {
+    const body = err?.error;
+    if (Array.isArray(body) && body.length > 0) {
+      return body.map((i: any) => i?.message || i?.code || String(i)).join('; ');
+    }
+    if (body?.message) {
+      return body.message;
+    }
+    return err?.message || 'Request failed';
+  }
+}

--- a/app/src/app/sys/_lib/bob/index.ts
+++ b/app/src/app/sys/_lib/bob/index.ts
@@ -1,0 +1,4 @@
+export * from 'term-web/sys/_lib/bob/model/bob-object';
+export * from 'term-web/sys/_lib/bob/services/bob-lib.service';
+export * from 'term-web/sys/_lib/bob/components/bob-archives.component';
+export * from 'term-web/sys/_lib/bob/bob-lib.module';

--- a/app/src/app/sys/_lib/bob/model/bob-object.ts
+++ b/app/src/app/sys/_lib/bob/model/bob-object.ts
@@ -1,0 +1,16 @@
+export class BobStorage {
+  public id?: number;
+  public storageType?: string;
+  public container?: string;
+  public path?: string;
+  public filename?: string;
+}
+
+export class BobObject {
+  public id?: number;
+  public uuid?: string;
+  public contentType?: string;
+  public meta?: {[key: string]: any};
+  public description?: string;
+  public storage?: BobStorage;
+}

--- a/app/src/app/sys/_lib/bob/services/bob-lib.service.ts
+++ b/app/src/app/sys/_lib/bob/services/bob-lib.service.ts
@@ -1,0 +1,83 @@
+import {HttpClient, HttpEvent, HttpEventType, HttpResponse} from '@angular/common/http';
+import {inject, Injectable} from '@angular/core';
+import {QueryParams, SearchHttpParams, SearchResult} from '@termx-health/core-util';
+import {environment} from 'environments/environment';
+import {EMPTY, mergeMap, Observable, of} from 'rxjs';
+import {map} from 'rxjs/operators';
+import {BobObject} from 'term-web/sys/_lib/bob/model/bob-object';
+
+/**
+ * Thin wrapper over the generic {@code /bob/objects} REST surface (see termx-server Phase 1a).
+ * Container-specific authz lives server-side; the UI simply passes {@code container} on every
+ * call and the server's {@code BobContainerAuthorizer} plugin enforces read/write privileges.
+ */
+@Injectable()
+export class BobLibService {
+  protected http = inject(HttpClient);
+  protected baseUrl = `${environment.termxApi}/bob/objects`;
+
+  public query(container: string, params: QueryParams & {meta?: any} = new QueryParams()): Observable<SearchResult<BobObject>> {
+    const httpParams: {[k: string]: any} = {...params, container};
+    if (params.meta && typeof params.meta !== 'string') {
+      httpParams['meta'] = JSON.stringify(params.meta);
+    }
+    return this.http.get<SearchResult<BobObject>>(this.baseUrl, {params: SearchHttpParams.build(httpParams)});
+  }
+
+  public load(uuid: string): Observable<BobObject> {
+    return this.http.get<BobObject>(`${this.baseUrl}/${uuid}`);
+  }
+
+  public contentUrl(uuid: string): string {
+    return `${this.baseUrl}/${uuid}/content`;
+  }
+
+  /**
+   * Streaming upload — the server uses {@code StreamingFileUpload} + a temp file, so even
+   * multi-hundred-MB archives don't OOM the JVM. The Observable emits intermediate
+   * {@code {finished:false, progress: 0-100}} events while bytes upload, then a final
+   * {@code {finished:true, body: BobObject}} when the server responds.
+   */
+  public upload(opts: {
+    container: string;
+    file: Blob;
+    filename?: string;
+    meta?: {[k: string]: any};
+    description?: string;
+    path?: string;
+    contentType?: string;
+  }): Observable<{finished: boolean; progress?: number; body?: BobObject}> {
+    const fd = new FormData();
+    fd.append('container', opts.container);
+    fd.append('file', opts.file, opts.filename || (opts.file as File).name || 'upload');
+    if (opts.meta) {
+      fd.append('meta', JSON.stringify(opts.meta));
+    }
+    if (opts.description) {
+      fd.append('description', opts.description);
+    }
+    if (opts.path) {
+      fd.append('path', opts.path);
+    }
+    if (opts.contentType) {
+      fd.append('contentType', opts.contentType);
+    }
+    return this.http.post<BobObject>(this.baseUrl, fd, {reportProgress: true, observe: 'events'})
+        .pipe(mergeMap((event: HttpEvent<BobObject>) => {
+          if (event.type === HttpEventType.UploadProgress) {
+            return of({finished: false, progress: event.total ? Math.round(100 * event.loaded / event.total) : 0});
+          } else if (event instanceof HttpResponse) {
+            return of({finished: true, body: event.body as BobObject});
+          }
+          return EMPTY;
+        }));
+  }
+
+  public update(uuid: string, patch: {meta?: any; description?: string}): Observable<BobObject> {
+    return this.http.patch<BobObject>(`${this.baseUrl}/${uuid}`, patch);
+  }
+
+  public delete(uuid: string): Observable<void> {
+    return this.http.delete<void>(`${this.baseUrl}/${uuid}`);
+  }
+}

--- a/app/src/app/sys/_lib/index.ts
+++ b/app/src/app/sys/_lib/index.ts
@@ -11,6 +11,7 @@ export * from 'term-web/sys/_lib/provenance/services/provenance-lib.service';
 export * from 'term-web/sys/_lib/sys-lib.module';
 
 
+export * from 'term-web/sys/_lib/bob';
 export * from 'term-web/sys/_lib/checklist';
 export * from 'term-web/sys/_lib/job';
 export * from 'term-web/sys/_lib/lorque';

--- a/app/src/app/sys/_lib/sys-lib.module.ts
+++ b/app/src/app/sys/_lib/sys-lib.module.ts
@@ -1,4 +1,5 @@
 import {NgModule} from '@angular/core';
+import {BobLibModule} from 'term-web/sys/_lib/bob';
 import {ChecklistLibModule} from 'term-web/sys/_lib/checklist';
 import {SpaceLibModule} from 'term-web/sys/_lib/space';
 import {JobLibModule} from 'term-web/sys/_lib/job';
@@ -8,6 +9,7 @@ import {ReleaseLibModule} from 'term-web/sys/_lib/release';
 
 @NgModule({
   imports: [
+    BobLibModule,
     JobLibModule,
     LorqueLibModule,
     ProvenanceLibModule,
@@ -16,6 +18,7 @@ import {ReleaseLibModule} from 'term-web/sys/_lib/release';
     SpaceLibModule
   ],
   exports: [
+    BobLibModule,
     JobLibModule,
     LorqueLibModule,
     ProvenanceLibModule,


### PR DESCRIPTION
Pairs with [termx-server PR #121](https://github.com/termx-health/termx-server/pull/121). Brings the new streaming-upload + from-archive-import flow to the UI.

## What's new

- **Generic Bob client (`@sys/_lib/bob`):**
  - `BobLibService` — thin wrapper over `/bob/objects` (query / load / streaming upload with progress events / patch / delete).
  - `<tw-bob-archives container="…" actionLabel="Import" (action)="…">` standalone component — lists stored archives for a container, lets admins upload new ones (streaming) and delete, and emits per-row actions.

- **SNOMED CodeSystem edit page** now embeds `<tw-bob-archives container="snomed">` with a per-row **Import** button that calls the new `POST /snomed/imports/from-archive`. The import runs server-side via Lorque (Minio → Snowstorm), so the browser doesn't need to re-upload a multi-hundred-MB zip for every retry.

- **LOINC import page** embeds `<tw-bob-archives container="loinc">` for managing stored LOINC release archives. The per-row Import action is intentionally left unwired — LOINC's multi-file import needs a server-side zip-entry dispatcher first.

## Test plan
- [ ] On the SNOMED CodeSystem edit page, the "Stored archives (snomed)" card lists existing archives.
- [ ] Uploading a multi-hundred-MB RF2 zip shows progress (0 → 100%), then the archive appears in the list and the browser DevTools network tab confirms a streamed (chunked) request.
- [ ] Clicking **Import** on a row triggers `POST /snomed/imports/from-archive`, a Lorque process starts, and progress notifications appear.
- [ ] Deleting an archive removes it from both Minio and the list.
- [ ] On the LOINC import page, the "Stored archives (loinc)" card lets admins upload / delete loinc release zips (no per-row Import yet).
- [ ] The existing `Import from RF2` modal on the SNOMED page still works (no regression).