### PR TITLE
feat(loinc): version autodetect from filename + refresh dropdown after upload

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,29 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "termx-web",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["start"],
+      "port": 4200
+    },
+    {
+      "name": "termx-web-embedded",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "start:embedded"],
+      "port": 4200
+    },
+    {
+      "name": "termx-server",
+      "runtimeExecutable": "/Users/igor/source/termx/termx-server/scripts/run-backend.sh",
+      "runtimeArgs": [],
+      "port": 8200
+    },
+    {
+      "name": "tx-minio",
+      "runtimeExecutable": "/Users/igor/source/termx/termx-server/scripts/run-minio.sh",
+      "runtimeArgs": [],
+      "port": 9000
+    }
+  ]
+}

--- a/app/src/app/integration/import/loinc/loinc-import.component.html
+++ b/app/src/app/integration/import/loinc/loinc-import.component.html
@@ -127,5 +127,6 @@
                    actionLabel="Open"
                    (action)="onArchiveOpen($event)"
                    (itemClick)="onArchiveOpen($event)"
-                   (fileSelected)="onLoincFilePicked($event)"/>
+                   (fileSelected)="onLoincFilePicked($event)"
+                   (uploaded)="onLoincUploaded($event)"/>
 </div>

--- a/app/src/app/integration/import/loinc/loinc-import.component.html
+++ b/app/src/app/integration/import/loinc/loinc-import.component.html
@@ -126,5 +126,6 @@
                    [meta]="{version: data.version, language: data.language}"
                    actionLabel="Open"
                    (action)="onArchiveOpen($event)"
-                   (itemClick)="onArchiveOpen($event)"/>
+                   (itemClick)="onArchiveOpen($event)"
+                   (fileSelected)="onLoincFilePicked($event)"/>
 </div>

--- a/app/src/app/integration/import/loinc/loinc-import.component.ts
+++ b/app/src/app/integration/import/loinc/loinc-import.component.ts
@@ -300,6 +300,36 @@ export class LoincImportComponent {
     }
   }
 
+  /**
+   * Called by {@code <tw-bob-archives (uploaded)>} after a new LOINC archive has been
+   * persisted to Bob. Refreshes the archives list (so the just-uploaded version shows up
+   * in the dropdown), then auto-selects a "more suitable" pick where possible:
+   *
+   *   - If the uploaded BobObject has {@code meta.version} (it should — the page tagged
+   *     the upload with the form's {@code data.version} via the {@code [meta]} binding),
+   *     select that version + the new uuid and route the per-slot selects to it via
+   *     {@code onVersionChange()}.
+   *   - If meta.version is empty (the admin uploaded without setting a version first),
+   *     leave the form alone and let the admin pick — the new file is in the list but
+   *     its dropdown entry shows as "(untagged)".
+   */
+  protected onLoincUploaded(uploaded: BobObject): void {
+    this.loader
+      .wrap(
+        'archives',
+        this.bobService.query('loinc', Object.assign(new QueryParams(), {limit: 100}) as any),
+      )
+      .subscribe(resp => {
+        this.archives = resp.data ?? [];
+        const newVersion = (uploaded.meta?.['version'] as string | undefined) ?? '';
+        if (newVersion) {
+          this.data.version = newVersion;
+          this.data.archiveUuid = uploaded.uuid;
+          this.onVersionChange();
+        }
+      });
+  }
+
   protected openCodeSystem(mode: 'edit' | 'view'): void {
     this.router.navigate(['/resources/code-systems/', 'loinc', mode]);
   }

--- a/app/src/app/integration/import/loinc/loinc-import.component.ts
+++ b/app/src/app/integration/import/loinc/loinc-import.component.ts
@@ -270,6 +270,36 @@ export class LoincImportComponent {
     this.onArchiveChange();
   }
 
+  /**
+   * Auto-detect the LOINC release version from the chosen file's NAME so the admin doesn't
+   * have to type it before uploading. Triggered by the {@code (fileSelected)} event on
+   * {@code <tw-bob-archives>}. Standard LOINC distribution filenames are
+   * {@code Loinc_<version>.zip} (e.g. {@code Loinc_2.82.zip}) and that's what we match —
+   * if the regex misses, the version field stays as whatever the admin had previously, so
+   * they can still type / pick it manually.
+   *
+   * Only overwrites the version when (a) the field is empty, or (b) the detected version
+   * differs from what's in the field. Doesn't clobber an admin-typed value with a re-detect
+   * of the same one.
+   *
+   * (For archives whose filename doesn't reveal the version, the server can still pick it
+   * up from the {@code Loinc_<version>_DifferenceReport.pdf} entry inside the zip — see
+   * {@code LoincZipReader.describe}; we'd need to add a similar regex on the server side
+   * to backfill {@code meta.version} on already-uploaded archives.)
+   */
+  protected onLoincFilePicked(file: File | undefined): void {
+    if (!file) {
+      return;
+    }
+    const m = /Loinc[_-]?([\d.]+)/i.exec(file.name);
+    if (m && m[1]) {
+      const detected = m[1].replace(/\.+$/, ''); // strip trailing dots if filename was "Loinc_2.82..zip"
+      if (this.data.version !== detected) {
+        this.data.version = detected;
+      }
+    }
+  }
+
   protected openCodeSystem(mode: 'edit' | 'view'): void {
     this.router.navigate(['/resources/code-systems/', 'loinc', mode]);
   }

--- a/app/src/app/sys/_lib/bob/components/bob-archives.component.ts
+++ b/app/src/app/sys/_lib/bob/components/bob-archives.component.ts
@@ -48,6 +48,13 @@ export class BobArchivesComponent implements OnInit, OnChanges {
    * decides whether to navigate, download, open a modal, etc.
    */
   @Output() public itemClick = new EventEmitter<BobObject>();
+  /**
+   * Fired when the user picks a file in the upload input — BEFORE the upload starts. Lets the
+   * host component peek at the file (e.g. parse its name for a version tag) and tweak
+   * {@link meta} via two-way binding so the upload picks up the new tag. {@code File | undefined}
+   * because clearing the input also fires this with no selection.
+   */
+  @Output() public fileSelected = new EventEmitter<File | undefined>();
 
   protected archives: BobObject[] = [];
   protected loader = new LoadingManager();
@@ -84,6 +91,7 @@ export class BobArchivesComponent implements OnInit, OnChanges {
 
   protected onPickFile(input: HTMLInputElement): void {
     this.uploadFile = input.files?.[0];
+    this.fileSelected.emit(this.uploadFile);
   }
 
   protected upload(): void {

--- a/app/src/app/sys/_lib/bob/components/bob-archives.component.ts
+++ b/app/src/app/sys/_lib/bob/components/bob-archives.component.ts
@@ -55,6 +55,13 @@ export class BobArchivesComponent implements OnInit, OnChanges {
    * because clearing the input also fires this with no selection.
    */
   @Output() public fileSelected = new EventEmitter<File | undefined>();
+  /**
+   * Fired AFTER a successful upload, once the server returns the new {@link BobObject}.
+   * Hosts use this to refresh side-state — e.g. the LOINC import page's version dropdown,
+   * which is populated from {@code meta.version} across all stored archives, needs to
+   * re-query after each new upload to surface the just-added version.
+   */
+  @Output() public uploaded = new EventEmitter<BobObject>();
 
   protected archives: BobObject[] = [];
   protected loader = new LoadingManager();
@@ -118,6 +125,9 @@ export class BobArchivesComponent implements OnInit, OnChanges {
             this.uploadDescription = undefined;
             this.notificationService.success('Archive uploaded');
             this.load();
+            if (ev.body) {
+              this.uploaded.emit(ev.body);
+            }
           } else {
             this.uploadProgress = ev.progress;
           }


### PR DESCRIPTION
Closes the LOINC import-page polish loop the user asked for:
1. **Detect LOINC version from the uploaded file's name** — so admins don't have to type it before clicking Upload.
2. **After upload, refresh the version dropdown** + auto-select the newly uploaded version so the admin lands on the per-slot file selects for the new release without touching the version control.

## Changes

### `BobArchivesComponent` — two new outputs
- `(fileSelected)` fires when the admin picks a file (before upload starts). Lets hosts peek at the File for pre-upload meta derivation (e.g. parse filename for version).
- `(uploaded)` fires after the server-side upload completes, emitting the new `BobObject`. Lets hosts refresh side-state (e.g. a version dropdown populated from `meta.version`).

### `LoincImportComponent`
- `onLoincFilePicked(file)` runs `/Loinc[_-]?([\d.]+)/i` against `file.name`. If a version matches, fills `data.version` before the upload fires — the existing `[meta]="{version, language}"` binding then tags the BobObject correctly.
- `onLoincUploaded(uploaded)` re-queries the LOINC archives list to pick up the new file, then if the BobObject has `meta.version` (it should, because the page tagged it from `data.version`), sets `data.version` + `data.archiveUuid` to the new entry and runs `onVersionChange()` so the per-slot CSV selects re-populate. Admin lands on the new release with one click.

If meta.version is empty (admin uploaded without setting a version first), the form is left alone and the admin picks from the now-refreshed dropdown — the new entry just appears as `(untagged)`.

### `.claude/launch.json`
Configures the project's four dev servers (termx-web Angular `:4200`, termx-web embedded, termx-server JVM `:8200`, tx-minio `:9000`) so `preview_start` can launch any of them. Mirrored to `~/source/termx/.claude/launch.json` (the workspace root the Preview MCP picks up).

## Test plan
- [ ] On the LOINC import page, pick `Loinc_2.82.zip` in the Stored archives card's file input → version field auto-fills with `2.82`.
- [ ] Click Upload → after the upload completes, the version dropdown above gains a `2.82` option, the form's version is set to `2.82`, the archive uuid points at the new upload, per-slot CSV selects populate from `GET /loinc/archives/{uuid}/files`.
- [ ] Pick a file whose name doesn't match the regex (e.g. `release.zip`) → version field stays as whatever the admin had typed.
- [ ] Pick + upload `Loinc_2.83.zip` → dropdown gains `2.83` and selects it (most recent wins).