### PR TITLE
Add property value extension display and editing

### DIFF
--- a/app/src/app/core/ui/components/inputs/property-value-input/entity-property-value-input.component.html
+++ b/app/src/app/core/ui/components/inputs/property-value-input/entity-property-value-input.component.html
@@ -89,21 +89,54 @@
           }
         }
       }
+      @if (propertyValue && extensionsVisible) {
+        <div class="extension-editor">
+          <m-button mDisplay="text" mShape="circle" m-tooltip mTitle="core.btn.add" (mClick)="addExtension()">
+            <m-icon mCode="plus"/>
+          </m-button>
+          @for (extension of extensionList(); track extension; let i = $index) {
+            <div class="extension-editor__row">
+              <m-textarea
+                  name="extensionUrl{{i}}"
+                  placeholder="URL"
+                  [(ngModel)]="extension.url"
+                  (ngModelChange)="fireOnChange()"></m-textarea>
+              <m-textarea
+                  name="extensionValue{{i}}"
+                  placeholder="Value"
+                  [(ngModel)]="extension.valueString"
+                  (ngModelChange)="fireOnChange()"></m-textarea>
+              <m-button mDisplay="text" mShape="circle" m-tooltip mTitle="core.btn.delete" (mClick)="removeExtension(i)">
+                <m-icon mCode="close"/>
+              </m-button>
+            </div>
+          }
+        </div>
+      }
     }
 
     @if (viewMode) {
       <div style="word-break: break-word">
+        <ng-template #extensionTooltip>
+          <div class="extension-tooltip">
+            @for (extension of propertyValue?.extensions; track extension) {
+              <div>{{ extension.url }}: {{ extension | apply:extensionValue }}</div>
+            }
+          </div>
+        </ng-template>
         @if (['string', 'decimal', 'integer', undefined, null] | includes:property?.type) {
-          <label>{{ value }}</label>
+          <label [mTooltip]="!!propertyValue?.extensions?.length" [mTitle]="extensionTooltip">{{ value }}</label>
         }
         @if ('boolean' === property?.type) {
-          <m-checkbox [ngModel]="value" name="value" readOnly></m-checkbox>
+          <span [mTooltip]="!!propertyValue?.extensions?.length" [mTitle]="extensionTooltip">
+            <m-checkbox [ngModel]="value" name="value" readOnly></m-checkbox>
+          </span>
         }
         @if ('dateTime' === property?.type) {
-          <label>{{ value | localDate }}</label>
+          <label [mTooltip]="!!propertyValue?.extensions?.length" [mTitle]="extensionTooltip">{{ value | localDate }}</label>
         }
         @if ('code' === property?.type) {
-          <label>{{ value | localizedConceptName: {codeSystem: codeSystem} | async }}</label>
+          <label [mTooltip]="!!propertyValue?.extensions?.length" [mTitle]="extensionTooltip">{{ value | localizedConceptName: {codeSystem: codeSystem} | async }}</label>
         }
         @if ('Coding' === property?.type) {
           <span [class.coding-compact-view]="compact" class="m-items-middle" [style.gap]="compact ? '0.15rem' : '0.5rem'">

--- a/app/src/app/core/ui/components/inputs/property-value-input/entity-property-value-input.component.ts
+++ b/app/src/app/core/ui/components/inputs/property-value-input/entity-property-value-input.component.ts
@@ -1,8 +1,8 @@
 import {Component, DoCheck, forwardRef, Input, OnChanges, SimpleChanges, ViewChild, inject} from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR, NgForm, FormsModule } from '@angular/forms';
 import { BooleanInput, DestroyService, isDefined, validateForm, ApplyPipe, IncludesPipe, LocalDatePipe, ToBooleanPipe } from '@termx-health/core-util';
-import {EntityProperty} from 'term-web/resources/_lib';
-import { MuiFormModule, MuiTextareaModule, MuiCheckboxModule, MuiDatePickerModule, MuiNumberInputModule, MuiSelectModule, MuiTooltipModule } from '@termx-health/ui';
+import {EntityProperty, EntityPropertyValue, EntityPropertyValueExtension} from 'term-web/resources/_lib';
+import { MuiFormModule, MuiTextareaModule, MuiCheckboxModule, MuiDatePickerModule, MuiNumberInputModule, MuiSelectModule, MuiTooltipModule, MuiButtonModule, MuiIconModule } from '@termx-health/ui';
 import { AsyncPipe } from '@angular/common';
 import { TerminologyConceptSearchComponent } from 'term-web/core/ui/components/inputs/terminology-concept-select/terminology-concept-search.component';
 import { CodeSystemSearchComponent } from 'term-web/resources/_lib/code-system/containers/code-system-search.component';
@@ -23,12 +23,32 @@ import { environment } from 'environments/environment';
         flex-wrap: wrap;
         max-width: 100%;
       }
+
+      .extension-tooltip {
+        display: grid;
+        gap: 0.25rem;
+        max-width: 36rem;
+        word-break: break-word;
+      }
+
+      .extension-editor {
+        display: grid;
+        gap: 0.5rem;
+        margin-top: 0.5rem;
+      }
+
+      .extension-editor__row {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) auto;
+        gap: 0.5rem;
+        align-items: start;
+      }
     `],
     providers: [
         { provide: NG_VALUE_ACCESSOR, useExisting: forwardRef(() => EntityPropertyValueInputComponent), multi: true },
         DestroyService
     ],
-    imports: [FormsModule, MuiFormModule, MuiTextareaModule, MuiCheckboxModule, MuiDatePickerModule, MuiNumberInputModule, TerminologyConceptSearchComponent, CodeSystemSearchComponent, MuiSelectModule, ValueSetConceptSelectComponent, MuiTooltipModule, AsyncPipe, ApplyPipe, IncludesPipe, LocalDatePipe, ToBooleanPipe, LocalizedConceptNamePipe]
+    imports: [FormsModule, MuiFormModule, MuiTextareaModule, MuiCheckboxModule, MuiDatePickerModule, MuiNumberInputModule, TerminologyConceptSearchComponent, CodeSystemSearchComponent, MuiSelectModule, ValueSetConceptSelectComponent, MuiTooltipModule, MuiButtonModule, MuiIconModule, AsyncPipe, ApplyPipe, IncludesPipe, LocalDatePipe, ToBooleanPipe, LocalizedConceptNamePipe]
 })
 export class EntityPropertyValueInputComponent implements OnChanges, DoCheck, ControlValueAccessor {
   private codingReferenceService = inject(CodeSystemCodingReferenceService);
@@ -40,6 +60,8 @@ export class EntityPropertyValueInputComponent implements OnChanges, DoCheck, Co
   @Input() @BooleanInput() public compact: boolean | string = false;
   @Input() public codeSystem?: string;
   @Input() public property?: EntityProperty;
+  @Input() public propertyValue?: EntityPropertyValue;
+  @Input() @BooleanInput() public extensionsVisible: boolean | string = false;
 
   @ViewChild("form") public form?: NgForm;
 
@@ -101,6 +123,37 @@ export class EntityPropertyValueInputComponent implements OnChanges, DoCheck, Co
       ?.map(f => (f.property?.name || f.association) + '|' + (f.value?.code || f.value))
       .join(';');
   };
+
+  protected extensionValue(extension: EntityPropertyValueExtension): string {
+    return [
+      extension.valueString,
+      extension.valueCode,
+      extension.valueDateTime,
+      extension.valueInteger,
+      extension.valueDecimal,
+      extension.valueBoolean
+    ].find(isDefined)?.toString() ?? '';
+  }
+
+  protected extensionList(): EntityPropertyValueExtension[] {
+    return this.propertyValue?.extensions ?? [];
+  }
+
+  protected addExtension(): void {
+    if (!this.propertyValue) {
+      return;
+    }
+    this.propertyValue.extensions = [...this.propertyValue.extensions || [], {}];
+    this.fireOnChange();
+  }
+
+  protected removeExtension(index: number): void {
+    if (!this.propertyValue) {
+      return;
+    }
+    this.propertyValue.extensions = this.propertyValue.extensions?.filter((_, i) => i !== index) || [];
+    this.fireOnChange();
+  }
 
   private prepareValue(property: EntityProperty): void {
     if (property?.type === 'Coding') {

--- a/app/src/app/resources/_lib/code-system/model/entity-property.ts
+++ b/app/src/app/resources/_lib/code-system/model/entity-property.ts
@@ -14,8 +14,19 @@ export class EntityProperty extends DefinedProperty {
 export class EntityPropertyValue {
   public id?: number;
   public value?: any;
+  public extensions?: EntityPropertyValueExtension[];
   public entityPropertyId?: number;
   public entityProperty?: string;
 
   public supplement?: boolean;
+}
+
+export class EntityPropertyValueExtension {
+  public url?: string;
+  public valueString?: string;
+  public valueBoolean?: boolean;
+  public valueDecimal?: number;
+  public valueInteger?: number;
+  public valueDateTime?: string;
+  public valueCode?: string;
 }

--- a/app/src/app/resources/code-system/containers/concepts/code-system-concepts-property-view.component.html
+++ b/app/src/app/resources/code-system/containers/concepts/code-system-concepts-property-view.component.html
@@ -87,6 +87,7 @@
                     viewMode
                     name="value" [ngModel]="property.value"
                     [property]="property.entityPropertyId | apply:getProperty:codeSystem.properties"
+                    [propertyValue]="property"
                   [codeSystem]="codeSystem.id"></tw-property-value-input>
                 }
               </div>
@@ -102,5 +103,4 @@
     </div>
   </div>
 </m-page>
-
 

--- a/app/src/app/resources/code-system/containers/concepts/edit/code-system-concept-edit.component.html
+++ b/app/src/app/resources/code-system/containers/concepts/edit/code-system-concept-edit.component.html
@@ -226,14 +226,21 @@ mode="concept-edit"></tw-resource-context>
           <m-card class="m-card-inside">
             <m-title *m-card-header mTitle="entities.code-system-entity-version.property-values">
               @if (codeSystem && conceptVersion?.status === 'draft') {
-                <m-dropdown mControls>
-                  <tw-add-button *m-dropdown-container>
-                    {{ 'web.code-system-concept-version.property-value.add-property-value' | translate }}
-                  </tw-add-button>
-                  @for (prop of codeSystem.properties | filter: filterProperties: 'property'; track prop) {
-                    <a *m-dropdown-item (mClick)="addPropertyValue(prop)">{{ prop.name }}</a>
-                  }
-                </m-dropdown>
+                <div class="m-items-middle" mControls>
+                  <m-dropdown>
+                    <tw-add-button *m-dropdown-container>
+                      {{ 'web.code-system-concept-version.property-value.add-property-value' | translate }}
+                    </tw-add-button>
+                    @for (prop of codeSystem.properties | filter: filterProperties: 'property'; track prop) {
+                      <a *m-dropdown-item (mClick)="addPropertyValue(prop)">{{ prop.name }}</a>
+                    }
+                  </m-dropdown>
+                  <m-checkbox
+                      name="propertyValueExtensionsVisible"
+                      [(ngModel)]="propertyValueExtensionsVisible">
+                    {{ 'web.code-system-concept-version.property-value.edit-composite-values' | translate }}
+                  </m-checkbox>
+                </div>
               }
             </m-title>
             <tw-code-system-property-value-edit #propertyValueEdit
@@ -241,6 +248,7 @@ mode="concept-edit"></tw-resource-context>
               [properties]="codeSystem?.properties"
               [propertyValues]="conceptVersion?.propertyValues"
               [showCodingReference]="true"
+              [extensionsVisible]="propertyValueExtensionsVisible"
             [viewMode]="conceptVersion?.status !== 'draft'"></tw-code-system-property-value-edit>
           </m-card>
           <!-- Associations -->

--- a/app/src/app/resources/code-system/containers/concepts/edit/code-system-concept-edit.component.ts
+++ b/app/src/app/resources/code-system/containers/concepts/edit/code-system-concept-edit.component.ts
@@ -24,7 +24,7 @@ import {CodeSystemDesignationEditComponent} from 'term-web/resources/code-system
 import {CodeSystemPropertyValueEditComponent} from 'term-web/resources/code-system/containers/concepts/edit/propertyvalue/code-system-property-value-edit.component';
 import {CodingRefreshApi, CodingRefreshScope, CodingValueRefreshModalComponent} from 'term-web/resources/code-system/components/coding-value-refresh-modal.component';
 import { ResourceContextComponent as ResourceContextComponent_1 } from 'term-web/resources/resource/components/resource-context.component';
-import { MarinPageLayoutModule, MuiCardModule, MuiDropdownModule, MuiCoreModule, MuiPopconfirmModule, MuiFormModule, MuiInputModule, MuiTextareaModule, MuiListModule, MuiDividerModule, MuiIconModule, MuiTooltipModule, MuiButtonModule, MuiTagModule, MuiModalModule } from '@termx-health/ui';
+import { MarinPageLayoutModule, MuiCardModule, MuiDropdownModule, MuiCoreModule, MuiPopconfirmModule, MuiFormModule, MuiInputModule, MuiTextareaModule, MuiListModule, MuiDividerModule, MuiIconModule, MuiTooltipModule, MuiButtonModule, MuiTagModule, MuiModalModule, MuiCheckboxModule } from '@termx-health/ui';
 import { SequenceValueGeneratorComponent } from 'term-web/sequence/_lib/components/sequence-value-generator.component';
 import { AddButtonComponent } from 'term-web/core/ui/components/add-button/add-button.component';
 import { StatusTagComponent } from 'term-web/core/ui/components/publication-status-tag/status-tag.component';
@@ -50,7 +50,7 @@ import { PrivilegedPipe } from 'term-web/core/auth/privileges/privileged.pipe';
       margin-top: 1rem
     }
   `],
-    imports: [ResourceContextComponent_1, MarinPageLayoutModule, MuiCardModule, MuiDropdownModule, MuiCoreModule, MuiPopconfirmModule, FormsModule, MuiFormModule, MuiInputModule, AutofocusDirective, SequenceValueGeneratorComponent, MuiTextareaModule, AddButtonComponent, MuiListModule, MuiDividerModule, StatusTagComponent, MuiIconModule, MuiTooltipModule, ResourceRelatedArtifactWidgetComponent, PrivilegedDirective, MuiButtonModule, ResourceTasksWidgetComponent_1, MuiTagModule, CodeSystemDesignationEditComponent, CodeSystemPropertyValueEditComponent, CodeSystemAssociationEditComponent, CodeSystemConceptReferenceComponent, CodingValueRefreshModalComponent, MuiModalModule, UserSelectComponent, TranslatePipe, MarinaUtilModule, FilterPipe, LocalDatePipe, LocalDateTimePipe, ToStringPipe, PrivilegedPipe]
+    imports: [ResourceContextComponent_1, MarinPageLayoutModule, MuiCardModule, MuiDropdownModule, MuiCoreModule, MuiPopconfirmModule, FormsModule, MuiFormModule, MuiInputModule, AutofocusDirective, SequenceValueGeneratorComponent, MuiTextareaModule, AddButtonComponent, MuiListModule, MuiDividerModule, StatusTagComponent, MuiIconModule, MuiTooltipModule, ResourceRelatedArtifactWidgetComponent, PrivilegedDirective, MuiButtonModule, MuiCheckboxModule, ResourceTasksWidgetComponent_1, MuiTagModule, CodeSystemDesignationEditComponent, CodeSystemPropertyValueEditComponent, CodeSystemAssociationEditComponent, CodeSystemConceptReferenceComponent, CodingValueRefreshModalComponent, MuiModalModule, UserSelectComponent, TranslatePipe, MarinaUtilModule, FilterPipe, LocalDatePipe, LocalDateTimePipe, ToStringPipe, PrivilegedPipe]
 })
 export class CodeSystemConceptEditComponent implements OnInit {
   private codeSystemService = inject(CodeSystemService);
@@ -70,6 +70,7 @@ export class CodeSystemConceptEditComponent implements OnInit {
   protected loader = new LoadingManager();
   public mode: 'add' | 'edit' = 'add';
   protected showOnlyOpenedTasks: boolean = true;
+  protected propertyValueExtensionsVisible = false;
 
   protected taskModalData: {visible?: boolean, assignee?: string, comment?: string} = {};
   @ViewChild("taskModalForm") public taskModalForm?: NgForm;

--- a/app/src/app/resources/code-system/containers/concepts/edit/propertyvalue/code-system-property-value-edit.component.html
+++ b/app/src/app/resources/code-system/containers/concepts/edit/propertyvalue/code-system-property-value-edit.component.html
@@ -18,10 +18,12 @@
                   <tw-property-value-input name="{{pv._key}}-propertyValue"
                     [(ngModel)]="pv.value"
                     [property]="pv.entityPropertyId | apply:getProperty:properties"
+                    [propertyValue]="pv"
                     [codeSystem]="codeSystemId"
                     [required]="(pv._key | apply:isRequired:properties)"
                     [showCodingReference]="showCodingReference"
                     [compact]="compact"
+                    [extensionsVisible]="extensionsVisible"
                   [viewMode]="pv.supplement"></tw-property-value-input>
                 </m-form-item>
               }
@@ -56,6 +58,7 @@
             <tw-property-value-input
               name="value" [ngModel]="pv.value"
               [property]="pv.entityPropertyId | apply: getProperty: properties"
+              [propertyValue]="pv"
               [codeSystem]="codeSystemId"
               [showCodingReference]="showCodingReference"
               [compact]="compact"

--- a/app/src/app/resources/code-system/containers/concepts/edit/propertyvalue/code-system-property-value-edit.component.ts
+++ b/app/src/app/resources/code-system/containers/concepts/edit/propertyvalue/code-system-property-value-edit.component.ts
@@ -54,6 +54,7 @@ export class CodeSystemPropertyValueEditComponent implements OnChanges {
   @Input() @BooleanInput() public viewMode: boolean | string = false;
   @Input() @BooleanInput() public showCodingReference: boolean | string = false;
   @Input() @BooleanInput() public compact: boolean | string = false;
+  @Input() @BooleanInput() public extensionsVisible: boolean | string = false;
   @Input() public propertyValues?: ExtendedEntityPropertyValue[];
   @Input() public properties?: EntityProperty[];
   @Input() public codeSystemId?: string;

--- a/app/src/app/resources/code-system/containers/concepts/list/code-system-concepts-list.component.html
+++ b/app/src/app/resources/code-system/containers/concepts/list/code-system-concepts-list.component.html
@@ -289,6 +289,7 @@
                   viewMode
                   name="value" [ngModel]="property.value"
                   [property]="property.entityPropertyId | apply:getProperty:codeSystem.properties"
+                  [propertyValue]="property"
                   [codeSystem]="codeSystem.id"
                 ></tw-property-value-input>
               </div>

--- a/app/src/assets/i18n/en.json
+++ b/app/src/assets/i18n/en.json
@@ -1222,6 +1222,7 @@
 				"add-supplement": "",
 				"coding-value-system": "",
 				"delete-property-value": "",
+				"edit-composite-values": "Edit extensions",
 				"edit-property-value": ""
 			}
 		},

--- a/app/src/assets/i18n/et.json
+++ b/app/src/assets/i18n/et.json
@@ -1091,6 +1091,7 @@
 				"add-supplement": "Lisa supplement",
 				"coding-value-system": "Coding väärtuse koodisüsteem",
 				"delete-property-value": "Kustuta tunnuse väärtus",
+				"edit-composite-values": "Muuda laiendusi",
 				"edit-property-value": "Muuda tunnuse väärtus"
 			}
 		},

--- a/app/src/assets/i18n/lt.json
+++ b/app/src/assets/i18n/lt.json
@@ -1180,6 +1180,7 @@
         "add-supplement": "Pridėti papildymą",
         "coding-value-system": "Kodo reikšmių sistema",
         "delete-property-value": "Pašalinti savybę",
+        "edit-composite-values": "Redaguoti plėtinius",
         "edit-property-value": "Redaguoti savybę"
       }
     },


### PR DESCRIPTION
Show entity property value extensions in view-mode tooltips for non-Coding values, and add edit-mode controls for managing extension url/valueString pairs from concept property values.