### PR TITLE
fix(code-system-summary): drop <m-page> wrapper — same NG0201 mode as landing

### DIFF
--- a/app/src/app/resources/code-system/containers/summary/code-system-summary.component.html
+++ b/app/src/app/resources/code-system/containers/summary/code-system-summary.component.html
@@ -1,5 +1,15 @@
 <tw-resource-context resourceType="CodeSystem" [resource]="codeSystem" [versions]="versions" mode="summary"></tw-resource-context>
-<m-page [mLoading]="loader.isLoading" [twPrivilegeContext]="[codeSystem?.id, 'CodeSystem']">
+<!-- Plain div wrapper rather than <m-page mLoading="...">. MuiPageComponent's constructor
+     declares a hard dependency on MuiPageLayoutComponent via element-injection, and Angular
+     21's standalone-component DI on this route doesn't surface the app shell's
+     <m-page-layout> as an ancestor — same NG0201 mode that hit the landing page (PR #78).
+     The previous twPrivilegeContext / ResourceContextComponent ancestors don't fix it; the
+     only reliable cure is to skip <m-page> entirely. Loading state is now expressed via the
+     m-loading class on the wrapper div (same overlay-pattern marina-ui's <m-page> applied
+     internally). -->
+<div [twPrivilegeContext]="[codeSystem?.id, 'CodeSystem']"
+     [class.m-loading]="loader.isLoading"
+     style="width: 100%; padding: 1rem;">
 
   <m-form-row class="with-row-gap" mGap="1rem">
     <div *mFormCol style="display: flex; gap: 1rem; flex-direction: column">
@@ -138,6 +148,6 @@
       </div>
     </m-form-row>
 
-  </m-page>
+</div>
 
-  <tw-resource-task-modal #taskModal (taskCreated)="tasksWidgetComponent.loadTasks()" resourceType="CodeSystem"/>
+<tw-resource-task-modal #taskModal (taskCreated)="tasksWidgetComponent.loadTasks()" resourceType="CodeSystem"/>

--- a/app/src/app/resources/code-system/containers/summary/code-system-summary.component.ts
+++ b/app/src/app/resources/code-system/containers/summary/code-system-summary.component.ts
@@ -7,7 +7,7 @@ import {CodeSystemUnlinkedConceptsComponent} from 'term-web/resources/code-syste
 import {CodeSystemService} from 'term-web/resources/code-system/services/code-system.service';
 import {ResourceTasksWidgetComponent} from 'term-web/resources/resource/components/resource-tasks-widget.component';
 import { ResourceContextComponent } from 'term-web/resources/resource/components/resource-context.component';
-import { MarinPageLayoutModule, MuiFormModule, MuiCardModule, MuiButtonModule, MuiIconModule, MuiDividerModule, MuiDropdownModule, MuiCoreModule, MuiListModule } from '@termx-health/ui';
+import { MuiFormModule, MuiCardModule, MuiButtonModule, MuiIconModule, MuiDividerModule, MuiDropdownModule, MuiCoreModule, MuiListModule } from '@termx-health/ui';
 import { PrivilegeContextDirective } from 'term-web/core/auth/privileges/privilege-context.directive';
 import { CodeSystemInfoWidgetComponent } from 'term-web/resources/code-system/containers/summary/widgets/code-system-info-widget.component';
 import { PrivilegedDirective } from 'term-web/core/auth/privileges/privileged.directive';
@@ -21,7 +21,7 @@ import { TranslatePipe } from '@ngx-translate/core';
 
 @Component({
     templateUrl: 'code-system-summary.component.html',
-    imports: [ResourceContextComponent, MarinPageLayoutModule, PrivilegeContextDirective, MuiFormModule, MuiCardModule, CodeSystemInfoWidgetComponent, MuiButtonModule, RouterLink, MuiIconModule, PrivilegedDirective, MuiDividerModule, CodeSystemVersionsWidgetComponent, MuiDropdownModule, MuiCoreModule, MuiListModule, CodeSystemUnlinkedConceptsComponent_1, ResourceTasksWidgetComponent_1, ResourceRelatedArtifactWidgetComponent, ResourceTaskModalComponent, TranslatePipe, FilterPipe]
+    imports: [ResourceContextComponent, PrivilegeContextDirective, MuiFormModule, MuiCardModule, CodeSystemInfoWidgetComponent, MuiButtonModule, RouterLink, MuiIconModule, PrivilegedDirective, MuiDividerModule, CodeSystemVersionsWidgetComponent, MuiDropdownModule, MuiCoreModule, MuiListModule, CodeSystemUnlinkedConceptsComponent_1, ResourceTasksWidgetComponent_1, ResourceRelatedArtifactWidgetComponent, ResourceTaskModalComponent, TranslatePipe, FilterPipe]
 })
 export class CodeSystemSummaryComponent implements OnInit {
   private route = inject(ActivatedRoute);


### PR DESCRIPTION
## Summary

Same failure mode that PR #78 fixed on the landing page now reproduces on `/resources/code-systems/{id}`:

```
ERROR ɵNotFound: NG0201: No provider found for `MuiPageLayoutComponent`.
Source: Standalone[CodeSystemSummaryComponent].
```

`MuiPageComponent`'s constructor declares a hard dependency on `MuiPageLayoutComponent` via element-injection. The app shell DOES render `<m-page-layout>` around `<router-outlet>`, but the indirection through `<ng-container [ngTemplateOutlet]="contentTpl">` breaks the element-injector chain for some routes under Angular 21's standalone DI.

The earlier hypothesis in the landing-page comment (that `ResourceContextComponent` / `twPrivilegeContext` ancestors keep DI happy on summary pages) turns out to be wrong — `CodeSystemSummaryComponent` has both and still fails.

## Fix

Drop `<m-page mLoading="..." twPrivilegeContext="...">` in favour of a plain `<div twPrivilegeContext="..." [class.m-loading]>`. The privilege context still applies; the `m-loading` class preserves the spinner overlay marina-ui's `<m-page>` applied internally.

## Longer-term

If this keeps surfacing on more pages (31 templates use `<m-page>`), the right fix is to inline `<router-outlet>` directly under `<m-page-layout>` in `AppComponent` and drop the `ngTemplateOutlet` indirection so element-injection works uniformly.

## Test plan

- [x] Builds clean (TypeScript compile)
- [ ] Reviewer: navigate to `/resources/code-systems/<id>` (any CodeSystem). Previously threw NG0201, now should render the summary page with widgets and the privilege-context buttons enabled per ACL.