### PR TITLE
feat(bob): scope Stored archives card to the current CodeSystem

### DIFF
--- a/app/src/app/integration/snomed/containers/management/codesystem/snomed-codesystem-edit.component.html
+++ b/app/src/app/integration/snomed/containers/management/codesystem/snomed-codesystem-edit.component.html
@@ -194,7 +194,10 @@
 <ng-container *twPrivileged="'snomed-ct.CodeSystem.read'">
   <m-form-row>
     <div *m-form-col>
-      <tw-bob-archives container="snomed" actionLabel="Import" (action)="importFromArchive($event)"/>
+      <tw-bob-archives container="snomed"
+                       [meta]="{shortName: snomedCodeSystem?.shortName, branchPath: snomedCodeSystem?.branchPath}"
+                       actionLabel="Import"
+                       (action)="importFromArchive($event)"/>
     </div>
   </m-form-row>
 </ng-container>

--- a/app/src/app/integration/snomed/containers/management/codesystem/snomed-codesystem-edit.component.ts
+++ b/app/src/app/integration/snomed/containers/management/codesystem/snomed-codesystem-edit.component.ts
@@ -139,10 +139,20 @@ export class SnomedCodesystemEditComponent implements OnInit {
     this.importModalData.phase = 'uploading';
     this.importModalData.progress = 0;
 
+    // Tag the upload with the current CS so the Stored archives card below filters to just
+    // this CodeSystem's archives. snomedRF2Type goes on the meta so the per-row Import button
+    // can default to the right RF2 type instead of always SNAPSHOT.
+    const archiveMeta = {
+      shortName: this.snomedCodeSystem.shortName,
+      branchPath,
+      rf2Type: this.importModalData.type,
+    };
+
     this.loader.wrap('import', this.bobService.upload({
       container: 'snomed',
       file,
       description: `${dryRun ? 'dry-run upload' : 'import upload'} for ${this.snomedCodeSystem.shortName}`,
+      meta: archiveMeta,
     })).subscribe({
       next: ev => {
         if (!ev.finished) {
@@ -220,11 +230,15 @@ export class SnomedCodesystemEditComponent implements OnInit {
     if (!archive?.uuid || !this.snomedCodeSystem) {
       return;
     }
-    const branchPath = this.snomedCodeSystem.branchPath;
+    // Prefer the meta the upload was tagged with — that's the branch the user intended at
+    // upload time. Fall back to the current CS so legacy archives (uploaded before meta
+    // scoping landed) still work.
+    const branchPath = archive.meta?.['branchPath'] || this.snomedCodeSystem.branchPath;
+    const type = archive.meta?.['rf2Type'] || 'SNAPSHOT';
     this.loader.wrap('importFromArchive', this.snomedService.createImportJobFromArchive({
       archiveUuid: archive.uuid,
       branchPath,
-      type: 'SNAPSHOT',
+      type,
       createCodeSystemVersion: true
     })).subscribe({
       next: lorque => {

--- a/app/src/app/sys/_lib/bob/components/bob-archives.component.html
+++ b/app/src/app/sys/_lib/bob/components/bob-archives.component.html
@@ -15,7 +15,17 @@
           <a (click)="download(o)">{{o.storage?.filename || o.uuid}}</a>
           <div class="m-subtitle">{{o.contentType}}</div>
         </td>
-        <td>{{o.description || '-'}}</td>
+        <td>
+          <div>{{o.description || '-'}}</div>
+          @if (o.meta && (o.meta['branchPath'] || o.meta['rf2Type'] || o.meta['version'] || o.meta['language'])) {
+            <div class="m-subtitle">
+              @if (o.meta['branchPath']) { <span>{{o.meta['branchPath']}}</span> }
+              @if (o.meta['rf2Type']) { <span> · {{o.meta['rf2Type']}}</span> }
+              @if (o.meta['version']) { <span> · v{{o.meta['version']}}</span> }
+              @if (o.meta['language']) { <span> · {{o.meta['language']}}</span> }
+            </div>
+          }
+        </td>
         <td>
           @if (actionLabel) {
             <m-button mDisplay="primary" mSize="small" (mClick)="action.emit(o)">{{actionLabel}}</m-button>

--- a/app/src/app/sys/_lib/bob/components/bob-archives.component.ts
+++ b/app/src/app/sys/_lib/bob/components/bob-archives.component.ts
@@ -1,5 +1,5 @@
 import {CommonModule} from '@angular/common';
-import {Component, EventEmitter, inject, Input, OnInit, Output} from '@angular/core';
+import {Component, EventEmitter, inject, Input, OnChanges, OnInit, Output, SimpleChanges} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {LoadingManager, QueryParams} from '@termx-health/core-util';
 import {MuiButtonModule, MuiCardModule, MuiCoreModule, MuiNotificationService, MuiPopconfirmModule, MuiTableModule} from '@termx-health/ui';
@@ -14,8 +14,16 @@ import {BobLibService} from 'term-web/sys/_lib/bob/services/bob-lib.service';
  * SNOMED RF2 zip. The upload uses the streaming {@code POST /bob/objects} endpoint, so
  * multi-hundred-MB files never live in JVM heap.
  *
+ * The optional {@link meta} input scopes the card to a logical "owner" — e.g. a specific
+ * SNOMED CodeSystem. When set:
+ *   - {@code GET /bob/objects?meta=…} is sent so only matching rows are listed.
+ *   - Uploads are tagged with the same meta so they show up under the same scope next time.
+ *
  * Usage:
- *   <tw-bob-archives container="snomed" actionLabel="Import" (action)="importFromArchive($event)" />
+ *   <tw-bob-archives container="snomed"
+ *                    [meta]="{shortName: cs.shortName, branchPath: cs.branchPath}"
+ *                    actionLabel="Import"
+ *                    (action)="importFromArchive($event)" />
  */
 @Component({
   selector: 'tw-bob-archives',
@@ -23,10 +31,16 @@ import {BobLibService} from 'term-web/sys/_lib/bob/services/bob-lib.service';
   standalone: true,
   imports: [CommonModule, FormsModule, TranslateModule, MuiButtonModule, MuiCardModule, MuiCoreModule, MuiPopconfirmModule, MuiTableModule]
 })
-export class BobArchivesComponent implements OnInit {
+export class BobArchivesComponent implements OnInit, OnChanges {
   @Input() public container!: string;
   /** Optional per-row action button label. Hidden if not set. */
   @Input() public actionLabel?: string;
+  /**
+   * Optional JSONB-containment filter and upload tag. When set, only archives whose meta
+   * contains all listed entries are shown, and new uploads inherit the same meta — so the
+   * card always stays scoped to its logical owner (current CS, current LOINC release, etc.).
+   */
+  @Input() public meta?: {[k: string]: any};
   @Output() public action = new EventEmitter<BobObject>();
 
   protected archives: BobObject[] = [];
@@ -42,8 +56,23 @@ export class BobArchivesComponent implements OnInit {
     this.load();
   }
 
+  public ngOnChanges(changes: SimpleChanges): void {
+    // Reload when meta or container changes — the parent may swap the CS context without
+    // recreating the component (e.g. ViewChild route reuse), and we'd otherwise show stale rows.
+    if (!changes['container']?.firstChange && (changes['container'] || changes['meta'])) {
+      this.load();
+    }
+  }
+
   protected load(): void {
-    this.loader.wrap('load', this.bobService.query(this.container, Object.assign(new QueryParams(), {limit: 100}) as any))
+    if (!this.container) {
+      return;
+    }
+    const params: QueryParams & {meta?: any} = Object.assign(new QueryParams(), {limit: 100}) as any;
+    if (this.meta && Object.keys(this.meta).length > 0) {
+      params.meta = this.compactMeta();
+    }
+    this.loader.wrap('load', this.bobService.query(this.container, params))
       .subscribe(resp => this.archives = resp.data || []);
   }
 
@@ -58,7 +87,12 @@ export class BobArchivesComponent implements OnInit {
     const file = this.uploadFile;
     this.uploadProgress = 0;
     this.loader.start('upload');
-    this.bobService.upload({container: this.container, file, description: this.uploadDescription})
+    this.bobService.upload({
+      container: this.container,
+      file,
+      description: this.uploadDescription,
+      meta: this.compactMeta(),
+    })
       .pipe(finalize(() => {
         this.loader.stop('upload');
         this.uploadProgress = undefined;
@@ -76,6 +110,24 @@ export class BobArchivesComponent implements OnInit {
         },
         error: err => this.notificationService.error(this.extractError(err)),
       });
+  }
+
+  /** Drops {@code undefined} / {@code null} values so the server-side {@code @>} JSONB
+   *  containment filter doesn't try to match an explicit null. */
+  private compactMeta(): {[k: string]: any} | undefined {
+    if (!this.meta) {
+      return undefined;
+    }
+    const out: {[k: string]: any} = {};
+    let any = false;
+    for (const key of Object.keys(this.meta)) {
+      const v = this.meta[key];
+      if (v !== undefined && v !== null && v !== '') {
+        out[key] = v;
+        any = true;
+      }
+    }
+    return any ? out : undefined;
   }
 
   protected download(o: BobObject): void {


### PR DESCRIPTION
**Stacked on #66.** Merge order: #66 → this.

The Stored archives card on the SNOMED CodeSystem edit page was listing every `snomed` archive on the server regardless of which CodeSystem was being edited — confusing when multiple SNOMED CSes (`SNOMEDCT`, `SNOMEDCT-ES`, …) share the same Bob container. Reported during testing of the live page (`GET /bob/objects?limit=100&offset=0&container=snomed`).

## What changes

- `<tw-bob-archives>` gains an optional `[meta]` input that doubles as:
  - JSONB-containment filter on `GET /bob/objects` (server-side `@>`)
  - tag for new uploads, so subsequent visits see only the scope's archives
- The SNOMED page now passes `[meta]="{shortName, branchPath}"` and the modal's streaming upload tags `meta = {shortName, branchPath, rf2Type}` — the card automatically narrows to just this CodeSystem.
- The per-row **Import** button reads `branchPath` / `rf2Type` from the archive's own meta first, falling back to the page CS for archives uploaded before meta scoping landed (so it never silently imports a SNOMEDCT-ES archive into the SNOMEDCT branch by accident).
- The card surfaces `branchPath / rf2Type / version / language` as a subtitle row when those keys are present in meta — useful for the LOINC card (which still lists across all releases) and for debugging on a fresh CS with no filter set.

## Test plan
- [ ] Navigate to `/integration/snomed/codesystems/SNOMEDCT/edit`. `GET /bob/objects?container=snomed&meta=%7B%22shortName%22%3A%22SNOMEDCT%22…%7D` is sent; only archives uploaded for this CS appear.
- [ ] Upload an archive via the modal → it appears in the card and its meta shows `MAIN · SNAPSHOT` underneath the description.
- [ ] Switch to a different SNOMED CS in the URL → card shows only its archives.
- [ ] Click **Import** on an archive with `meta.branchPath = "MAIN"` from the SNOMEDCT-ES page → goes to MAIN, not the SNOMEDCT-ES branch (defensive).
- [ ] LOINC import page still lists all `loinc` archives (no `[meta]` set there) — no regression.