### PR TITLE
Revert PR #85: open-in-FHIR list links don't need ?_summary=false

### DIFF
--- a/app/src/app/resources/code-system/containers/list/code-system-list.component.ts
+++ b/app/src/app/resources/code-system/containers/list/code-system-list.component.ts
@@ -113,12 +113,7 @@ export class CodeSystemListComponent implements OnInit {
   }
 
   protected openFhir(id: string): void {
-    // Explicit ?_summary=false: ensures the opened tab shows the FULL FHIR CodeSystem
-    // body — including concept[], filter[], property[], text — rather than the lightweight
-    // representation a server might default to. Read defaults to full today, but pinning
-    // it here keeps the "Show FHIR" action self-documenting and stable against future
-    // server-side default changes.
-    window.open(`${window.location.origin + environment.baseHref}fhir/CodeSystem/${id}?_summary=false`, '_blank');
+    window.open(`${window.location.origin + environment.baseHref}fhir/CodeSystem/${id}`, '_blank');
   }
 
 

--- a/app/src/app/resources/map-set/containers/list/map-set-list.component.ts
+++ b/app/src/app/resources/map-set/containers/list/map-set-list.component.ts
@@ -102,9 +102,7 @@ export class MapSetListComponent implements OnInit {
   // events
 
   protected openFhir(id: string): void {
-    // Explicit ?_summary=false: keep all group.element[] association rows in the opened
-    // tab. Same self-documenting pattern as the CodeSystem and ValueSet list pages.
-    window.open(`${window.location.origin + environment.baseHref}fhir/ConceptMap/${id}?_summary=false`, '_blank');
+    window.open(`${window.location.origin + environment.baseHref}fhir/ConceptMap/${id}`, '_blank');
   }
 
   protected deleteMapSet(mapSetId: string): void {

--- a/app/src/app/resources/value-set/containers/list/value-set-list.component.ts
+++ b/app/src/app/resources/value-set/containers/list/value-set-list.component.ts
@@ -136,10 +136,7 @@ export class ValueSetListComponent implements OnInit {
   }
 
   protected openFhir(id: string): void {
-    // Explicit ?_summary=false: keep compose.include with its inline concept[] entries
-    // and any rule.concepts arrays in the opened tab. Same self-documenting pattern as
-    // the CodeSystem and ConceptMap list pages.
-    window.open(`${window.location.origin + environment.baseHref}fhir/ValueSet/${id}?_summary=false`, '_blank');
+    window.open(`${window.location.origin + environment.baseHref}fhir/ValueSet/${id}`, '_blank');
   }
 
 


### PR DESCRIPTION
Revert of [#85](https://github.com/termx-health/termx-web/pull/85). The original ask to append `?_summary=false` to the CS / VS / CM open-in-FHIR list links was wrong — those links should keep using the server's default read behaviour (no `_summary` parameter), which matches FHIR's spec default for read.

Server-side support from [termx-server #144](https://github.com/termx-health/termx-server/pull/144) is unaffected and still in place: when a ValueSet has a saved snapshot, the read response carries `expansion.total` (no `expansion.contains`) regardless of whether the URL has `?_summary=...`.