### PR TITLE
feat(snomed): 'Analyze concepts' button on delta archives — reuses legacy scan + concept-usage chain

### DIFF
--- a/app/src/app/integration/snomed/containers/management/codesystem/snomed-archive-detail.component.html
+++ b/app/src/app/integration/snomed/containers/management/codesystem/snomed-archive-detail.component.html
@@ -74,13 +74,30 @@
             </div>
           </div>
 
-          <div style="margin-top: 1.5rem;">
+          <div style="margin-top: 1.5rem; display: flex; gap: 0.5rem; flex-wrap: wrap;">
             <m-button mDisplay="primary"
                       [mLoading]="loader.state['upload-delta']"
                       (mClick)="uploadDeltaToSnowstorm()">
               Upload Delta to Snowstorm
             </m-button>
+            <!-- Reuses the legacy in-Java SnomedRF2ScanService against the delta zip — same
+                 added / modified / invalidated tables the dry-run flow rendered, plus a
+                 "Find usages" link from that result page into /integration/snomed/concept-usage
+                 so admins can see which local CodeSystems / ValueSets reference the touched
+                 concepts. -->
+            <m-button mDisplay="default"
+                      [mLoading]="loader.state['scan']"
+                      [disabled]="!branchPath || !shortName"
+                      (mClick)="analyzeConcepts()">
+              Analyze concepts
+            </m-button>
           </div>
+          @if (scanProgress != null) {
+            <p class="m-subtitle" style="margin-top: 0.5rem;">Scanning delta: {{scanProgress}}%</p>
+          }
+          @if (scanError) {
+            <m-alert mType="warning" mShowIcon>{{scanError}}</m-alert>
+          }
         </div>
       </m-card>
     }

--- a/app/src/app/integration/snomed/containers/management/codesystem/snomed-archive-detail.component.ts
+++ b/app/src/app/integration/snomed/containers/management/codesystem/snomed-archive-detail.component.ts
@@ -91,6 +91,11 @@ export class SnomedArchiveDetailComponent implements OnInit {
   protected loader = new LoadingManager();
   protected deltaProgress?: number;
   protected deltaError?: string;
+  /** Progress / error state for the legacy SnomedRF2ScanService run triggered by the
+   *  "Analyze concepts" button on delta archives. The actual scan result is rendered on
+   *  the existing SnomedRF2ScanResultComponent route. */
+  protected scanProgress?: number;
+  protected scanError?: string;
 
   public ngOnInit(): void {
     this.shortName = this.route.snapshot.paramMap.get('shortName') ?? undefined;
@@ -368,6 +373,75 @@ export class SnomedArchiveDetailComponent implements OnInit {
       },
       error: err => this.notificationService.error(this.extractErrorMessage(err)),
     });
+  }
+
+  /**
+   * Trigger the legacy in-Java RF2 scan against this archive (typically a delta) and route
+   * to the existing /rf2-scan-result page when it finishes. That page renders the added /
+   * modified / invalidated concept tables and has its own "Find usages" button into the
+   * concept-usage analysis page — i.e. we reuse the dry-run UI on delta archives per the
+   * Phase 2 user spec.
+   *
+   * The endpoint POST /snomed/imports/scan/from-archive already accepts any Bob archive uuid
+   * and produces a SnomedRF2ScanEnvelope, so this is pure wiring — no new backend.
+   */
+  protected analyzeConcepts(): void {
+    if (!this.uuid || !this.branchPath || !this.shortName) {
+      return;
+    }
+    this.scanError = undefined;
+    this.scanProgress = 0;
+    this.loader.wrap(
+      'scan',
+      this.snomedService.scanRF2FromArchive({
+        archiveUuid: this.uuid,
+        branchPath: this.branchPath,
+        // For a delta the RF2 layout under /Delta/* uses delta filenames; reuse the same
+        // SnomedImportRequest.type the legacy /imports/scan flow used (the scan parser keys
+        // off filename prefixes, not the type tag, so DELTA is safe here).
+        type: this.isDelta ? 'DELTA' : (this.rf2Type as 'SNAPSHOT' | 'FULL') ?? 'SNAPSHOT',
+        // 'full' mode populates relationships + language refset so the result has acceptability
+        // and attribute coverage. Summary mode hides those — and on a delta they're already
+        // small enough that the full pass costs no real time.
+        mode: 'full',
+      }),
+    ).subscribe({
+      next: lorque => this.pollScanProgress(lorque.id),
+      error: err => this.handleScanError(err),
+    });
+  }
+
+  private pollScanProgress(lorqueId: number): void {
+    this.lorqueService.pollProcessProgress(lorqueId, this.destroy$).subscribe(p => {
+      if (p?.progressPercent != null) {
+        this.scanProgress = p.progressPercent;
+      }
+      if (!p?.status || p.status === 'running') {
+        return;
+      }
+      this.scanProgress = undefined;
+      if (p.status === 'failed') {
+        this.lorqueService.load(lorqueId).subscribe(loaded => this.scanError = loaded.resultText ?? 'Scan failed');
+        return;
+      }
+      // Hand off to the existing scan-result component — it has the added/modified/
+      // invalidated tables already, plus the "Find usages" button into the concept-usage
+      // analysis page (which is the answer to "how do I see which CS/VS are affected").
+      this.snomedService.loadScanResult(lorqueId).subscribe(envelope => {
+        if (!this.shortName) {
+          return;
+        }
+        this.router.navigate(
+          ['/integration/snomed/codesystems', this.shortName, 'rf2-scan-result'],
+          {state: {envelope, shortName: this.shortName}},
+        );
+      });
+    });
+  }
+
+  private handleScanError(err: any): void {
+    this.scanProgress = undefined;
+    this.scanError = this.extractErrorMessage(err);
   }
 
   protected baselineLabel(c: BobObject): string {


### PR DESCRIPTION
**Stacked on #72.** Merge order: #72 → this.

## What the user asked for

> If kind Delta then use current functionality from Dry run and provide the ability to ... show added, modified, and terminated concepts.
> How I can call which CS/VS affected, no switch to "analyze relations" (don't remember actual name) web component (I need it)?

The "analyze relations" component the user couldn't remember the name of is **`SnomedConceptUsageComponent`** at `/integration/snomed/concept-usage`. Both pieces already exist — this PR is pure wiring.

## Existing infrastructure (rediscovered, NOT touched)

- `SnomedRF2ScanService` (server, kept after Phase 2 because of this exact use case) — the in-Java zip parser + diff engine produces a `SnomedRF2ScanEnvelope` with `newConcepts`, `modifiedConcepts`, `invalidatedConcepts`.
- `POST /snomed/imports/scan/from-archive` (server) — takes any Bob archive uuid and returns a `LorqueProcess`; result is downloadable via `GET /snomed/imports/scan/result/{lorqueId}`.
- `SnomedRF2ScanResultComponent` (web, route `/integration/snomed/codesystems/{shortName}/rf2-scan-result`) — already renders the three concept tables AND has a "Find usages" button that navigates to `/integration/snomed/concept-usage` with `{state: {codes}}`.
- `SnomedConceptUsageComponent` — already reads `state.scan` / `state.codes` on init and returns where the codes are referenced (`CodeSystemSupplement`, `ValueSet` rule, `ValueSetExpansion`).

## What this PR adds (web only)

1. **`SnomedArchiveDetailComponent.analyzeConcepts()`** — POSTs to `/imports/scan/from-archive`, polls the Lorque process, fetches the envelope via `snomedService.loadScanResult`, then `router.navigate`s to `/rf2-scan-result` with `state.{envelope, shortName}`. Same hand-off pattern the legacy modal used pre-Phase-2c.

2. **"Analyze concepts" button** on the Delta summary card next to "Upload Delta to Snowstorm". Shows a percent-progress line during the scan and a warning alert on failure.

The scan runs in `'full'` mode (relationships + language refset parsed too) so the result has acceptability + attribute coverage. On a delta zip those tables are small enough that full mode costs no real wall-clock time.

Phase 2d (deleting `SnomedRF2ScanService` et al.) is correctly **deferred** — turns out the scan is the centerpiece of this analysis flow, not legacy dead weight.

## End-to-end click path after merge

1. SNOMED CodeSystem edit page → Stored archives card → click the delta row
2. Delta detail page → Delta summary card → **Analyze concepts**
3. Progress bar advances; on completion routes to RF2 scan result page
4. RF2 scan result page → tables of new / modified / invalidated concepts → click **Find usages** at the top
5. Concept usage page renders rows showing which local CodeSystems / ValueSets reference the touched concepts

## Test plan
- [ ] Navigate to an existing delta archive's detail page → "Analyze concepts" button visible next to "Upload Delta to Snowstorm".
- [ ] Click → scan runs (progress bar updates), completes, routes to `/rf2-scan-result`.
- [ ] Result page shows the three concept tables.
- [ ] Click "Find usages" → concept-usage page receives the codes via router state and renders results.
- [ ] On a source archive page (non-delta), the button is absent (intentional — Phase 2's spec asked for this only on deltas).