### PR TITLE
chore(app): drop unused NgTemplateOutlet from AppComponent imports

### DIFF
--- a/app/src/app/app.component.ts
+++ b/app/src/app/app.component.ts
@@ -9,7 +9,7 @@ import {environment} from 'environments/environment';
 import {delay, distinctUntilChanged, filter, map, pairwise, startWith, switchMap} from 'rxjs';
 import {AuthService, HasAnyPrivilegePipe} from 'term-web/core/auth';
 import {InfoService} from 'term-web/core/info';
-import { AsyncPipe, KeyValuePipe, NgTemplateOutlet } from '@angular/common';
+import { AsyncPipe, KeyValuePipe } from '@angular/common';
 import { NoPrivilegeComponent } from 'term-web/core/components/no-privilege';
 
 
@@ -27,7 +27,7 @@ const getRouteLastChild = (snap: ActivatedRouteSnapshot): ActivatedRouteSnapshot
 @Component({
     templateUrl: 'app.component.html',
     styleUrls: ['app.component.less'],
-    imports: [MarinPageLayoutModule, MuiCoreModule, RouterLink, MuiFormModule, RouterOutlet, NoPrivilegeComponent, AsyncPipe, KeyValuePipe, NgTemplateOutlet, TranslatePipe, HasAnyPrivilegePipe, ApplyPipe]
+    imports: [MarinPageLayoutModule, MuiCoreModule, RouterLink, MuiFormModule, RouterOutlet, NoPrivilegeComponent, AsyncPipe, KeyValuePipe, TranslatePipe, HasAnyPrivilegePipe, ApplyPipe]
 })
 export class AppComponent {
   protected auth = inject(AuthService);


### PR DESCRIPTION
Cleanup after PR #82 — `[ngTemplateOutlet]` was removed from the template, so the `NgTemplateOutlet` import + imports-array entry are dead. Removing them clears the NG8113 warning ng serve emits on every rebuild. No functional change.