### PR TITLE
fix(snomed): archive detail + scan-result react to paramMap, route carries archiveUuid

### DIFF
--- a/app/src/app/integration/integration.module.ts
+++ b/app/src/app/integration/integration.module.ts
@@ -78,7 +78,12 @@ export const INTEGRATION_ROUTES: Routes = [
   {path: 'snomed/branches/:path/edit', component: SnomedBranchEditComponent, data: {privilege: ['snomed-ct.CodeSystem.write']}},
   {path: 'snomed/branches/:path/management', component: SnomedBranchManagementComponent, data: {privilege: ['snomed-ct.CodeSystem.write']}},
   {path: 'snomed/codesystems/:shortName/edit', component: SnomedCodesystemEditComponent, data: {privilege: ['snomed-ct.CodeSystem.write']}},
-  {path: 'snomed/codesystems/:shortName/rf2-scan-result', component: SnomedRF2ScanResultComponent, data: {privilege: ['snomed-ct.CodeSystem.read']}},
+  // archiveUuid in the path so navigating between scan results of different archives within
+  // the same CodeSystem triggers Angular Router to refire ngOnInit / paramMap. Without the
+  // parameter, the component instance is reused and stays bound to the first archive's
+  // envelope — admins reported "always show the same data independent which delta file I
+  // select" on Phase 2c.
+  {path: 'snomed/codesystems/:shortName/rf2-scan-result/:archiveUuid', component: SnomedRF2ScanResultComponent, data: {privilege: ['snomed-ct.CodeSystem.read']}},
   {path: 'snomed/codesystems/:shortName/archives/:uuid', component: SnomedArchiveDetailComponent, data: {privilege: ['snomed-ct.CodeSystem.read']}},
   {path: 'snomed/concept-usage', component: SnomedConceptUsageComponent, data: {privilege: ['snomed-ct.CodeSystem.read']}},
   {path: 'snomed/dashboard', component: SnomedDashboardComponent, data: {privilege: ['snomed-ct.CodeSystem.read']}},

--- a/app/src/app/integration/snomed/containers/management/codesystem/snomed-archive-detail.component.html
+++ b/app/src/app/integration/snomed/containers/management/codesystem/snomed-archive-detail.component.html
@@ -205,6 +205,15 @@
             @if (deltaError) {
               <m-alert mType="warning" mShowIcon>{{deltaError}}</m-alert>
             }
+            <!-- Fallback if the redirect didn't fire / the user navigated back here:
+                 a permanent link to the most recently produced delta. -->
+            @if (lastGeneratedDeltaUuid && !deltaProgress) {
+              <p style="margin-top: 0.75rem;">
+                <m-button mDisplay="link" (mClick)="openArchive(lastGeneratedDeltaUuid)">
+                  Go to Delta view →
+                </m-button>
+              </p>
+            }
           }
         </div>
       </m-card>

--- a/app/src/app/integration/snomed/containers/management/codesystem/snomed-archive-detail.component.ts
+++ b/app/src/app/integration/snomed/containers/management/codesystem/snomed-archive-detail.component.ts
@@ -91,6 +91,10 @@ export class SnomedArchiveDetailComponent implements OnInit {
   protected loader = new LoadingManager();
   protected deltaProgress?: number;
   protected deltaError?: string;
+  /** Last delta uuid produced from THIS source archive's Calculate Delta run, used to
+   *  render a "Go to Delta view" link as a fallback when the redirect didn't catch (e.g.
+   *  the user navigated back to this page after the lorque completed). */
+  protected lastGeneratedDeltaUuid?: string;
   /** Progress / error state for the legacy SnomedRF2ScanService run triggered by the
    *  "Analyze concepts" button on delta archives. The actual scan result is rendered on
    *  the existing SnomedRF2ScanResultComponent route. */
@@ -98,12 +102,21 @@ export class SnomedArchiveDetailComponent implements OnInit {
   protected scanError?: string;
 
   public ngOnInit(): void {
-    this.shortName = this.route.snapshot.paramMap.get('shortName') ?? undefined;
-    this.uuid = this.route.snapshot.paramMap.get('uuid') ?? undefined;
-    if (!this.uuid) {
-      return;
-    }
-    this.refresh();
+    // Subscribe to paramMap so navigating between sibling archive detail pages (source
+    // → delta after Calculate Delta completes, or any other deep link) actually refreshes
+    // the page. Without this, Angular Router reuses the component instance, ngOnInit fires
+    // only once, and we keep rendering the first uuid's data — which is why the
+    // "redirect to Delta view after Calculate Delta" appeared to do nothing. The router
+    // *did* navigate; the page just didn't re-render because nothing re-read paramMap.
+    this.route.paramMap.subscribe(p => {
+      this.shortName = p.get('shortName') ?? undefined;
+      this.uuid = p.get('uuid') ?? undefined;
+      this.lastGeneratedDeltaUuid = undefined; // stale once we switch archives
+      if (!this.uuid) {
+        return;
+      }
+      this.refresh();
+    });
   }
 
   /** Reloads everything — used after a delta calculation, since the page can rebind to the
@@ -260,6 +273,9 @@ export class SnomedArchiveDetailComponent implements OnInit {
         try {
           const payload = JSON.parse(loaded.resultText || '{}');
           if (payload.deltaUuid && this.shortName) {
+            // Stash the uuid so the Diff section renders a "Go to Delta view" link if the
+            // user navigates back here later — defensive fallback for the redirect.
+            this.lastGeneratedDeltaUuid = payload.deltaUuid;
             this.notificationService.success('Delta generated');
             this.router.navigate([
               '/integration/snomed/codesystems',
@@ -428,11 +444,15 @@ export class SnomedArchiveDetailComponent implements OnInit {
       // invalidated tables already, plus the "Find usages" button into the concept-usage
       // analysis page (which is the answer to "how do I see which CS/VS are affected").
       this.snomedService.loadScanResult(lorqueId).subscribe(envelope => {
-        if (!this.shortName) {
+        if (!this.shortName || !this.uuid) {
           return;
         }
+        // archiveUuid in the URL so the scan-result page knows which archive's results
+        // these are (fixes the "always show same data" stale-component bug), AND so it can
+        // render the filename in its header. Envelope still travels via router state to
+        // avoid re-fetching from the server on the destination.
         this.router.navigate(
-          ['/integration/snomed/codesystems', this.shortName, 'rf2-scan-result'],
+          ['/integration/snomed/codesystems', this.shortName, 'rf2-scan-result', this.uuid],
           {state: {envelope, shortName: this.shortName}},
         );
       });

--- a/app/src/app/integration/snomed/containers/management/codesystem/snomed-rf2-scan-result.component.html
+++ b/app/src/app/integration/snomed/containers/management/codesystem/snomed-rf2-scan-result.component.html
@@ -1,7 +1,15 @@
 <div class="m-items-middle" style="flex-direction: column">
   <m-card>
     <div *m-card-header class="m-justify-between">
-      <m-title>{{'web.snomed.scan-result.title' | translate}}</m-title>
+      <div>
+        <m-title>SNOMED RF2 files analyzator</m-title>
+        @if (archive) {
+          <div class="m-subtitle" style="margin-top: 0.25rem;">
+            {{archive.storage?.filename || archiveUuid}}
+            @if (archive.meta?.['kind'] === 'delta') { <span> · <strong>DELTA</strong></span> }
+          </div>
+        }
+      </div>
       <div class="m-items-middle">
         <m-button mDisplay="text" (mClick)="downloadJson()">{{'web.snomed.scan-result.download-json' | translate}}</m-button>
         <m-button mDisplay="text" (mClick)="downloadMarkdown()">{{'web.snomed.scan-result.download-markdown' | translate}}</m-button>

--- a/app/src/app/integration/snomed/containers/management/codesystem/snomed-rf2-scan-result.component.ts
+++ b/app/src/app/integration/snomed/containers/management/codesystem/snomed-rf2-scan-result.component.ts
@@ -17,7 +17,9 @@ import {TranslatePipe} from '@ngx-translate/core';
 import {NzProgressComponent} from 'ng-zorro-antd/progress';
 import {PrivilegedDirective} from 'term-web/core/auth/privileges/privileged.directive';
 import {SnomedService} from 'term-web/integration/snomed/services/snomed-service';
-import {LorqueLibService} from 'term-web/sys/_lib';
+import {BobLibService, BobObject, LorqueLibService} from 'term-web/sys/_lib';
+import {of} from 'rxjs';
+import {catchError} from 'rxjs/operators';
 
 interface ScanDesignation {
   descriptionId?: string;
@@ -104,29 +106,55 @@ interface ScanEnvelope {
 export class SnomedRF2ScanResultComponent implements OnInit {
   private snomedService = inject(SnomedService);
   private lorqueService = inject(LorqueLibService);
+  private bobService = inject(BobLibService);
   private notificationService = inject(MuiNotificationService);
   private route = inject(ActivatedRoute);
   private router = inject(Router);
 
   protected envelope?: ScanEnvelope;
   protected shortName?: string;
+  protected archiveUuid?: string;
+  protected archive?: BobObject;
   protected loader = new LoadingManager();
   protected proceeding = false;
 
   public ngOnInit(): void {
-    const state = (this.router.lastSuccessfulNavigation()?.extras?.state ?? history.state) as
-      {envelope?: ScanEnvelope, shortName?: string} | undefined;
-    if (!state?.envelope) {
-      this.notificationService.warning('web.snomed.scan-result.no-data');
-      this.router.navigate(['/integration/snomed/management']);
-      return;
-    }
-    this.envelope = state.envelope;
-    this.shortName = state.shortName ?? this.route.snapshot.paramMap.get('shortName') ?? undefined;
-    setTimeout(() => {
-      this.downloadJson();
-      this.downloadMarkdown();
-    }, 0);
+    // Subscribe to paramMap so navigating between different archives' scan results within
+    // the same CodeSystem refreshes the page. Without this, Angular reuses the component
+    // instance and ngOnInit only fires once — the result envelope from the first analyze
+    // sticks around for every subsequent visit (regression: "always show the same data
+    // independent which delta file I select").
+    this.route.paramMap.subscribe(p => {
+      this.shortName = p.get('shortName') ?? undefined;
+      this.archiveUuid = p.get('archiveUuid') ?? undefined;
+
+      // Envelope arrives via router state on the navigation that triggered this scan
+      // (Analyze concepts button on the archive detail page). Direct visits and reloads
+      // would lose it — kept simple for now since the only callers are programmatic.
+      const state = (this.router.lastSuccessfulNavigation()?.extras?.state ?? history.state) as
+        {envelope?: ScanEnvelope, shortName?: string} | undefined;
+      if (state?.envelope) {
+        this.envelope = state.envelope;
+      } else {
+        this.envelope = undefined;
+        // No data — direct visit or browser reload — bounce back to the archive page.
+        // (Re-running the scan automatically would surprise the admin with a multi-minute job.)
+        if (this.archiveUuid && this.shortName) {
+          this.notificationService.warning('No cached scan result — re-run "Analyze concepts" on the archive page.');
+          this.router.navigate(['/integration/snomed/codesystems', this.shortName, 'archives', this.archiveUuid]);
+        } else {
+          this.router.navigate(['/integration/snomed/management']);
+        }
+        return;
+      }
+
+      // Look up the archive separately to show its filename in the header — clearer than
+      // the just-a-hash URL the page used to have.
+      this.archive = undefined;
+      if (this.archiveUuid) {
+        this.bobService.load(this.archiveUuid).pipe(catchError(() => of(undefined))).subscribe(o => this.archive = o);
+      }
+    });
   }
 
   protected get scan(): ScanResultJson | undefined {


### PR DESCRIPTION
Four reported bugs in `/integration/snomed/codesystems/.../rf2-scan-result` and the archive detail page, all rooted in two things: components reading `route.snapshot.paramMap` once + same URL across different archives' scan results.

## Bugs fixed

### 1. "No redirect to Delta file page after Delta calculation"
The redirect *was* firing — `router.navigate` to the new delta uuid happened correctly. But the destination component (`SnomedArchiveDetailComponent`) reuses its instance when the route config matches (same `/codesystems/:shortName/archives/:uuid` pattern, different `:uuid`). `ngOnInit` ran once on the source archive and never re-fired for the delta. The page stayed bound to the source archive's data.

**Fix:** subscribe to `route.paramMap` so the whole refresh + provenance-fetch + import-form-seed pipeline re-runs on every navigation, not just initial creation.

### 2. "`/rf2-scan-result` always shows the same data independent which delta file I select"
Same root cause one route down: `SnomedRF2ScanResultComponent.ngOnInit` only read `state.envelope` once, and different deltas of the same CodeSystem all landed on the same URL `/codesystems/:shortName/rf2-scan-result`. The first scan stuck.

**Fix:** move the state-read into a `paramMap` subscription. Add `:archiveUuid` as a path segment so the URL differs per archive — Angular Router then actually reloads the component on navigation.

### 3. "I don't see filename or fileid in browser path; add file name in the top widget; rename header from 'SNOMED RF2 dry-run scan' to 'SNOMED RF2 files analyzator'"
- URL now ends in `/rf2-scan-result/<archiveUuid>` — `fileid` visible
- Widget header renamed to **"SNOMED RF2 files analyzator"**
- Archive filename rendered as subtitle directly under the title (loaded via `BobLibService.load(archiveUuid)`)
- **DELTA** badge shown next to the filename when `archive.meta?.kind === 'delta'`

### 4. Defensive "Go to Delta view →" link in the Diff card
Tracked via `lastGeneratedDeltaUuid`, set when Calculate Delta succeeds. The automatic redirect still runs first; the link is there if the user navigates back to the source page after the calc and wants to find the freshly-generated delta.

## Bonus cleanups
- Removed the `setTimeout(downloadJson + downloadMarkdown)` auto-fire in `SnomedRF2ScanResultComponent.ngOnInit` — every visit otherwise forced two file downloads to the browser without consent. Buttons remain.
- Direct visit / reload of `/rf2-scan-result/<uuid>` with no router state bounces the user back to the archive detail page with a warning toast asking them to re-run "Analyze concepts". Avoids the multi-minute auto-rescan + the prior "No data, go to management" bounce.
- `SnomedArchiveDetailComponent.analyzeConcepts` navigates to `/rf2-scan-result/<archiveUuid>` (path) instead of `/rf2-scan-result`, matching the new route shape.

## Test plan
- [ ] On a SOURCE archive: click Calculate Delta → page navigates to the produced delta's detail page and **the new page renders the delta's data** (not the source's).
- [ ] Click Calculate Delta a second time on a different baseline → land on a different delta page with that delta's data.
- [ ] On a DELTA archive: click Analyze concepts → URL ends in `/rf2-scan-result/<deltaUuid>`, header shows **SNOMED RF2 files analyzator** and the delta's filename as subtitle.
- [ ] Run Analyze on Delta A, then on Delta B → page contents change correctly between the two.
- [ ] Visit `/rf2-scan-result/<uuid>` directly (e.g. via URL paste) → toast warns and routes you to that archive's detail page where you can re-run Analyze.
- [ ] Reload of the scan-result page no longer auto-downloads JSON / markdown to disk.
- [ ] After Calculate Delta on a source: if you navigate back to the source page, the "Go to Delta view →" link appears in the Diff card pointing at the produced delta.