### PR TITLE
fix(snomed): archive detail form context — NG01203, NG8113, drop DELTA from source

### DIFF
--- a/app/src/app/integration/snomed/containers/management/codesystem/snomed-archive-detail.component.html
+++ b/app/src/app/integration/snomed/containers/management/codesystem/snomed-archive-detail.component.html
@@ -123,25 +123,30 @@
             Import this archive into Snowstorm on branch
             <code>{{branchPath || '(unset)'}}</code>. For a SNAPSHOT or FULL upload,
             keep "Create CodeSystem version" checked so Snowstorm bumps the version pin.
+            DELTA isn't offered here — pick "Calculate Delta" below for that flow.
           </p>
-          <m-form-row>
-            <m-form-item *mFormCol mLabel="RF2 type" required>
-              <m-select name="importType" [(ngModel)]="importForm.type">
-                <m-option [mValue]="'SNAPSHOT'" [mLabel]="'SNAPSHOT'"/>
-                <m-option [mValue]="'DELTA'" [mLabel]="'DELTA'"/>
-                <m-option [mValue]="'FULL'" [mLabel]="'FULL'"/>
-              </m-select>
-            </m-form-item>
-            <m-form-item *mFormCol mLabel="Create CodeSystem version">
-              <m-checkbox name="csv" [(ngModel)]="importForm.createCodeSystemVersion"></m-checkbox>
-            </m-form-item>
-            <m-button *mFormCol mDisplay="primary"
-                      [disabled]="!branchPath || loader.state['upload']"
-                      [mLoading]="loader.state['upload']"
-                      (mClick)="uploadToSnowstorm()">
-              Upload to Snowstorm
-            </m-button>
-          </m-form-row>
+          <!-- <form> wrapper supplies the NgForm ControlContainer that m-checkbox /
+               m-select require when bound with name + ngModel. Without it Angular 21
+               raises NG01203 ('No value accessor for form control name csv'). -->
+          <form #importNgForm="ngForm">
+            <m-form-row>
+              <m-form-item *mFormCol mLabel="RF2 type" required>
+                <m-select name="importType" [(ngModel)]="importForm.type">
+                  <m-option [mValue]="'SNAPSHOT'" [mLabel]="'SNAPSHOT'"/>
+                  <m-option [mValue]="'FULL'" [mLabel]="'FULL'"/>
+                </m-select>
+              </m-form-item>
+              <m-form-item *mFormCol mLabel="Create CodeSystem version">
+                <m-checkbox name="csv" [(ngModel)]="importForm.createCodeSystemVersion"></m-checkbox>
+              </m-form-item>
+              <m-button *mFormCol mDisplay="primary"
+                        [disabled]="!branchPath || loader.state['upload']"
+                        [mLoading]="loader.state['upload']"
+                        (mClick)="uploadToSnowstorm()">
+                Upload to Snowstorm
+              </m-button>
+            </m-form-row>
+          </form>
         </div>
       </m-card>
     }

--- a/app/src/app/integration/snomed/containers/management/codesystem/snomed-archive-detail.component.ts
+++ b/app/src/app/integration/snomed/containers/management/codesystem/snomed-archive-detail.component.ts
@@ -2,7 +2,6 @@ import {CommonModule, Location} from '@angular/common';
 import {Component, inject, OnInit} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {ActivatedRoute, Router} from '@angular/router';
-import {TranslatePipe} from '@ngx-translate/core';
 import {DestroyService, LoadingManager} from '@termx-health/core-util';
 import {
   MarinPageLayoutModule,
@@ -55,7 +54,6 @@ import {BobLibService, BobObject, LorqueLibService} from 'term-web/sys/_lib';
     MuiSelectModule,
     MuiSpinnerModule,
     MuiTableModule,
-    TranslatePipe,
   ],
 })
 export class SnomedArchiveDetailComponent implements OnInit {
@@ -82,8 +80,10 @@ export class SnomedArchiveDetailComponent implements OnInit {
   protected baselineArchive?: BobObject;
 
   /** Form bound to the "Import to Snowstorm" panel for source archives. Defaults are seeded
-   *  from the archive's meta on load so the admin doesn't have to re-pick the RF2 type. */
-  protected importForm: {type: 'SNAPSHOT' | 'DELTA' | 'FULL'; createCodeSystemVersion: boolean} = {
+   *  from the archive's meta on load so the admin doesn't have to re-pick the RF2 type.
+   *  DELTA is intentionally not offered — that flow lives under the Diff section + the
+   *  generated delta archive's own page. */
+  protected importForm: {type: 'SNAPSHOT' | 'FULL'; createCodeSystemVersion: boolean} = {
     type: 'SNAPSHOT',
     createCodeSystemVersion: true,
   };
@@ -144,12 +144,11 @@ export class SnomedArchiveDetailComponent implements OnInit {
           }
         } else {
           // Seed the import-to-Snowstorm form from whatever rf2Type the modal tagged at upload.
-          // Falls back to SNAPSHOT (the most common case) if meta lacks the tag.
+          // Falls back to SNAPSHOT (the most common case). DELTA is not offered here — the
+          // delta flow lives under the Diff section.
           const rf2Type = this.rf2Type;
-          this.importForm.type = (rf2Type === 'DELTA' || rf2Type === 'FULL') ? rf2Type : 'SNAPSHOT';
-          // Creating a CS version only makes sense for SNAPSHOT/FULL — DELTA imports a diff,
-          // not a new versioned state.
-          this.importForm.createCodeSystemVersion = this.importForm.type !== 'DELTA';
+          this.importForm.type = rf2Type === 'FULL' ? 'FULL' : 'SNAPSHOT';
+          this.importForm.createCodeSystemVersion = true;
         }
       });
   }


### PR DESCRIPTION
Three quick fixes reported live after #71 merged.

## 1. `NG01203: No value accessor for form control name: 'csv'`

The Import-to-Snowstorm panel's `<m-checkbox>` / `<m-select>` bindings need an ancestor `NgForm` to provide a `ControlContainer`. Without one Angular 21 throws at bind time:

```
ERROR Error: NG01203: No value accessor for form control name: 'csv'.
```

Wrap the form rows in `<form #importNgForm="ngForm">` the same way every other form-control group on the SNOMED edit page already does.

## 2. `NG8113: TranslatePipe is not used`

Follow-up to the `LocalDateTimePipe` removal in PR #70 — after we hardcoded the Back / Download labels there's no `| translate` usage left in this template. Remove both the import and the standalone-imports entry.

## 3. Drop `DELTA` from the source-archive "RF2 type" select

It was confusing — a source archive is by definition not a delta (deltas live on their own detail page with the "Upload Delta" button). The select now offers `SNAPSHOT | FULL` only; the form's TypeScript type and default-seeding narrow accordingly. Added a helper line in the panel copy pointing admins to the Diff section below when they actually want a DELTA flow.

## Test plan
- [ ] Source archive detail page loads without `NG01203` in the console.
- [ ] `npx ng build app` no longer prints `NG8113: TranslatePipe is not used`.
- [ ] RF2 type select shows two options (SNAPSHOT, FULL) — DELTA removed.
- [ ] Submitting the Import to Snowstorm form actually triggers `/snomed/imports/from-archive` (checkbox value is propagated).