### PR TITLE
fix(snomed): fetch latest scan result by archive uuid (no more router-state reliance)

### DIFF
--- a/app/src/app/integration/snomed/containers/management/codesystem/snomed-rf2-scan-result.component.ts
+++ b/app/src/app/integration/snomed/containers/management/codesystem/snomed-rf2-scan-result.component.ts
@@ -120,40 +120,55 @@ export class SnomedRF2ScanResultComponent implements OnInit {
 
   public ngOnInit(): void {
     // Subscribe to paramMap so navigating between different archives' scan results within
-    // the same CodeSystem refreshes the page. Without this, Angular reuses the component
-    // instance and ngOnInit only fires once — the result envelope from the first analyze
-    // sticks around for every subsequent visit (regression: "always show the same data
-    // independent which delta file I select").
+    // the same CodeSystem refreshes the page. Each paramMap emission re-fetches the latest
+    // scan envelope server-side, keyed by archive uuid — this is the canonical "same URL ⇒
+    // same data" path. Router state is consulted only as a fast-path for the Analyze
+    // concepts → router.navigate handoff (so we don't re-fetch what the just-completed
+    // server call already returned to us).
     this.route.paramMap.subscribe(p => {
       this.shortName = p.get('shortName') ?? undefined;
       this.archiveUuid = p.get('archiveUuid') ?? undefined;
+      this.envelope = undefined;
+      this.archive = undefined;
 
-      // Envelope arrives via router state on the navigation that triggered this scan
-      // (Analyze concepts button on the archive detail page). Direct visits and reloads
-      // would lose it — kept simple for now since the only callers are programmatic.
+      if (!this.archiveUuid) {
+        this.router.navigate(['/integration/snomed/management']);
+        return;
+      }
+
+      // Fast path: envelope arrived via router state on the Analyze-concepts navigation.
+      // Skip the server round-trip in that case.
       const state = (this.router.lastSuccessfulNavigation()?.extras?.state ?? history.state) as
         {envelope?: ScanEnvelope, shortName?: string} | undefined;
       if (state?.envelope) {
         this.envelope = state.envelope;
       } else {
-        this.envelope = undefined;
-        // No data — direct visit or browser reload — bounce back to the archive page.
-        // (Re-running the scan automatically would surprise the admin with a multi-minute job.)
-        if (this.archiveUuid && this.shortName) {
-          this.notificationService.warning('No cached scan result — re-run "Analyze concepts" on the archive page.');
-          this.router.navigate(['/integration/snomed/codesystems', this.shortName, 'archives', this.archiveUuid]);
-        } else {
-          this.router.navigate(['/integration/snomed/management']);
-        }
-        return;
+        // Refresh / paste / back-forward / no state — fetch the latest scan keyed by archive
+        // uuid. The server resolves to the most-recent scan_lorque_id for this Bob uuid and
+        // returns the envelope. Null body means "never scanned" → route the admin back to
+        // the archive page so they can hit Analyze.
+        this.loader
+          .wrap('load-envelope', this.snomedService.loadLatestScanResult(this.archiveUuid))
+          .subscribe({
+            next: env => {
+              if (env && env.json) {
+                this.envelope = env as ScanEnvelope;
+              } else {
+                this.notificationService.warning('No cached scan result — re-run "Analyze concepts" on the archive page.');
+                if (this.shortName && this.archiveUuid) {
+                  this.router.navigate(['/integration/snomed/codesystems', this.shortName, 'archives', this.archiveUuid]);
+                }
+              }
+            },
+            error: () => {
+              this.notificationService.error('Failed to load the latest scan result for this archive.');
+            },
+          });
       }
 
-      // Look up the archive separately to show its filename in the header — clearer than
-      // the just-a-hash URL the page used to have.
-      this.archive = undefined;
-      if (this.archiveUuid) {
-        this.bobService.load(this.archiveUuid).pipe(catchError(() => of(undefined))).subscribe(o => this.archive = o);
-      }
+      // Always fetch the BobObject so the header can show filename + DELTA badge regardless
+      // of which code path filled the envelope.
+      this.bobService.load(this.archiveUuid).pipe(catchError(() => of(undefined))).subscribe(o => this.archive = o);
     });
   }
 

--- a/app/src/app/integration/snomed/services/snomed-service.ts
+++ b/app/src/app/integration/snomed/services/snomed-service.ts
@@ -125,6 +125,16 @@ export class SnomedService extends SnomedLibService {
   }
 
   /**
+   * Most-recent scan envelope for a Bob archive, server-side keyed by archive uuid.
+   * Replaces the previous "envelope via Angular router state" approach which was lost on
+   * refresh / back-forward-cache restore and could surface a stale envelope on URL-pasted
+   * navigations. Returns {@code null} (HTTP 200 with empty body) when no scan exists yet.
+   */
+  public loadLatestScanResult(archiveUuid: string): Observable<any> {
+    return this.http.get(`${this.baseUrl}/archives/${archiveUuid}/latest-scan-result`);
+  }
+
+  /**
    * Streaming counterpart of {@link createImportJob} — the archive already lives in the Bob
    * "snomed" container (uploaded via {@link BobLibService#upload}). Returns a Lorque process
    * the caller polls for progress / completion.


### PR DESCRIPTION
**Pairs with termx-server [#133](https://github.com/termx-health/termx-server/pull/133)** (`latest-scan-result` endpoint + per-delta unique Minio paths).

`SnomedRF2ScanResultComponent` used to read the scan envelope from `history.state` / `router.lastSuccessfulNavigation().extras.state`. Router state is per-history-entry, lost on refresh / back-forward cache restore, and can return stale data when the same route config matches a new URL with different params — which is why two different scan-result URLs could end up showing the same envelope **even after** PR #74 added `:archiveUuid` to the route + a `paramMap` subscription.

(The other half of "same data shown for two URLs" was a server-side storage collision — see #133.)

## What changes

Fetch by archive uuid on every `paramMap` emission:

- **Fast path**: if router state carries an envelope (the Analyze-concepts handoff from the archive detail page just placed it there), use it directly — saves a server round-trip on the common in-app flow.
- **Otherwise** (refresh / paste / back-forward / out-of-app entry): `GET /snomed/archives/{uuid}/latest-scan-result`. Server resolves to the most-recent `scan_lorque_id` for that Bob uuid and returns the envelope. Null body → bounce back to the archive page with a "click Analyze" toast.

The `BobLibService.load(archiveUuid)` lookup runs unconditionally so the header filename + `DELTA` badge work regardless of which code path filled the envelope.

## Test plan
- [ ] After #133 is deployed + a fresh delta calc on each (source, baseline) pair: navigate from one delta's scan-result URL to another — distinct envelopes, distinct stats, distinct filenames.
- [ ] Reload of `/rf2-scan-result/<uuid>` (Cmd-R) — page rebuilds from the server, no "no data" bounce.
- [ ] Paste a scan-result URL into a fresh tab — page renders the cached envelope from the server.
- [ ] An archive that's never been scanned → toast warns + routes to the archive page.
- [ ] Analyze concepts in-app → router state fast-path still works (verify by checking the network panel: no extra `/latest-scan-result` GET fires immediately after the in-app navigation).