### PR TITLE
feat(loinc): version select + per-slot CSV picker driven by Bob archives

### DIFF
--- a/app/src/app/integration/import/loinc/loinc-import.component.html
+++ b/app/src/app/integration/import/loinc/loinc-import.component.html
@@ -6,47 +6,71 @@
     </nz-breadcrumb>
   </div>
   <form #form="ngForm">
-    <m-form-item mName="csVersion" mLabel="entities.code-system-version.version" required>
-      <m-input name="csVersion" [(ngModel)]="data.version" required></m-input>
-    </m-form-item>
-    <m-form-item mName="parts" mLabel="web.integration.loinc-import.parts" required>
-      <input #partsFileInput id="partsFileInput" name="parts" type="file" required>
-    </m-form-item>
-    <m-form-item mName="loinc-terminology" mLabel="web.integration.loinc-import.loinc-terminology" required>
-      <input #loincTerminologyFileInput id="loincTerminologyFileInput" name="loinc-terminology" type="file" required>
-    </m-form-item>
-    <m-form-item mName="loinc-terminology" mLabel="web.integration.loinc-import.supplementary-properties">
-      <input #supplementaryPropertiesFileInput id="supplementaryPropertiesFileInput" name="supplementary-properties" type="file">
-    </m-form-item>
-    <m-form-item mName="panels" mLabel="web.integration.loinc-import.panels">
-      <input #panelsFileInput id="panelsFileInput" name="panels" type="file">
-    </m-form-item>
-
     <m-form-row>
-      <m-form-item *m-form-col mName="answer-list" mLabel="web.integration.loinc-import.answer-list">
-        <input #answerListFileInput id="answerListFileInput" name="answer-list" type="file">
+      <!-- Version — populated from distinct meta.version values across stored archives.
+           Picking a version auto-resolves the latest matching archive so admins don't have
+           to do a second click for the common case of one archive per version. -->
+      <m-form-item *mFormCol mName="version" mLabel="entities.code-system-version.version" required>
+        <m-select name="version" [(ngModel)]="data.version" (ngModelChange)="onVersionChange()" required>
+          @for (v of versionOptions; track v.value) {
+            <m-option [mValue]="v.value" [mLabel]="v.label"/>
+          }
+        </m-select>
       </m-form-item>
-      <m-form-item *m-form-col mName="answer-list-link" mLabel="web.integration.loinc-import.answer-list-link">
-        <input #answerListLinkFileInput id="answerListLinkFileInput" name="answer-list-link" type="file">
+      <!-- Language drives the basename suggestion for the `translations` slot —
+           <lang>LinguisticVariant.csv only matches when the server knows the language. -->
+      <m-form-item *mFormCol mName="language" mLabel="web.integration.loinc-import.language">
+        <tw-value-set-concept-select name="language" [(ngModel)]="data.language"
+                                     valueSet="languages"
+                                     (ngModelChange)="onLanguageChange()"/>
       </m-form-item>
     </m-form-row>
 
-    <m-form-row>
-      <m-form-item *m-form-col mName="language" mLabel="web.integration.loinc-import.language">
-        <tw-value-set-concept-select name="language" [(ngModel)]="data.language" valueSet="languages"></tw-value-set-concept-select>
+    <!-- Archive picker. Shown when the version has more than one upload, so the admin can
+         pick a specific one. Hidden otherwise (the version select already determined it). -->
+    @if (matchingArchives.length > 1) {
+      <m-form-item mName="archiveUuid" mLabel="LOINC archive">
+        <m-select name="archiveUuid" [(ngModel)]="data.archiveUuid" (ngModelChange)="onArchiveChange()">
+          @for (a of matchingArchives; track a.uuid) {
+            <m-option [mValue]="a.uuid" [mLabel]="a.storage?.filename || a.uuid"/>
+          }
+        </m-select>
       </m-form-item>
-      <m-form-item *m-form-col mName="translations" mLabel="web.integration.loinc-import.translations">
-        <input #translationsFileInput id="translationsFileInput" name="translations" type="file">
-      </m-form-item>
-    </m-form-row>
+    }
 
-    <m-form-item mName="orderObservation" mLabel="web.integration.loinc-import.order-observation">
-      <input #orderObservationFileInput id="orderObservationFileInput" name="orderObservation" type="file">
-    </m-form-item>
-
+    <!-- Per-slot file selects — once an archive is picked, each slot lists every .csv entry
+         inside the zip, preselected from the server's basename suggestion. Admins can
+         override (e.g. swap in a custom Part.csv) before clicking Import. -->
+    @if (data.archiveUuid) {
+      @if (entries.length === 0) {
+        <m-alert mType="warning" mShowIcon>
+          No .csv entries found in this archive — re-upload or pick a different one.
+        </m-alert>
+      } @else {
+        @for (slot of slots; track slot.key) {
+          <m-form-item [mName]="slot.key" [mLabel]="slot.label">
+            <m-select [name]="'slot-' + slot.key" [(ngModel)]="data.fileMap[slot.key]">
+              <!-- Empty option leaves the slot unmapped — the server's auto-dispatch fills in
+                   whichever basename it matches for that slot, or skips if nothing matches. -->
+              <m-option [mValue]="''" [mLabel]="'(none — use server default)'"/>
+              @for (e of entries; track e.name) {
+                <m-option [mValue]="e.name" [mLabel]="e.name + (e.suggestedSlot === slot.key ? ' (suggested)' : '')"/>
+              }
+            </m-select>
+          </m-form-item>
+        }
+      }
+    } @else {
+      <m-alert mType="info" mShowIcon>
+        Pick a LOINC version above to load the matching release archive — or upload a new
+        zip via the Stored archives card below.
+      </m-alert>
+    }
   </form>
 
-  <m-button *m-card-footer (click)="modalData = {visible: true}" [mLoading]="loading['process']" [disabled]="form.invalid">
+  <m-button *m-card-footer (click)="modalData = {visible: true}"
+            [mLoading]="loading['process']"
+            [disabled]="form.invalid || !data.archiveUuid">
     {{'web.integration.loinc-import.import' | translate}}
   </m-button>
   @if (jobResponse) {
@@ -92,11 +116,15 @@
 </m-modal>
 
 <!--
-  Stored LOINC release archives — uploaded to the Bob "loinc" container via the streaming
-  /bob/objects endpoint. Per-row "Import" calls POST /loinc/import/from-archive, which
-  unpacks the zip server-side and runs the same import pipeline as the legacy multipart
-  endpoint above. The version / language from the form above are sent with the request.
+  Stored LOINC release archives. Uploads via this card are tagged with the version + language
+  currently in the form above (meta.version) so the version select above picks them up on
+  the next load. Per-row "Open" routes the row back into the form (version + archive +
+  per-slot selects) — Import button at the bottom of the form is the single confirm step.
 -->
 <div style="margin-top: 1rem;">
-  <tw-bob-archives container="loinc" actionLabel="Import" (action)="importFromArchive($event)"/>
+  <tw-bob-archives container="loinc"
+                   [meta]="{version: data.version, language: data.language}"
+                   actionLabel="Open"
+                   (action)="onArchiveOpen($event)"
+                   (itemClick)="onArchiveOpen($event)"/>
 </div>

--- a/app/src/app/integration/import/loinc/loinc-import.component.ts
+++ b/app/src/app/integration/import/loinc/loinc-import.component.ts
@@ -1,123 +1,283 @@
 import {HttpClient} from '@angular/common/http';
-import { Component, ElementRef, TemplateRef, ViewChild, inject } from '@angular/core';
-import { NgForm, FormsModule } from '@angular/forms';
+import {Component, TemplateRef, ViewChild, inject} from '@angular/core';
+import {FormsModule, NgForm} from '@angular/forms';
 import {Router} from '@angular/router';
-import {DestroyService} from '@termx-health/core-util';
-import { MuiNotificationService, MuiCardModule, MuiFormModule, MuiInputModule, MuiButtonModule, MuiAlertModule, MuiCoreModule, MuiModalModule, MarinPageLayoutModule } from '@termx-health/ui';
+import {DestroyService, LoadingManager, QueryParams} from '@termx-health/core-util';
+import {
+  MarinPageLayoutModule,
+  MuiAlertModule,
+  MuiButtonModule,
+  MuiCardModule,
+  MuiCoreModule,
+  MuiFormModule,
+  MuiInputModule,
+  MuiModalModule,
+  MuiNotificationService,
+  MuiSelectModule,
+} from '@termx-health/ui';
 import {environment} from 'environments/environment';
-import {BobArchivesComponent, BobObject, JobLibService, JobLog, JobLogResponse} from 'term-web/sys/_lib';
-import { NzBreadCrumbComponent, NzBreadCrumbItemComponent } from 'ng-zorro-antd/breadcrumb';
-import { ValueSetConceptSelectComponent } from 'term-web/resources/_lib/value-set/containers/value-set-concept-select.component';
+import {BobArchivesComponent, BobLibService, BobObject, JobLibService, JobLog, JobLogResponse} from 'term-web/sys/_lib';
+import {NzBreadCrumbComponent, NzBreadCrumbItemComponent} from 'ng-zorro-antd/breadcrumb';
+import {ValueSetConceptSelectComponent} from 'term-web/resources/_lib/value-set/containers/value-set-concept-select.component';
+import {TranslatePipe} from '@ngx-translate/core';
+import {HasAnyPrivilegePipe} from 'term-web/core/auth/privileges/has-any-privilege.pipe';
 
-import { TranslatePipe } from '@ngx-translate/core';
-import { HasAnyPrivilegePipe } from 'term-web/core/auth/privileges/has-any-privilege.pipe';
+/**
+ * Slot identifiers consumed by termx-server's LoincService.importLoinc — must stay in lock-
+ * step with both LoincZipReader's BASENAME_TO_KEY and the {@code fileMap} keys accepted by
+ * POST /loinc/import/from-archive. {@code translations} is filled in by the
+ * {@code <lang>LinguisticVariant.csv} file matching the chosen language, so it doesn't carry
+ * a fixed display name like the others.
+ */
+const SLOTS: {key: string; label: string}[] = [
+  {key: 'parts', label: 'Parts'},
+  {key: 'terminology', label: 'Terminology (LoincPartLink_Primary)'},
+  {key: 'supplementary-properties', label: 'Supplementary properties (LoincPartLink_Supplementary)'},
+  {key: 'panels', label: 'Panels and forms'},
+  {key: 'answer-list', label: 'Answer list'},
+  {key: 'answer-list-link', label: 'Answer list link'},
+  {key: 'order-observation', label: 'Order/observation (LoincUniversalLabOrdersValueSet)'},
+  {key: 'translations', label: 'Translations (<lang>LinguisticVariant)'},
+];
 
+interface ArchiveEntry {
+  name?: string;
+  suggestedSlot?: string | null;
+}
 
 @Component({
-    templateUrl: 'loinc-import.component.html',
-    providers: [DestroyService],
-    imports: [MuiCardModule, NzBreadCrumbComponent, NzBreadCrumbItemComponent, FormsModule, MuiFormModule, MuiInputModule, ValueSetConceptSelectComponent, MuiButtonModule, MuiAlertModule, MuiCoreModule, MuiModalModule, MarinPageLayoutModule, TranslatePipe, HasAnyPrivilegePipe, BobArchivesComponent]
+  templateUrl: 'loinc-import.component.html',
+  providers: [DestroyService],
+  imports: [
+    MuiCardModule,
+    NzBreadCrumbComponent,
+    NzBreadCrumbItemComponent,
+    FormsModule,
+    MuiFormModule,
+    MuiInputModule,
+    MuiSelectModule,
+    ValueSetConceptSelectComponent,
+    MuiButtonModule,
+    MuiAlertModule,
+    MuiCoreModule,
+    MuiModalModule,
+    MarinPageLayoutModule,
+    TranslatePipe,
+    HasAnyPrivilegePipe,
+    BobArchivesComponent,
+  ],
 })
 export class LoincImportComponent {
   private http = inject(HttpClient);
+  private bobService = inject(BobLibService);
   private notificationService = inject(MuiNotificationService);
   private jobService = inject(JobLibService);
   private destroy$ = inject(DestroyService);
   private router = inject(Router);
 
+  /** Slot definitions (key + display label). */
+  protected readonly slots = SLOTS;
 
+  /** Form-bound state. */
   public data: {
-    version?: string,
-    language?: string
-  } = {};
+    version?: string;
+    language?: string;
+    archiveUuid?: string;
+    /** Per-slot entry-name picks. Keyed by SLOTS[].key. */
+    fileMap: {[slot: string]: string | undefined};
+  } = {fileMap: {}};
 
+  /** All LOINC archives in Bob, used to (a) populate the version select and (b) resolve a
+   *  picked version to the matching archive uuid. Refreshed after the user uploads via the
+   *  Stored archives card. */
+  protected archives: BobObject[] = [];
+  /** Archives whose {@code meta.version} matches {@link data.version}. Recomputed on every
+   *  version-select change so the secondary "LOINC archive" picker is bound to a stable
+   *  array (avoids function-call expressions in the template that re-run every CD pass). */
+  protected matchingArchives: BobObject[] = [];
+  /** Entries inside the currently-selected archive (one per .csv) — populated from
+   *  {@code GET /loinc/archives/{uuid}/files}. Drives the per-slot select options. */
+  protected entries: ArchiveEntry[] = [];
+
+  protected loader = new LoadingManager();
   public loading: {[k: string]: boolean} = {};
-
-  @ViewChild('form') public form?: NgForm;
-  @ViewChild('partsFileInput') public partsFileInput?: ElementRef<HTMLInputElement>;
-  @ViewChild('loincTerminologyFileInput') public loincTerminologyFileInput?: ElementRef<HTMLInputElement>;
-  @ViewChild('supplementaryPropertiesFileInput') public supplementaryPropertiesFileInput?: ElementRef<HTMLInputElement>;
-  @ViewChild('panelsFileInput') public panelsFileInput?: ElementRef<HTMLInputElement>;
-  @ViewChild('answerListFileInput') public answerListFileInput?: ElementRef<HTMLInputElement>;
-  @ViewChild('answerListLinkFileInput') public answerListLinkFileInput?: ElementRef<HTMLInputElement>;
-  @ViewChild('translationsFileInput') public translationsFileInput?: ElementRef<HTMLInputElement>;
-  @ViewChild('orderObservationFileInput') public orderObservationFileInput?: ElementRef<HTMLInputElement>;
-  @ViewChild('successNotificationContent') public successNotificationContent?: TemplateRef<any>;
-
   public jobResponse: JobLog | null = null;
   protected modalData: {visible?: boolean} = {};
 
+  @ViewChild('form') public form?: NgForm;
+  @ViewChild('successNotificationContent') public successNotificationContent?: TemplateRef<any>;
+
+  public ngOnInit(): void {
+    this.loadArchives();
+  }
+
+  /** Distinct {@code meta.version} values across all LOINC archives, newest first by upload
+   *  order. {@code null} / missing versions are surfaced as "(untagged)" so admins can still
+   *  reach archives uploaded before meta-tagging was wired (PR #76's precursor). */
+  protected get versionOptions(): {value: string; label: string}[] {
+    const seen = new Set<string>();
+    const out: {value: string; label: string}[] = [];
+    for (const a of this.archives) {
+      const v = (a.meta?.['version'] ?? '') as string;
+      if (!seen.has(v)) {
+        seen.add(v);
+        out.push({value: v, label: v ? v : '(untagged)'});
+      }
+    }
+    return out;
+  }
+
+  /** Triggered on version-select change. Auto-picks the most recently uploaded archive of
+   *  the matching version so the admin doesn't have to do a second click for the common case
+   *  of "one archive per version". They can still pick a different one manually. */
+  protected onVersionChange(): void {
+    this.matchingArchives = this.archives
+      .filter(a => (a.meta?.['version'] ?? '') === (this.data.version ?? ''))
+      // Most recent first — BobObject.id is monotonic per insertion, simplest "latest" proxy.
+      .sort((a, b) => (b.id ?? 0) - (a.id ?? 0));
+    if (this.matchingArchives.length === 0) {
+      this.data.archiveUuid = undefined;
+      this.entries = [];
+      this.data.fileMap = {};
+      return;
+    }
+    this.data.archiveUuid = this.matchingArchives[0].uuid;
+    this.onArchiveChange();
+  }
+
+  protected onArchiveChange(): void {
+    this.entries = [];
+    this.data.fileMap = {};
+    if (!this.data.archiveUuid) {
+      return;
+    }
+    const params = new HttpParamsLite();
+    if (this.data.language) {
+      params.set('language', this.data.language);
+    }
+    this.loader
+      .wrap(
+        'entries',
+        this.http.get<{entries: ArchiveEntry[]}>(
+          `${environment.termxApi}/loinc/archives/${this.data.archiveUuid}/files`,
+          {params: params.build()},
+        ),
+      )
+      .subscribe({
+        next: resp => {
+          this.entries = resp.entries ?? [];
+          // Preselect each slot from the suggested mapping.
+          for (const slot of SLOTS) {
+            const hit = this.entries.find(e => e.suggestedSlot === slot.key);
+            this.data.fileMap[slot.key] = hit?.name;
+          }
+        },
+        error: () => this.entries = [],
+      });
+  }
+
+  /** Language change re-runs the archive listing so the language-specific translations file
+   *  gets its {@code suggestedSlot} populated. (Server keys translations off
+   *  {@code <lang>LinguisticVariant.csv} — without the language, no entry can match.) */
+  protected onLanguageChange(): void {
+    if (this.data.archiveUuid) {
+      this.onArchiveChange();
+    }
+  }
+
+  /** Bob-archives card calls back here after a successful upload so the version dropdown +
+   *  archive selection reflect the new file without a page reload. */
+  protected onArchiveListChanged(): void {
+    this.loadArchives();
+  }
+
+  private loadArchives(): void {
+    this.loader
+      .wrap(
+        'archives',
+        this.bobService.query('loinc', Object.assign(new QueryParams(), {limit: 100}) as any),
+      )
+      .subscribe(resp => {
+        this.archives = resp.data ?? [];
+        // If the form already has a version picked, re-derive the matching archive so the
+        // per-slot selects stay populated after a refresh.
+        if (this.data.version != null && !this.data.archiveUuid) {
+          this.onVersionChange();
+        }
+      });
+  }
+
   protected importLoinc(): void {
-    const formData = new FormData();
-    formData.append('request', JSON.stringify(this.data));
-    formData.append('partsFile', this.partsFileInput.nativeElement.files[0] as Blob, 'partsFile');
-    formData.append('terminologyFile', this.loincTerminologyFileInput.nativeElement.files[0] as Blob, 'loincTerminologyFile');
-    if (this.supplementaryPropertiesFileInput?.nativeElement?.files?.[0]) {
-      formData.append('supplementaryPropertiesFile', this.supplementaryPropertiesFileInput.nativeElement.files[0] as Blob, 'supplementaryPropertiesFile');
+    if (!this.data.archiveUuid) {
+      this.notificationService.error('Pick a LOINC version (and an archive) before importing.');
+      return;
     }
-    if (this.panelsFileInput?.nativeElement?.files?.[0]) {
-      formData.append('panelsFile', this.panelsFileInput.nativeElement.files[0] as Blob, 'panelsFile');
+    if (!this.data.version) {
+      this.notificationService.error('Set the LOINC version above before importing.');
+      return;
     }
-    if (this.answerListFileInput?.nativeElement?.files?.[0]) {
-      formData.append('answerListFile', this.answerListFileInput.nativeElement.files[0] as Blob, 'answerListFile');
-    }
-    if (this.answerListLinkFileInput?.nativeElement?.files?.[0]) {
-      formData.append('answerListLinkFile', this.answerListLinkFileInput.nativeElement.files[0] as Blob, 'answerListLinkFile');
-    }
-    if (this.translationsFileInput?.nativeElement?.files?.[0]) {
-      formData.append('translationsFile', this.translationsFileInput.nativeElement.files[0] as Blob, 'translationsFile');
-    }
-    if (this.orderObservationFileInput?.nativeElement?.files?.[0]) {
-      formData.append('orderObservationFile', this.orderObservationFileInput.nativeElement.files[0] as Blob, 'orderObservationFile');
+    // Strip empty / undefined picks so the server's auto-dispatch fallback fires per-slot
+    // for any that weren't explicitly mapped (otherwise the fileMap-override path skips
+    // them silently).
+    const fileMap: {[k: string]: string} = {};
+    for (const slot of SLOTS) {
+      const v = this.data.fileMap[slot.key];
+      if (v) {
+        fileMap[slot.key] = v;
+      }
     }
 
     this.jobResponse = null;
     this.loading['process'] = true;
     this.modalData = {};
-    this.http.post<JobLogResponse>(`${environment.termxApi}/loinc/import`, formData)
+    this.http
+      .post<JobLogResponse>(`${environment.termxApi}/loinc/import/from-archive`, {
+        archiveUuid: this.data.archiveUuid,
+        version: this.data.version,
+        language: this.data.language,
+        fileMap: Object.keys(fileMap).length > 0 ? fileMap : undefined,
+      })
       .subscribe({
-        next: (resp) => {
-          this.pollJobStatus(resp.jobId as number);
-        }, error: () => this.loading['process'] = false
+        next: resp => this.pollJobStatus(resp.jobId as number),
+        error: () => (this.loading['process'] = false),
       });
   }
 
   private pollJobStatus(jobId: number): void {
     this.jobService.pollFinishedJobLog(jobId, this.destroy$).subscribe(jobResp => {
       if (!jobResp.errors && !jobResp.warnings) {
-        this.notificationService.success("web.integration.file-import.success-message", this.successNotificationContent!, {duration: 0, closable: true});
+        this.notificationService.success(
+          'web.integration.file-import.success-message',
+          this.successNotificationContent!,
+          {duration: 0, closable: true},
+        );
       }
       this.jobResponse = jobResp;
-    }).add(() => this.loading['process'] = false);
+    }).add(() => (this.loading['process'] = false));
   }
 
-  /**
-   * Per-row Import button on the "Stored archives" panel: re-uses {@link data.version} +
-   * {@link data.language} from the form (so the user can set them once and import any of the
-   * stored release zips). The server unpacks the zip by basename and runs the same import
-   * pipeline as the legacy multipart endpoint — no need to re-upload from the browser.
-   */
-  protected importFromArchive(archive: BobObject): void {
+  /** Stored archives card's per-row Open action: select the row's version+archive in the
+   *  form rather than triggering an immediate import. Admin then confirms via the Import
+   *  button at the bottom of the form. Re-loads the archive list first so a freshly-
+   *  uploaded zip's version shows up in the version select. */
+  protected onArchiveOpen(archive: BobObject): void {
     if (!archive?.uuid) {
       return;
     }
-    if (!this.data.version) {
-      this.notificationService.error('Set the version (and language, if importing translations) above before importing from a stored archive.');
-      return;
-    }
-    this.jobResponse = null;
-    this.loading['process'] = true;
-    this.http.post<JobLogResponse>(`${environment.termxApi}/loinc/import/from-archive`, {
-      archiveUuid: archive.uuid,
-      version: this.data.version,
-      language: this.data.language,
-    }).subscribe({
-      next: resp => this.pollJobStatus(resp.jobId as number),
-      error: () => this.loading['process'] = false,
-    });
+    this.data.version = (archive.meta?.['version'] as string | undefined) ?? '';
+    this.data.archiveUuid = archive.uuid;
+    this.loadArchives();
+    this.onArchiveChange();
   }
 
   protected openCodeSystem(mode: 'edit' | 'view'): void {
     this.router.navigate(['/resources/code-systems/', 'loinc', mode]);
   }
+}
+
+/** Tiny shim so we don't pull a whole HttpParams instance for one optional language param. */
+class HttpParamsLite {
+  private map: {[k: string]: string} = {};
+  public set(k: string, v: string): void { this.map[k] = v; }
+  public build(): {[k: string]: string} { return this.map; }
 }


### PR DESCRIPTION
**Pairs with termx-server [#134](https://github.com/termx-health/termx-server/pull/134)** (`GET /loinc/archives/{uuid}/files` + optional `fileMap` on `/loinc/import/from-archive`).

Three reported pain points on `/integration/dashboard/loinc/import`:

1. Store LOINC version in Bob metadata when uploading
2. Replace the version input with a select populated from the uploaded LOINC editions
3. Replace the per-slot "Choose file" inputs with selects populated from the chosen archive's contents, preselected when possible

The legacy form had eight hand-rolled `<input type="file">` boxes (`parts`, `terminology`, `supplementary-properties`, `panels`, `answer-list`, `answer-list-link`, `translations`, `order-observation`) plus a free-text version field. Admins had to unzip the LOINC release locally, pick the right CSV for each slot by hand, and type the version.

## New flow

```
┌─ Version: 2.78 ▾  ──┬─ Language: Estonian (et) ▾ ─┐    ← drop-downs from Bob meta
│                    │                                │
│ (LOINC archive)    │  (only if >1 upload for that version)
│   SnomedCT_…20.zip ▾                                │
│                                                     │
│  Parts                                  AccessoryFiles/PartFile/Part.csv (suggested) ▾
│  Terminology                            AccessoryFiles/PartFile/LoincPartLink_Primary.csv (suggested) ▾
│  Supplementary properties               AccessoryFiles/PartFile/LoincPartLink_Supplementary.csv (suggested) ▾
│  Panels and forms                       AccessoryFiles/PanelsAndForms/PanelsAndForms.csv (suggested) ▾
│  Answer list                            AccessoryFiles/AnswerFile/AnswerList.csv (suggested) ▾
│  Answer list link                       AccessoryFiles/AnswerFile/LoincAnswerListLink.csv (suggested) ▾
│  Order/observation                      AccessoryFiles/…/LoincUniversalLabOrdersValueSet.csv (suggested) ▾
│  Translations (<lang>LinguisticVariant) AccessoryFiles/LinguisticVariants/etLinguisticVariant.csv (suggested) ▾
│                                                     │
│              [ Import ]                             │
└─────────────────────────────────────────────────────┘

┌─ Stored archives (loinc) ──┐    ← upload tags meta = {version, language}
│  SnomedCT_…20.zip   v2.78  │
│  SnomedCT_…21.zip   v2.79  │
└────────────────────────────┘
```

## Changes

- **`<tw-bob-archives>` `[meta]`** binds to `{version, language}` from the form — uploads via the Stored archives card automatically inherit the version/language tags the admin set above, and the version select picks them up on the next refresh.
- **Version `<m-select>`** populated from distinct `meta.version` values across Bob LOINC archives, newest first. Untagged uploads (pre-Bob-meta) appear as `(untagged)` for backward compat.
- **Picking a version auto-resolves the latest matching archive** by `id` descending. If multiple archives share the version, a secondary `<m-select>` appears for the admin to choose. Single-archive-per-version → one click.
- **Per-slot `<m-select>`s** populated from `GET /loinc/archives/{uuid}/files`. Each option labeled with the full zip entry path; the entry whose `suggestedSlot === <slot.key>` is preselected and gets a "(suggested)" suffix. Admin can switch to any other `.csv` entry (e.g. swap a custom `Part.csv`) and the picks travel as the request's optional `fileMap`.
- **Language change** re-runs the entries fetch so the matching `<lang>LinguisticVariant.csv` shows up as the suggested `translations` file.
- **"Open" on the Stored archives card** routes the row into the form (sets version + archive + slot picks). Import button at the bottom of the form is the single confirm step.

The legacy multipart `POST /loinc/import` endpoint stays reachable server-side, but the page no longer constructs an 8-blob FormData — every flow now goes through `/loinc/import/from-archive`.

## Test plan
- [ ] Upload a LOINC zip via the Stored archives card with a version typed in the form first → the upload appears in the version select on next refresh.
- [ ] Pick a version → version select fires, archive auto-resolves, per-slot selects populate with the suggested entries preselected.
- [ ] Change language → the `translations` slot's preselected entry updates to the matching `<lang>LinguisticVariant.csv` (if any).
- [ ] Override one slot to a non-default entry → Import succeeds and the server log reflects the explicit `fileMap` value.
- [ ] Upload a zip for a new version `2.79` → that version appears in the dropdown without a page reload after clicking any archive's Open button.
- [ ] `(none — use server default)` option in a slot select → that slot is omitted from `fileMap`, server's auto-dispatch fills it in.