### PR TITLE
fix(snomed): drop unused LocalDateTimePipe import in archive detail (NG8113)

### DIFF
--- a/app/src/app/integration/snomed/containers/management/codesystem/snomed-archive-detail.component.ts
+++ b/app/src/app/integration/snomed/containers/management/codesystem/snomed-archive-detail.component.ts
@@ -3,7 +3,7 @@ import {Component, inject, OnInit} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {ActivatedRoute, Router} from '@angular/router';
 import {TranslatePipe} from '@ngx-translate/core';
-import {DestroyService, LoadingManager, LocalDateTimePipe} from '@termx-health/core-util';
+import {DestroyService, LoadingManager} from '@termx-health/core-util';
 import {
   MarinPageLayoutModule,
   MuiAlertModule,
@@ -56,7 +56,6 @@ import {BobLibService, BobObject, LorqueLibService} from 'term-web/sys/_lib';
     MuiSpinnerModule,
     MuiTableModule,
     TranslatePipe,
-    LocalDateTimePipe,
   ],
 })
 export class SnomedArchiveDetailComponent implements OnInit {


### PR DESCRIPTION
Trivial follow-up to PR #69. The standalone component declared `LocalDateTimePipe` in its `imports` array intending to render the upload date in the header, but the template never wired the `| localDateTime` binding — leaving an Angular 21 `NG8113` warning on every web build:

\`\`\`
NG8113: LocalDateTimePipe is not used within the template of SnomedArchiveDetailComponent
\`\`\`

Drop the import. The header still surfaces the relevant context (`branchPath`, `rf2Type`, content type, `isDelta` flag). We can re-add the pipe + an "Uploaded … ago" line once `BobObject` exposes a created-at timestamp.

## Test plan
- [ ] `npx ng build app` no longer prints NG8113.
- [ ] Archive detail page header still renders correctly for both source and delta archives.