### PR TITLE
feat(loinc): wire 'Import' button on Stored archives to /loinc/import/from-archive

### DIFF
--- a/app/src/app/integration/import/loinc/loinc-import.component.html
+++ b/app/src/app/integration/import/loinc/loinc-import.component.html
@@ -93,9 +93,10 @@
 
 <!--
   Stored LOINC release archives — uploaded to the Bob "loinc" container via the streaming
-  /bob/objects endpoint. The per-row Import action is not wired yet (LOINC's multi-file
-  import flow needs a server-side zip-entry dispatcher; see termx-server PR #121).
+  /bob/objects endpoint. Per-row "Import" calls POST /loinc/import/from-archive, which
+  unpacks the zip server-side and runs the same import pipeline as the legacy multipart
+  endpoint above. The version / language from the form above are sent with the request.
 -->
 <div style="margin-top: 1rem;">
-  <tw-bob-archives container="loinc"/>
+  <tw-bob-archives container="loinc" actionLabel="Import" (action)="importFromArchive($event)"/>
 </div>

--- a/app/src/app/integration/import/loinc/loinc-import.component.ts
+++ b/app/src/app/integration/import/loinc/loinc-import.component.ts
@@ -5,7 +5,7 @@ import {Router} from '@angular/router';
 import {DestroyService} from '@termx-health/core-util';
 import { MuiNotificationService, MuiCardModule, MuiFormModule, MuiInputModule, MuiButtonModule, MuiAlertModule, MuiCoreModule, MuiModalModule, MarinPageLayoutModule } from '@termx-health/ui';
 import {environment} from 'environments/environment';
-import {BobArchivesComponent, JobLibService, JobLog, JobLogResponse} from 'term-web/sys/_lib';
+import {BobArchivesComponent, BobObject, JobLibService, JobLog, JobLogResponse} from 'term-web/sys/_lib';
 import { NzBreadCrumbComponent, NzBreadCrumbItemComponent } from 'ng-zorro-antd/breadcrumb';
 import { ValueSetConceptSelectComponent } from 'term-web/resources/_lib/value-set/containers/value-set-concept-select.component';
 
@@ -89,6 +89,32 @@ export class LoincImportComponent {
       }
       this.jobResponse = jobResp;
     }).add(() => this.loading['process'] = false);
+  }
+
+  /**
+   * Per-row Import button on the "Stored archives" panel: re-uses {@link data.version} +
+   * {@link data.language} from the form (so the user can set them once and import any of the
+   * stored release zips). The server unpacks the zip by basename and runs the same import
+   * pipeline as the legacy multipart endpoint — no need to re-upload from the browser.
+   */
+  protected importFromArchive(archive: BobObject): void {
+    if (!archive?.uuid) {
+      return;
+    }
+    if (!this.data.version) {
+      this.notificationService.error('Set the version (and language, if importing translations) above before importing from a stored archive.');
+      return;
+    }
+    this.jobResponse = null;
+    this.loading['process'] = true;
+    this.http.post<JobLogResponse>(`${environment.termxApi}/loinc/import/from-archive`, {
+      archiveUuid: archive.uuid,
+      version: this.data.version,
+      language: this.data.language,
+    }).subscribe({
+      next: resp => this.pollJobStatus(resp.jobId as number),
+      error: () => this.loading['process'] = false,
+    });
   }
 
   protected openCodeSystem(mode: 'edit' | 'view'): void {


### PR DESCRIPTION
Pairs with termx-server [#123](https://github.com/termx-health/termx-server/pull/123). The LOINC import page already lists stored archives via `<tw-bob-archives container="loinc">`. This change enables the per-row **Import** button.

## What changes
- `LoincImportComponent.importFromArchive(archive)` — POSTs `{archiveUuid, version, language}` to `/loinc/import/from-archive` and polls `JobLogResponse` exactly like the legacy `/loinc/import` flow. Server unpacks the zip by basename and runs `LoincService.importLoinc` as an async job.
- HTML: `<tw-bob-archives actionLabel="Import" (action)="importFromArchive($event)">`.
- No new modal — `version` and `language` live in the form above, so import-from-archive is one click once those are set.
- If `version` is empty when the user clicks Import, a notification asks them to fill it in first.

## Test plan
- [ ] Upload a LOINC release zip via the Stored archives card → appears in the list.
- [ ] Fill `version` (and optionally `language`) at the top of the form, click **Import** on the stored row → the existing job-result display ("Imported successfully" / errors / warnings) appears, no need to re-pick files.
- [ ] Click **Import** without setting `version` → red toast asking for it.
- [ ] The legacy multipart import button still works (regression).