### PR TITLE
chore(resources): pin ?_summary=false on the three open-in-FHIR list links

### DIFF
--- a/app/src/app/resources/code-system/containers/list/code-system-list.component.ts
+++ b/app/src/app/resources/code-system/containers/list/code-system-list.component.ts
@@ -113,7 +113,12 @@ export class CodeSystemListComponent implements OnInit {
   }
 
   protected openFhir(id: string): void {
-    window.open(`${window.location.origin + environment.baseHref}fhir/CodeSystem/${id}`, '_blank');
+    // Explicit ?_summary=false: ensures the opened tab shows the FULL FHIR CodeSystem
+    // body — including concept[], filter[], property[], text — rather than the lightweight
+    // representation a server might default to. Read defaults to full today, but pinning
+    // it here keeps the "Show FHIR" action self-documenting and stable against future
+    // server-side default changes.
+    window.open(`${window.location.origin + environment.baseHref}fhir/CodeSystem/${id}?_summary=false`, '_blank');
   }
 
 

--- a/app/src/app/resources/map-set/containers/list/map-set-list.component.ts
+++ b/app/src/app/resources/map-set/containers/list/map-set-list.component.ts
@@ -102,7 +102,9 @@ export class MapSetListComponent implements OnInit {
   // events
 
   protected openFhir(id: string): void {
-    window.open(`${window.location.origin + environment.baseHref}fhir/ConceptMap/${id}`, '_blank');
+    // Explicit ?_summary=false: keep all group.element[] association rows in the opened
+    // tab. Same self-documenting pattern as the CodeSystem and ValueSet list pages.
+    window.open(`${window.location.origin + environment.baseHref}fhir/ConceptMap/${id}?_summary=false`, '_blank');
   }
 
   protected deleteMapSet(mapSetId: string): void {

--- a/app/src/app/resources/value-set/containers/list/value-set-list.component.ts
+++ b/app/src/app/resources/value-set/containers/list/value-set-list.component.ts
@@ -136,7 +136,10 @@ export class ValueSetListComponent implements OnInit {
   }
 
   protected openFhir(id: string): void {
-    window.open(`${window.location.origin + environment.baseHref}fhir/ValueSet/${id}`, '_blank');
+    // Explicit ?_summary=false: keep compose.include with its inline concept[] entries
+    // and any rule.concepts arrays in the opened tab. Same self-documenting pattern as
+    // the CodeSystem and ConceptMap list pages.
+    window.open(`${window.location.origin + environment.baseHref}fhir/ValueSet/${id}?_summary=false`, '_blank');
   }
 
 


### PR DESCRIPTION
The CS / VS / CM list pages each have an "Open in FHIR" action that opens a new tab with the raw FHIR resource. The URL was relying on the server's default read behaviour to return the full body. Append `?_summary=false` explicitly so the link is self-documenting and stable against future server-side default changes.

- CodeSystem list — keeps `concept[]`, `filter[]`, `property[]`, `text` in the opened tab
- ValueSet list — keeps `compose.include` with inline concepts; after termx-server [#144](https://github.com/termx-health/termx-server/pull/144) also emits `expansion.total` when a snapshot is saved (no `expansion.contains`)
- ConceptMap list — keeps all `group.element[]` association rows

No functional change against today's defaults.