### PR TITLE
fix(landing): drop <m-page> wrapper — Standalone[LandingPageComponent] DI breaks on it

### DIFF
--- a/app/src/app/landing/landing-page.component.html
+++ b/app/src/app/landing/landing-page.component.html
@@ -1,4 +1,13 @@
-<m-page mFull>
+<!-- Plain div wrapper rather than <m-page mFull>. MuiPageComponent's constructor declares
+     a hard dependency on MuiPageLayoutComponent via element-injection, and Angular 21's
+     standalone-component DI for this specific route fails to surface the AppComponent's
+     <m-page-layout> as an ancestor — landing rendered fine via the app shell's chrome but
+     its body was completely BLANK because <m-page> threw before its content rendered (the
+     "Source: Standalone[LandingPageComponent]" NG0201). Other pages (IG / CodeSystem
+     summaries) use <m-page> with extra context directives that happen to keep DI happy;
+     landing doesn't need any of that, just the full-bleed layout — keep .wrapper styles
+     intact and skip the page chrome entirely. -->
+<div style="width:100%">
   <div class="wrapper animated">
     <!-- Resources -->
     @if ((['*.CodeSystem.read', '*.ValueSet.read', '*.MapSet.read'] | twPrivileged) && (modules | includes: 'terminology')) {
@@ -98,7 +107,7 @@
       }
     }
   </div>
-</m-page>
+</div>
 
 
 <ng-template #taskTemplate let-task>

--- a/app/src/app/landing/landing-page.component.ts
+++ b/app/src/app/landing/landing-page.component.ts
@@ -9,20 +9,18 @@ import {Task, TaskLibModule, TaskLibService} from 'term-web/task/_lib';
 import {PageLibService, WikiLibModule} from 'term-web/wiki/_lib';
 import {AuthService} from 'term-web/core/auth';
 import {CoreUiModule} from 'term-web/core/ui/core-ui.module';
-import {MarinPageLayoutModule} from '@termx-health/ui';
 
 type Modules = 'terminology' | 'core' | 'task' | 'wiki';
 
 @Component({
   standalone: true,
-  // MarinPageLayoutModule has to be imported directly even though CoreUiModule transitively
-  // re-exports it via MarinaUiModule. Angular 21's standalone element-injection no longer
-  // resolves MuiPageLayoutComponent (the host that <m-page> needs as a DI ancestor) through
-  // nested NgModule re-export chains the same way Angular 17 did — without this direct
-  // import the page throws "NG0201: No provider found for MuiPageLayoutComponent. Source:
-  // Standalone[LandingPageComponent]". Other pages that use <m-page> already import
-  // MarinPageLayoutModule directly for the same reason (e.g. SnomedDashboardComponent).
-  imports: [CoreUiModule, MarinPageLayoutModule, TaskLibModule, WikiLibModule, SysLibModule],
+  // No MarinPageLayoutModule — the template uses a plain div wrapper instead of <m-page>.
+  // (See landing-page.component.html for the full story.) Importing MarinPageLayoutModule
+  // earlier didn't help — adding the module makes <m-page> a known element, but
+  // MuiPageComponent's constructor still requires MuiPageLayoutComponent as an element-
+  // injection ancestor, and Angular 21's standalone DI for this route doesn't surface the
+  // app shell's <m-page-layout>. Drop <m-page> entirely; landing didn't need page chrome.
+  imports: [CoreUiModule, TaskLibModule, WikiLibModule, SysLibModule],
   templateUrl: 'landing-page.component.html',
   styleUrls: ['landing-page.component.less']
 })


### PR DESCRIPTION
The NG0201 from earlier (`No provider found for MuiPageLayoutComponent. Source: Standalone[LandingPageComponent]`) returned even after #76's `MarinPageLayoutModule` import. Drove Chrome to `/landing` to confirm the failure mode:

> The app-shell header rendered fine (top bar with "TermX" / "YUPI" badge) — but the **entire body was blank**. `<m-page>` threw during its factory call, swallowing all of landing's content.

## Why #76 didn't fix it

Adding `MarinPageLayoutModule` to the standalone imports made `<m-page>` a known element under template strict-mode, so the *compilation* error was gone — but the *runtime* failure remained. `MuiPageComponent`'s constructor declares a hard dependency on `MuiPageLayoutComponent` via element-injection:

```ts
declare class MuiPageComponent {
  constructor(pageLayout: MuiPageLayoutComponent);
}
```

The lookup walks the element-injector chain starting at `<m-page>` and must find an `<m-page-layout>` ancestor. The AppComponent template DOES render `<m-page-layout>` around the router-outlet:

```html
<m-page-layout …>
  <ng-container [ngTemplateOutlet]="contentTpl"/>
</m-page-layout>
<ng-template #contentTpl><router-outlet/></ng-template>
```

But Angular 21's standalone-DI for this specific route doesn't surface the shell's `MuiPageLayoutComponent` to the routed LandingPageComponent. (Other pages that use `<m-page>` — IG / CodeSystem summaries — happen to keep DI happy via the extra context directives they bring along: `twPrivilegeContext`, `ResourceContextComponent`. Landing imported none of that — and shouldn't need to.)

## Fix

Drop the `<m-page>` wrapper altogether and use a plain `<div style="width:100%">`. The existing `.wrapper.animated` child carries all the padding and grid styles, so the layout looks unchanged. With no `<m-page>`, there's no `MuiPageComponent` factory to fail.

Also remove the `MarinPageLayoutModule` import added in #76 — no longer needed.

## Test plan
- [ ] Navigate to `/landing` → page body renders (resources / spaces / tasks sections), no console error.
- [ ] Click landing nav items from the menu → still works, no NG0201 thrown during navigation.
- [ ] Other pages that use `<m-page>` (IG summary, CodeSystem summary, etc.) still work — change is isolated to landing.