### PR TITLE
fix(code-system-summary): restore MarinPageLayoutModule import for <m-title>

### DIFF
--- a/app/src/app/resources/code-system/containers/summary/code-system-summary.component.ts
+++ b/app/src/app/resources/code-system/containers/summary/code-system-summary.component.ts
@@ -7,7 +7,7 @@ import {CodeSystemUnlinkedConceptsComponent} from 'term-web/resources/code-syste
 import {CodeSystemService} from 'term-web/resources/code-system/services/code-system.service';
 import {ResourceTasksWidgetComponent} from 'term-web/resources/resource/components/resource-tasks-widget.component';
 import { ResourceContextComponent } from 'term-web/resources/resource/components/resource-context.component';
-import { MuiFormModule, MuiCardModule, MuiButtonModule, MuiIconModule, MuiDividerModule, MuiDropdownModule, MuiCoreModule, MuiListModule } from '@termx-health/ui';
+import { MarinPageLayoutModule, MuiFormModule, MuiCardModule, MuiButtonModule, MuiIconModule, MuiDividerModule, MuiDropdownModule, MuiCoreModule, MuiListModule } from '@termx-health/ui';
 import { PrivilegeContextDirective } from 'term-web/core/auth/privileges/privilege-context.directive';
 import { CodeSystemInfoWidgetComponent } from 'term-web/resources/code-system/containers/summary/widgets/code-system-info-widget.component';
 import { PrivilegedDirective } from 'term-web/core/auth/privileges/privileged.directive';
@@ -21,7 +21,9 @@ import { TranslatePipe } from '@ngx-translate/core';
 
 @Component({
     templateUrl: 'code-system-summary.component.html',
-    imports: [ResourceContextComponent, PrivilegeContextDirective, MuiFormModule, MuiCardModule, CodeSystemInfoWidgetComponent, MuiButtonModule, RouterLink, MuiIconModule, PrivilegedDirective, MuiDividerModule, CodeSystemVersionsWidgetComponent, MuiDropdownModule, MuiCoreModule, MuiListModule, CodeSystemUnlinkedConceptsComponent_1, ResourceTasksWidgetComponent_1, ResourceRelatedArtifactWidgetComponent, ResourceTaskModalComponent, TranslatePipe, FilterPipe]
+    // MarinPageLayoutModule kept in imports even though <m-page> is no longer used:
+    // the same module re-exports <m-title> and other primitives this template depends on.
+    imports: [ResourceContextComponent, MarinPageLayoutModule, PrivilegeContextDirective, MuiFormModule, MuiCardModule, CodeSystemInfoWidgetComponent, MuiButtonModule, RouterLink, MuiIconModule, PrivilegedDirective, MuiDividerModule, CodeSystemVersionsWidgetComponent, MuiDropdownModule, MuiCoreModule, MuiListModule, CodeSystemUnlinkedConceptsComponent_1, ResourceTasksWidgetComponent_1, ResourceRelatedArtifactWidgetComponent, ResourceTaskModalComponent, TranslatePipe, FilterPipe]
 })
 export class CodeSystemSummaryComponent implements OnInit {
   private route = inject(ActivatedRoute);


### PR DESCRIPTION
Hotfix — PR #80 over-trimmed the @Component.imports list. <m-title> (used 8x in the template) comes from MarinPageLayoutModule, so removing the module broke the build with NG8001. Keep the module in imports; only the template change (drop <m-page> wrapper) is needed.