### PR TITLE
Refactor FHIR operation forms and split them into an Operations menu

### DIFF
--- a/app/src/app/fhir/_lib/code-system/model/fhir-code-system-lookup.params.ts
+++ b/app/src/app/fhir/_lib/code-system/model/fhir-code-system-lookup.params.ts
@@ -4,4 +4,5 @@ export class FhirCodeSystemLookupParams {
   public version?: string;
   public date?: string;
   public properties?: string;
+  public displayLanguage?: string;
 }

--- a/app/src/app/fhir/_lib/code-system/services/fhir-code-system-lib.service.ts
+++ b/app/src/app/fhir/_lib/code-system/services/fhir-code-system-lib.service.ts
@@ -27,6 +27,10 @@ export class FhirCodeSystemLibService {
     return this.http.get<FhirParameters>(`${this.baseUrl}/$lookup`, {params: SearchHttpParams.build(params)});
   }
 
+  public lookupPost(params: FhirParameters): Observable<FhirParameters> {
+    return this.http.post<FhirParameters>(`${this.baseUrl}/$lookup`, {...params, resourceType: 'Parameters'});
+  }
+
   public validateCode(params: FhirCodeSystemValidateCodeParams): Observable<FhirParameters> {
     return this.http.get<FhirParameters>(`${this.baseUrl}/$validate-code`, {params: SearchHttpParams.build(params)});
   }

--- a/app/src/app/fhir/_lib/value-set/model/fhir-value-set-expand.params.ts
+++ b/app/src/app/fhir/_lib/value-set/model/fhir-value-set-expand.params.ts
@@ -1,4 +1,6 @@
 export class FhirValueSetExpandParams {
   public url?: string;
   public valueSetVersion?: string;
+  public includeDesignations?: boolean;
+  public displayLanguage?: string;
 }

--- a/app/src/app/integration/dashboard/integration-dashboard.component.html
+++ b/app/src/app/integration/dashboard/integration-dashboard.component.html
@@ -14,10 +14,6 @@
         <nz-collapse-panel nzHeader="CodeSystem">
           <div style="display: grid">
             <m-button mDisplay="link" [routerLink]="'./fhir/$sync'" *twPrivileged="'*.CodeSystem.write'" [queryParams]="{ source: 'CodeSystem'}">$sync</m-button>
-            <m-button mDisplay="link" [routerLink]="'./fhir/CodeSystem/$lookup'">$lookup</m-button>
-            <m-button mDisplay="link" [routerLink]="'./fhir/CodeSystem/$validate-code'">$validate-code</m-button>
-            <m-button mDisplay="link" [routerLink]="'./fhir/CodeSystem/$subsumes'">$subsumes</m-button>
-            <m-button mDisplay="link" [routerLink]="'./fhir/CodeSystem/$find-matches'">$find-matches</m-button>
           </div>
         </nz-collapse-panel>
       </nz-collapse>
@@ -26,8 +22,6 @@
         <nz-collapse-panel nzHeader="ValueSet">
           <div style="display: grid">
             <m-button mDisplay="link" [routerLink]="'./fhir/$sync'" *twPrivileged="'*.ValueSet.write'" [queryParams]="{ source: 'ValueSet'}">$sync</m-button>
-            <m-button mDisplay="link" [routerLink]="'./fhir/ValueSet/$expand'">$expand</m-button>
-            <m-button mDisplay="link" [routerLink]="'./fhir/ValueSet/$validate-code'">$validate-code</m-button>
           </div>
         </nz-collapse-panel>
       </nz-collapse>
@@ -36,8 +30,6 @@
         <nz-collapse-panel nzHeader="ConceptMap">
           <div style="display: grid">
             <m-button mDisplay="link" [routerLink]="'./fhir/$sync'" *twPrivileged="'*.MapSet.write'" [queryParams]="{ source: 'ConceptMap'}">$sync</m-button>
-            <m-button mDisplay="link" [routerLink]="'./fhir/ConceptMap/$translate'">$translate</m-button>
-            <m-button mDisplay="link" [routerLink]="'./fhir/ConceptMap/$closure'">$closure</m-button>
           </div>
         </nz-collapse-panel>
       </nz-collapse>

--- a/app/src/app/integration/fhir/code-system/fhir-code-system-find-matches.component.html
+++ b/app/src/app/integration/fhir/code-system/fhir-code-system-find-matches.component.html
@@ -6,55 +6,59 @@
         <nz-breadcrumb-item>CodeSystem</nz-breadcrumb-item>
         <nz-breadcrumb-item>$find-matches</nz-breadcrumb-item>
       </nz-breadcrumb>
-      <m-button mDisplay="primary" [disabled]="!data.system || !(data.properties?.length > 0)" (click)="findMatches()">{{'web.integration.send-request' | translate}}</m-button>
+      <m-button mDisplay="primary" [disabled]="!data.system" (click)="findMatches()">{{'web.integration.send-request' | translate}}</m-button>
     </div>
 
-    <m-form-item [mLabel]="system" required>
-      <ng-template #system>
-        <div>{{'web.integration.fhir.code-system.find-matches.system' | translate}}&nbsp;</div>
-        <m-icon mCode="info-circle" m-popover mContent="{{'web.integration.fhir.code-system.find-matches.system-tooltip' | translate}}"></m-icon>
-      </ng-template>
-      <m-textarea name="system" [(ngModel)]="data.system"></m-textarea>
+    <!-- System -->
+    <m-form-item mLabel="System" required>
+      <tw-code-system-search name="system" [(ngModel)]="codeSystem" (ngModelChange)="onSystemSelect($event)"></tw-code-system-search>
+      @if (data.system) {
+        <div style="margin-top: .25rem; color: var(--color-text-secondary, #888); word-break: break-all">{{data.system}}</div>
+      }
     </m-form-item>
 
-    <m-form-item [mLabel]="version">
-      <ng-template #version>
-        <div>{{'web.integration.fhir.code-system.find-matches.version' | translate}}&nbsp;</div>
-        <m-icon mCode="info-circle" m-popover mContent="{{'web.integration.fhir.code-system.find-matches.version-tooltip' | translate}}"></m-icon>
-      </ng-template>
-      <m-textarea name="version" [(ngModel)]="data.version"></m-textarea>
+    <!-- Version (optional) -->
+    <m-form-item mLabel="Version">
+      <tw-code-system-version-select name="version" valueType="full" [autoSelect]="false"
+        [codeSystemId]="codeSystem?.id" [disabled]="!codeSystem"
+        [(ngModel)]="versionObj" (ngModelChange)="onVersionSelect($event)"></tw-code-system-version-select>
     </m-form-item>
 
-    <m-form-item [mLabel]="properties" required>
-      <ng-template #properties>
-        <div>{{'web.integration.fhir.code-system.find-matches.properties' | translate}}&nbsp;</div>
-        <m-icon mCode="info-circle" m-popover mContent="{{'web.integration.fhir.code-system.find-matches.properties-tooltip' | translate}}"></m-icon>
-      </ng-template>
+    <!-- Exact -->
+    <m-form-item mLabel="Exact">
+      <m-checkbox name="exact" [(ngModel)]="data.exact"></m-checkbox>
+    </m-form-item>
+
+    <!-- Properties (name / value pairs to match on) -->
+    <m-form-item mLabel="Properties">
       <div class="m-items-middle">
-        <m-textarea name="propertyName" [(ngModel)]="propertyInput.propertyName" placeholder="web.integration.fhir.code-system.find-matches.property-name"></m-textarea>
-        <m-textarea name="propertyValue" [(ngModel)]="propertyInput.propertyValue" placeholder="web.integration.fhir.code-system.find-matches.property-value"></m-textarea>
+        <m-input name="propertyName" [(ngModel)]="propertyInput.propertyName" placeholder="property"></m-input>
+        <m-input name="propertyValue" [(ngModel)]="propertyInput.propertyValue" placeholder="value"></m-input>
         <m-button (click)="addProperty()">
-          <m-icon [mCode]="'plus'"></m-icon>
+          <m-icon mCode="plus"></m-icon>
         </m-button>
       </div>
     </m-form-item>
     @for (property of data.properties; track property; let index = $index) {
       <div style="display:flex">
-        <p>{{property.propertyName}} {{property.propertyValue}}</p>&nbsp;
+        <p>{{property.propertyName}} = {{property.propertyValue}}</p>&nbsp;
         <m-button mSize="small" (click)="removeProperty(index)">
           <m-icon [mCode]="'delete'"></m-icon>
         </m-button>
       </div>
     }
 
-    <m-form-item [mLabel]="exact">
-      <ng-template #exact>
-        <div>{{'web.integration.fhir.code-system.find-matches.exact' | translate}}&nbsp;</div>
-        <m-icon mCode="info-circle" m-popover mContent="{{'web.integration.fhir.code-system.find-matches.exact-tooltip' | translate}}"></m-icon>
-      </ng-template>
-      <m-checkbox name="exact" [(ngModel)]="data.exact"></m-checkbox>
+    <!-- Request command preview (POST body) -->
+    <m-form-item mLabel="Request command">
+      <div class="m-items-middle" style="align-items: flex-start">
+        <m-textarea name="command" [ngModel]="command" readonly style="flex: 1; font-family: monospace"></m-textarea>
+        <m-button (click)="copyCommand()">
+          <m-icon mCode="copy"></m-icon>
+        </m-button>
+      </div>
     </m-form-item>
 
+    <!-- Results -->
     @if (response || error) {
       <m-card class="m-card-inside">
         <div *m-card-header class="m-items-middle">

--- a/app/src/app/integration/fhir/code-system/fhir-code-system-find-matches.component.ts
+++ b/app/src/app/integration/fhir/code-system/fhir-code-system-find-matches.component.ts
@@ -1,31 +1,27 @@
 import {Clipboard} from '@angular/cdk/clipboard';
-import { Component, inject } from '@angular/core';
+import {Component, inject} from '@angular/core';
+import {environment} from 'environments/environment';
 import {FhirCodeSystemLibService, FhirParameters} from 'term-web/fhir/_lib';
-import { MuiCardModule, MuiSpinnerModule, MuiButtonModule, MuiFormModule, MuiIconModule, MuiPopoverModule, MuiTextareaModule, MuiCheckboxModule, MuiAlertModule } from '@termx-health/ui';
-import { NzBreadCrumbComponent, NzBreadCrumbItemComponent } from 'ng-zorro-antd/breadcrumb';
-import { FormsModule } from '@angular/forms';
-import { JsonPipe } from '@angular/common';
-import { TranslatePipe } from '@ngx-translate/core';
+import {CodeSystem} from 'term-web/resources/_lib/code-system/model/code-system';
+import {CodeSystemVersion} from 'term-web/resources/_lib/code-system/model/code-system-version';
+import {CodeSystemLibModule} from 'term-web/resources/_lib/code-system/code-system-lib.module';
+import {
+  MuiAlertModule, MuiButtonModule, MuiCardModule, MuiCheckboxModule, MuiFormModule, MuiIconModule,
+  MuiInputModule, MuiPopoverModule, MuiSpinnerModule, MuiTextareaModule
+} from '@termx-health/ui';
+import {NzBreadCrumbComponent, NzBreadCrumbItemComponent} from 'ng-zorro-antd/breadcrumb';
+import {FormsModule} from '@angular/forms';
+import {JsonPipe} from '@angular/common';
+import {TranslatePipe} from '@ngx-translate/core';
 
 
 @Component({
-    templateUrl: './fhir-code-system-find-matches.component.html',
-    imports: [
-    MuiCardModule,
-    MuiSpinnerModule,
-    NzBreadCrumbComponent,
-    NzBreadCrumbItemComponent,
-    MuiButtonModule,
-    MuiFormModule,
-    MuiIconModule,
-    MuiPopoverModule,
-    MuiTextareaModule,
-    FormsModule,
-    MuiCheckboxModule,
-    MuiAlertModule,
-    JsonPipe,
-    TranslatePipe
-],
+  templateUrl: './fhir-code-system-find-matches.component.html',
+  imports: [
+    MuiCardModule, MuiSpinnerModule, NzBreadCrumbComponent, NzBreadCrumbItemComponent, MuiButtonModule,
+    MuiFormModule, MuiIconModule, MuiPopoverModule, MuiInputModule, MuiCheckboxModule, MuiTextareaModule,
+    MuiAlertModule, FormsModule, JsonPipe, TranslatePipe, CodeSystemLibModule
+  ],
 })
 export class FhirCodeSystemFindMatchesComponent {
   private fhirCodeSystemLibService = inject(FhirCodeSystemLibService);
@@ -33,56 +29,52 @@ export class FhirCodeSystemFindMatchesComponent {
 
   public response?: any;
   public error?: any;
+  public loading = false;
 
+  public codeSystem?: CodeSystem;
+  public versionObj?: CodeSystemVersion;
   public data: {
     system?: string,
     version?: string,
     exact?: boolean,
     properties?: {propertyName?: string, propertyValue?: string}[]
   } = {};
-
   public propertyInput: {propertyName?: string, propertyValue?: string} = {};
 
-  public loading: boolean = false;
+  protected get baseUrl(): string {
+    return `${environment.termxApi}/fhir/CodeSystem`;
+  }
+
+  public onSystemSelect(cs: CodeSystem): void {
+    this.codeSystem = cs;
+    this.data.system = cs?.uri;
+    this.data.version = undefined;
+    this.versionObj = undefined;
+  }
+
+  public onVersionSelect(v: CodeSystemVersion): void {
+    this.versionObj = v;
+    // SNOMED needs the edition URI as the version (see $lookup); other code systems use the version string.
+    const isSnomed = this.data.system?.startsWith('http://snomed.info/sct');
+    this.data.version = (isSnomed && v?.uri) ? v.uri : v?.version;
+  }
+
+  public get command(): string {
+    return `POST ${this.baseUrl}/$find-matches\n` + JSON.stringify(this.buildParameters(), null, 2);
+  }
 
   public findMatches(): void {
-    const sp = new FhirParameters();
-    sp.parameter = [];
-    if (this.data.system) {
-      sp.parameter.push({name: 'system', valueString: this.data.system});
-    }
-    if (this.data.version) {
-      sp.parameter.push({name: 'version', valueString: this.data.version});
-    }
-    if (this.data.exact) {
-      sp.parameter.push({name: 'exact', valueBoolean: this.data.exact});
-    }
-    if (this.data.properties) {
-      this.data.properties.forEach(p => {
-        const parts = [];
-        if (p.propertyName) {
-          parts.push({name: 'code', valueCode: p.propertyName});
-        }
-        if (p.propertyValue) {
-          parts.push({name: 'value', valueString: p.propertyValue});
-        }
-        sp.parameter!.push({name: 'property', part: parts});
-      });
-    }
-
-
     this.loading = true;
     this.error = undefined;
     this.response = undefined;
-
-    this.fhirCodeSystemLibService.findMatches(sp).subscribe({
+    this.fhirCodeSystemLibService.findMatches(this.buildParameters()).subscribe({
       next: r => this.response = r,
       error: err => this.error = err.error
     }).add(() => this.loading = false);
   }
 
   public addProperty(): void {
-    if (this.propertyInput) {
+    if (this.propertyInput?.propertyName || this.propertyInput?.propertyValue) {
       this.data.properties = [...(this.data.properties || []), this.propertyInput];
       this.propertyInput = {};
     }
@@ -94,8 +86,36 @@ export class FhirCodeSystemFindMatchesComponent {
     if (this.data.properties.length === 0) { this.data.properties = undefined; }
   }
 
-
   public copyResult(): void {
     this.clipboardService.copy(JSON.stringify(this.response || this.error));
+  }
+
+  public copyCommand(): void {
+    this.clipboardService.copy(this.command);
+  }
+
+  private buildParameters(): FhirParameters {
+    const sp = new FhirParameters();
+    sp.parameter = [];
+    if (this.data.system) {
+      sp.parameter.push({name: 'system', valueString: this.data.system});
+    }
+    if (this.data.version) {
+      sp.parameter.push({name: 'version', valueString: this.data.version});
+    }
+    if (this.data.exact) {
+      sp.parameter.push({name: 'exact', valueBoolean: this.data.exact});
+    }
+    (this.data.properties || []).forEach(p => {
+      const parts = [];
+      if (p.propertyName) {
+        parts.push({name: 'code', valueCode: p.propertyName});
+      }
+      if (p.propertyValue) {
+        parts.push({name: 'value', valueString: p.propertyValue});
+      }
+      sp.parameter!.push({name: 'property', part: parts});
+    });
+    return sp;
   }
 }

--- a/app/src/app/integration/fhir/code-system/fhir-code-system-lookup.component.html
+++ b/app/src/app/integration/fhir/code-system/fhir-code-system-lookup.component.html
@@ -6,56 +6,68 @@
         <nz-breadcrumb-item>CodeSystem</nz-breadcrumb-item>
         <nz-breadcrumb-item>$lookup</nz-breadcrumb-item>
       </nz-breadcrumb>
-      <m-button mDisplay="primary" [disabled]="!data.code || !data.system" (click)="lookUp()">{{'web.integration.send-request' | translate}}</m-button>
+      <div class="m-items-middle" style="gap: .5rem">
+        <m-select name="method" [(ngModel)]="method" style="width: 7rem">
+          <m-option mValue="GET" mLabel="GET"></m-option>
+          <m-option mValue="POST" mLabel="POST"></m-option>
+        </m-select>
+        <m-button mDisplay="primary" [disabled]="!data.code || !data.system" (click)="lookUp()">{{'web.integration.send-request' | translate}}</m-button>
+      </div>
     </div>
 
-    <m-form-item [mLabel]="code" required>
-      <ng-template #code>
-        <div>{{'web.integration.fhir.code-system.lookup.code' | translate}}&nbsp;</div>
-        <m-icon mCode="info-circle" m-popover mContent="{{'web.integration.fhir.code-system.lookup.code-tooltip' | translate}}"></m-icon>
-      </ng-template>
-      <m-textarea name="code" [(ngModel)]="data.code"></m-textarea>
+    <!-- 1. System — select from CodeSystems; shows the canonical URL -->
+    <m-form-item mLabel="System" required>
+      <tw-code-system-search name="system" [(ngModel)]="codeSystem" (ngModelChange)="onSystemSelect($event)"></tw-code-system-search>
+      @if (data.system) {
+        <div style="margin-top: .25rem; color: var(--color-text-secondary, #888); word-break: break-all">{{data.system}}</div>
+      }
     </m-form-item>
 
-    <m-form-item [mLabel]="system" required>
-      <ng-template #system>
-        <div>{{'web.integration.fhir.code-system.lookup.system' | translate}}&nbsp;</div>
-        <m-icon mCode="info-circle" m-popover mContent="{{'web.integration.fhir.code-system.lookup.system-tooltip' | translate}}"></m-icon>
-      </ng-template>
-      <m-textarea name="system" [(ngModel)]="data.system"></m-textarea>
+    <!-- 2. Version — from the selected CodeSystem (optional) -->
+    <m-form-item mLabel="Version">
+      <tw-code-system-version-select name="version" valueType="full" [autoSelect]="false"
+        [codeSystemId]="codeSystem?.id" [disabled]="!codeSystem"
+        [(ngModel)]="versionObj" (ngModelChange)="onVersionSelect($event)"></tw-code-system-version-select>
     </m-form-item>
 
-    <m-form-item [mLabel]="version">
-      <ng-template #version>
-        <div>{{'web.integration.fhir.code-system.lookup.version' | translate}}&nbsp;</div>
-        <m-icon mCode="info-circle" m-popover mContent="{{'web.integration.fhir.code-system.lookup.version-tooltip' | translate}}"></m-icon>
-      </ng-template>
-      <m-textarea name="version" [(ngModel)]="data.version"></m-textarea>
+    <!-- 3. Code — free text + concept autocomplete from the selected CS/version -->
+    <m-form-item mLabel="Code" required>
+      <m-input name="code" [(ngModel)]="data.code" placeholder="Enter any code, or pick a concept below"></m-input>
+      @if (codeSystem) {
+        <div style="margin-top: .25rem">
+          <tw-concept-search name="codePick" valueType="code" displayType="codeName"
+            [codeSystem]="codeSystem.id" [codeSystemVersion]="data.version" [searchDebounce]="600"
+            [ngModel]="data.code" (ngModelChange)="data.code = $event"
+            placeholder="Search concept…"></tw-concept-search>
+        </div>
+      }
     </m-form-item>
 
-    <m-form-item [mLabel]="date">
-      <ng-template #date>
-        <div>{{'web.integration.fhir.code-system.lookup.date' | translate}}&nbsp;</div>
-        <m-icon mCode="info-circle" m-popover [mContent]="dateContent"></m-icon>
-        <ng-template #dateContent>
-          <span [innerHTML]="('web.integration.fhir.code-system.lookup.date-tooltip'| translate)"></span>
-        </ng-template>
-      </ng-template>
+    <!-- 4. Show designations -->
+    <m-form-item mLabel="Show designations">
+      <m-checkbox name="showDesignations" [(ngModel)]="data.showDesignations"></m-checkbox>
+    </m-form-item>
+
+    <!-- 5. Designation languages — any language selectable; the version's languages listed first -->
+    <m-form-item mLabel="Designation languages">
+      <m-select name="langs" [multiple]="true" [(ngModel)]="data.designationLanguages" placeholder="Languages">
+        @for (l of languageOptions; track l.code) {
+          <m-option [mValue]="l.code" [mLabel]="l.label"></m-option>
+        }
+      </m-select>
+    </m-form-item>
+
+    <!-- 6. Date -->
+    <m-form-item mLabel="Date">
       <m-date-picker name="date" [(ngModel)]="data.date"></m-date-picker>
     </m-form-item>
 
-    <m-form-item [mLabel]="properties">
-      <ng-template #properties>
-        <div>{{'web.integration.fhir.code-system.lookup.properties' | translate}}&nbsp;</div>
-        <m-icon mCode="info-circle" m-popover [mContent]="propertiesContent"></m-icon>
-        <ng-template #propertiesContent>
-          <span [innerHTML]="('web.integration.fhir.code-system.lookup.properties-tooltip' | translate)"></span>
-        </ng-template>
-      </ng-template>
+    <!-- 7. Properties -->
+    <m-form-item mLabel="Properties">
       <div class="m-items-middle">
-        <m-textarea name="propertyInput" [(ngModel)]="data.propertyInput"></m-textarea>
+        <m-input name="propertyInput" [(ngModel)]="data.propertyInput"></m-input>
         <m-button (click)="addProperty()">
-          <m-icon [mCode]="'plus'"></m-icon>
+          <m-icon mCode="plus"></m-icon>
         </m-button>
       </div>
     </m-form-item>
@@ -63,11 +75,22 @@
       <div style="display:flex">
         <p>{{property}}</p>&nbsp;
         <m-button mSize="small" (click)="removeProperty(index)">
-          <m-icon [mCode]="'delete'"></m-icon>
+          <m-icon mCode="delete"></m-icon>
         </m-button>
       </div>
     }
 
+    <!-- 8. Request command preview (GET / POST) -->
+    <m-form-item mLabel="Request command">
+      <div class="m-items-middle" style="align-items: flex-start">
+        <m-textarea name="command" [ngModel]="command" readonly style="flex: 1; font-family: monospace"></m-textarea>
+        <m-button (click)="copyCommand()">
+          <m-icon mCode="copy"></m-icon>
+        </m-button>
+      </div>
+    </m-form-item>
+
+    <!-- 9. Results -->
     @if (response || error) {
       <m-card class="m-card-inside">
         <div *m-card-header class="m-items-middle">

--- a/app/src/app/integration/fhir/code-system/fhir-code-system-lookup.component.ts
+++ b/app/src/app/integration/fhir/code-system/fhir-code-system-lookup.component.ts
@@ -1,17 +1,28 @@
 import {Clipboard} from '@angular/cdk/clipboard';
-import { Component, inject } from '@angular/core';
+import {Component, OnInit, inject} from '@angular/core';
 import {serializeDate} from '@termx-health/core-util';
+import {environment} from 'environments/environment';
 import {FhirCodeSystemLibService, FhirCodeSystemLookupParams} from 'term-web/fhir/_lib';
-import { MuiCardModule, MuiSpinnerModule, MuiButtonModule, MuiFormModule, MuiIconModule, MuiPopoverModule, MuiTextareaModule, MuiDatePickerModule, MuiAlertModule } from '@termx-health/ui';
-import { NzBreadCrumbComponent, NzBreadCrumbItemComponent } from 'ng-zorro-antd/breadcrumb';
-import { FormsModule } from '@angular/forms';
-import { JsonPipe } from '@angular/common';
-import { TranslatePipe } from '@ngx-translate/core';
+import {FhirParameters} from 'term-web/fhir/_lib/model/fhir-parameters';
+import {CodeSystem} from 'term-web/resources/_lib/code-system/model/code-system';
+import {CodeSystemVersion} from 'term-web/resources/_lib/code-system/model/code-system-version';
+import {CodeSystemLibModule} from 'term-web/resources/_lib/code-system/code-system-lib.module';
+import {VsConceptUtil} from 'term-web/resources/_lib';
+import {ValueSetLibService} from 'term-web/resources/_lib/value-set/services/value-set-lib.service';
+import {ValueSetVersionConcept} from 'term-web/resources/_lib/value-set/model/value-set-version-concept';
+import {
+  MuiAlertModule, MuiButtonModule, MuiCardModule, MuiCheckboxModule, MuiDatePickerModule, MuiFormModule,
+  MuiIconModule, MuiInputModule, MuiPopoverModule, MuiSelectModule, MuiSpinnerModule, MuiTextareaModule
+} from '@termx-health/ui';
+import {NzBreadCrumbComponent, NzBreadCrumbItemComponent} from 'ng-zorro-antd/breadcrumb';
+import {FormsModule} from '@angular/forms';
+import {JsonPipe} from '@angular/common';
+import {TranslatePipe, TranslateService} from '@ngx-translate/core';
 
 
 @Component({
-    templateUrl: './fhir-code-system-lookup.component.html',
-    imports: [
+  templateUrl: './fhir-code-system-lookup.component.html',
+  imports: [
     MuiCardModule,
     MuiSpinnerModule,
     NzBreadCrumbComponent,
@@ -21,44 +32,121 @@ import { TranslatePipe } from '@ngx-translate/core';
     MuiIconModule,
     MuiPopoverModule,
     MuiTextareaModule,
-    FormsModule,
+    MuiInputModule,
+    MuiSelectModule,
+    MuiCheckboxModule,
     MuiDatePickerModule,
     MuiAlertModule,
+    FormsModule,
     JsonPipe,
-    TranslatePipe
-],
+    TranslatePipe,
+    CodeSystemLibModule
+  ],
+  providers: [ValueSetLibService],
 })
-export class FhirCodeSystemLookupComponent {
+export class FhirCodeSystemLookupComponent implements OnInit {
   private fhirCodeSystemLibService = inject(FhirCodeSystemLibService);
+  private valueSetService = inject(ValueSetLibService);
+  private translate = inject(TranslateService);
   private clipboardService = inject(Clipboard);
+
+  /** All languages from the `languages` value set, keyed by code (for the designation-language picker). */
+  private languages: {[code: string]: ValueSetVersionConcept} = {};
+
+  public ngOnInit(): void {
+    this.valueSetService.expand({valueSet: 'languages'}).subscribe(concepts => {
+      concepts.forEach(c => {
+        if (c.concept?.code) { this.languages[c.concept.code] = c; }
+      });
+    });
+  }
 
   public response?: any;
   public error?: any;
+  public loading = false;
+
+  public method: 'GET' | 'POST' = 'GET';
+
+  /** Full objects from the pickers (drive url display + language list). */
+  public codeSystem?: CodeSystem;
+  public versionObj?: CodeSystemVersion;
 
   public data: {
-    code?: string,
     system?: string,
     version?: string,
+    code?: string,
+    showDesignations?: boolean,
+    designationLanguages?: string[],
     date?: Date,
     propertyInput?: string,
-    properties?: string[]
+    properties?: string[],
   } = {};
 
-  public loading: boolean = false;
+  protected get baseUrl(): string {
+    return `${environment.termxApi}/fhir/CodeSystem`;
+  }
+
+  /**
+   * Designation languages: ALL languages (from the `languages` value set) are selectable,
+   * but the selected version's supported languages are listed first (tagged "· version").
+   */
+  public get languageOptions(): {code: string, label: string}[] {
+    const lang = this.translate.currentLang;
+    const label = (code: string): string => {
+      const c = this.languages[code];
+      return c ? (VsConceptUtil.getDisplay(c, lang) || code) : code;
+    };
+    // Version's supported languages first (ordering only — no label decoration), then the rest A–Z.
+    const out: {code: string, label: string}[] = [];
+    const seen = new Set<string>();
+    (this.versionObj?.supportedLanguages || []).forEach(code => {
+      if (!seen.has(code)) { seen.add(code); out.push({code, label: label(code)}); }
+    });
+    Object.keys(this.languages)
+      .filter(code => !seen.has(code))
+      .map(code => ({code, label: label(code)}))
+      .sort((a, b) => a.label.localeCompare(b.label))
+      .forEach(o => out.push(o));
+    return out;
+  }
+
+  public onSystemSelect(cs: CodeSystem): void {
+    this.codeSystem = cs;
+    this.data.system = cs?.uri;
+    // Reset dependent fields — version/code/languages belong to the previous code system.
+    this.data.version = undefined;
+    this.versionObj = undefined;
+    this.data.code = undefined;
+    this.data.designationLanguages = undefined;
+  }
+
+  public onVersionSelect(v: CodeSystemVersion): void {
+    this.versionObj = v;
+    // For SNOMED the FHIR `version` must be the edition URI (http://snomed.info/sct/<module>[/version/<date>])
+    // so the server routes to the correct edition branch — the bare version string (module id) resolves to
+    // the International edition and edition-specific concepts come back "not found". Other code systems use
+    // their plain version string.
+    const isSnomed = this.data.system?.startsWith('http://snomed.info/sct');
+    this.data.version = (isSnomed && v?.uri) ? v.uri : v?.version;
+  }
+
+  /** GET-or-POST request preview shown in the command text area. */
+  public get command(): string {
+    if (this.method === 'POST') {
+      return `POST ${this.baseUrl}/$lookup\n` + JSON.stringify(this.buildParameters(), null, 2);
+    }
+    const q = this.buildQuery();
+    return `GET ${this.baseUrl}/$lookup${q ? '?' + q : ''}`;
+  }
 
   public lookUp(): void {
-    const sp = new FhirCodeSystemLookupParams();
-    sp.code = this.data.code || undefined;
-    sp.system = this.data.system || undefined;
-    sp.version = this.data.version || undefined;
-    sp.date = serializeDate(this.data.date);
-    sp.properties = this.data.properties?.join(',');
-
     this.loading = true;
     this.error = undefined;
     this.response = undefined;
-
-    this.fhirCodeSystemLibService.lookup(sp).subscribe({
+    const req = this.method === 'POST'
+      ? this.fhirCodeSystemLibService.lookupPost(this.buildParameters())
+      : this.fhirCodeSystemLibService.lookup(this.buildGetParams());
+    req.subscribe({
       next: r => this.response = r,
       error: err => this.error = err.error
     }).add(() => this.loading = false);
@@ -79,5 +167,51 @@ export class FhirCodeSystemLookupComponent {
 
   public copyResult(): void {
     this.clipboardService.copy(JSON.stringify(this.response || this.error));
+  }
+
+  public copyCommand(): void {
+    this.clipboardService.copy(this.command);
+  }
+
+  private collectProperties(): string[] {
+    const props = [...(this.data.properties || [])];
+    if (this.data.showDesignations && !props.includes('designation')) {
+      props.push('designation');
+    }
+    return props;
+  }
+
+  private buildGetParams(): FhirCodeSystemLookupParams {
+    const sp = new FhirCodeSystemLookupParams();
+    sp.system = this.data.system || undefined;
+    sp.version = this.data.version || undefined;
+    sp.code = this.data.code || undefined;
+    sp.date = serializeDate(this.data.date);
+    const props = this.collectProperties();
+    sp.properties = props.length ? props.join(',') : undefined;
+    sp.displayLanguage = this.data.designationLanguages?.length ? this.data.designationLanguages.join(',') : undefined;
+    return sp;
+  }
+
+  private buildQuery(): string {
+    const sp = this.buildGetParams() as Record<string, string | undefined>;
+    return Object.keys(sp)
+      .filter(k => sp[k] !== undefined && sp[k] !== null && sp[k] !== '')
+      .map(k => `${k}=${encodeURIComponent(sp[k]!)}`)
+      .join('&');
+  }
+
+  private buildParameters(): FhirParameters {
+    const p: FhirParameters = {resourceType: 'Parameters', parameter: []};
+    const add = (name: string, valueString?: string): void => {
+      if (valueString) { p.parameter!.push({name, valueString}); }
+    };
+    add('system', this.data.system);
+    add('version', this.data.version);
+    add('code', this.data.code);
+    add('date', serializeDate(this.data.date));
+    add('displayLanguage', this.data.designationLanguages?.length ? this.data.designationLanguages.join(',') : undefined);
+    this.collectProperties().forEach(pr => p.parameter!.push({name: 'property', valueString: pr}));
+    return p;
   }
 }

--- a/app/src/app/integration/fhir/code-system/fhir-code-system-subsumes.component.html
+++ b/app/src/app/integration/fhir/code-system/fhir-code-system-subsumes.component.html
@@ -6,41 +6,61 @@
         <nz-breadcrumb-item>CodeSystem</nz-breadcrumb-item>
         <nz-breadcrumb-item>$subsumes</nz-breadcrumb-item>
       </nz-breadcrumb>
-      <m-button mDisplay="primary" [disabled]="!data.codeA || !data.codeB || !data.system" (click)="subsumes()">{{'web.integration.send-request' | translate}}</m-button>
+      <m-button mDisplay="primary" [disabled]="!data.system || !data.codeA || !data.codeB" (click)="subsumes()">{{'web.integration.send-request' | translate}}</m-button>
     </div>
 
-    <m-form-item [mLabel]="codeA" required>
-      <ng-template #codeA>
-        <div>{{'web.integration.fhir.code-system.subsumes.code-a' | translate}}&nbsp;</div>
-        <m-icon mCode="info-circle" m-popover mContent="{{'web.integration.fhir.code-system.subsumes.code-a-tooltip' | translate}}"></m-icon>
-      </ng-template>
-      <m-textarea name="codeA" [(ngModel)]="data.codeA"></m-textarea>
+    <!-- System -->
+    <m-form-item mLabel="System" required>
+      <tw-code-system-search name="system" [(ngModel)]="codeSystem" (ngModelChange)="onSystemSelect($event)"></tw-code-system-search>
+      @if (data.system) {
+        <div style="margin-top: .25rem; color: var(--color-text-secondary, #888); word-break: break-all">{{data.system}}</div>
+      }
     </m-form-item>
 
-    <m-form-item [mLabel]="codeB" required>
-      <ng-template #codeB>
-        <div>{{'web.integration.fhir.code-system.subsumes.code-b' | translate}}&nbsp;</div>
-        <m-icon mCode="info-circle" m-popover mContent="{{'web.integration.fhir.code-system.subsumes.code-b-tooltip' | translate}}"></m-icon>
-      </ng-template>
-      <m-textarea name="codeB" [(ngModel)]="data.codeB"></m-textarea>
+    <!-- Version (optional) -->
+    <m-form-item mLabel="Version">
+      <tw-code-system-version-select name="version" valueType="full" [autoSelect]="false"
+        [codeSystemId]="codeSystem?.id" [disabled]="!codeSystem"
+        [(ngModel)]="versionObj" (ngModelChange)="onVersionSelect($event)"></tw-code-system-version-select>
     </m-form-item>
 
-    <m-form-item [mLabel]="system" required>
-      <ng-template #system>
-        <div>{{'web.integration.fhir.code-system.subsumes.system' | translate}}&nbsp;</div>
-        <m-icon mCode="info-circle" m-popover mContent="{{'web.integration.fhir.code-system.subsumes.system-tooltip' | translate}}"></m-icon>
-      </ng-template>
-      <m-textarea name="system" [(ngModel)]="data.system"></m-textarea>
+    <!-- Code A -->
+    <m-form-item mLabel="Code A" required>
+      <m-input name="codeA" [(ngModel)]="data.codeA" placeholder="Enter any code, or pick a concept below"></m-input>
+      @if (codeSystem) {
+        <div style="margin-top: .25rem">
+          <tw-concept-search name="codeAPick" valueType="code" displayType="codeName"
+            [codeSystem]="codeSystem.id" [codeSystemVersion]="versionObj?.version" [searchDebounce]="600"
+            [ngModel]="data.codeA" (ngModelChange)="data.codeA = $event"
+            placeholder="Search concept…"></tw-concept-search>
+        </div>
+      }
     </m-form-item>
 
-    <m-form-item [mLabel]="version">
-      <ng-template #version>
-        <div>{{'web.integration.fhir.code-system.subsumes.version' | translate}}&nbsp;</div>
-        <m-icon mCode="info-circle" m-popover mContent="{{'web.integration.fhir.code-system.subsumes.version-tooltip' | translate}}"></m-icon>
-      </ng-template>
-      <m-textarea name="version" [(ngModel)]="data.version"></m-textarea>
+    <!-- Code B -->
+    <m-form-item mLabel="Code B" required>
+      <m-input name="codeB" [(ngModel)]="data.codeB" placeholder="Enter any code, or pick a concept below"></m-input>
+      @if (codeSystem) {
+        <div style="margin-top: .25rem">
+          <tw-concept-search name="codeBPick" valueType="code" displayType="codeName"
+            [codeSystem]="codeSystem.id" [codeSystemVersion]="versionObj?.version" [searchDebounce]="600"
+            [ngModel]="data.codeB" (ngModelChange)="data.codeB = $event"
+            placeholder="Search concept…"></tw-concept-search>
+        </div>
+      }
     </m-form-item>
 
+    <!-- Request command preview -->
+    <m-form-item mLabel="Request command">
+      <div class="m-items-middle" style="align-items: flex-start">
+        <m-textarea name="command" [ngModel]="command" readonly style="flex: 1; font-family: monospace"></m-textarea>
+        <m-button (click)="copyCommand()">
+          <m-icon mCode="copy"></m-icon>
+        </m-button>
+      </div>
+    </m-form-item>
+
+    <!-- Results -->
     @if (response || error) {
       <m-card class="m-card-inside">
         <div *m-card-header class="m-items-middle">

--- a/app/src/app/integration/fhir/code-system/fhir-code-system-subsumes.component.ts
+++ b/app/src/app/integration/fhir/code-system/fhir-code-system-subsumes.component.ts
@@ -1,30 +1,27 @@
 import {Clipboard} from '@angular/cdk/clipboard';
-import { Component, inject } from '@angular/core';
+import {Component, inject} from '@angular/core';
+import {environment} from 'environments/environment';
 import {FhirCodeSystemLibService, FhirCodeSystemSubsumesParams} from 'term-web/fhir/_lib';
-import { MuiCardModule, MuiSpinnerModule, MuiButtonModule, MuiFormModule, MuiIconModule, MuiPopoverModule, MuiTextareaModule, MuiAlertModule } from '@termx-health/ui';
-import { NzBreadCrumbComponent, NzBreadCrumbItemComponent } from 'ng-zorro-antd/breadcrumb';
-import { FormsModule } from '@angular/forms';
-import { JsonPipe } from '@angular/common';
-import { TranslatePipe } from '@ngx-translate/core';
+import {CodeSystem} from 'term-web/resources/_lib/code-system/model/code-system';
+import {CodeSystemVersion} from 'term-web/resources/_lib/code-system/model/code-system-version';
+import {CodeSystemLibModule} from 'term-web/resources/_lib/code-system/code-system-lib.module';
+import {
+  MuiAlertModule, MuiButtonModule, MuiCardModule, MuiFormModule, MuiIconModule, MuiInputModule,
+  MuiPopoverModule, MuiSpinnerModule, MuiTextareaModule
+} from '@termx-health/ui';
+import {NzBreadCrumbComponent, NzBreadCrumbItemComponent} from 'ng-zorro-antd/breadcrumb';
+import {FormsModule} from '@angular/forms';
+import {JsonPipe} from '@angular/common';
+import {TranslatePipe} from '@ngx-translate/core';
 
 
 @Component({
-    templateUrl: './fhir-code-system-subsumes.component.html',
-    imports: [
-    MuiCardModule,
-    MuiSpinnerModule,
-    NzBreadCrumbComponent,
-    NzBreadCrumbItemComponent,
-    MuiButtonModule,
-    MuiFormModule,
-    MuiIconModule,
-    MuiPopoverModule,
-    MuiTextareaModule,
-    FormsModule,
-    MuiAlertModule,
-    JsonPipe,
-    TranslatePipe
-],
+  templateUrl: './fhir-code-system-subsumes.component.html',
+  imports: [
+    MuiCardModule, MuiSpinnerModule, NzBreadCrumbComponent, NzBreadCrumbItemComponent, MuiButtonModule,
+    MuiFormModule, MuiIconModule, MuiPopoverModule, MuiInputModule, MuiTextareaModule, MuiAlertModule,
+    FormsModule, JsonPipe, TranslatePipe, CodeSystemLibModule
+  ],
 })
 export class FhirCodeSystemSubsumesComponent {
   private fhirCodeSystemLibService = inject(FhirCodeSystemLibService);
@@ -32,28 +29,42 @@ export class FhirCodeSystemSubsumesComponent {
 
   public response?: any;
   public error?: any;
+  public loading = false;
 
-  public data: {
-    codeA?: string,
-    codeB?: string,
-    system?: string,
-    version?: string
-  } = {};
+  public codeSystem?: CodeSystem;
+  public versionObj?: CodeSystemVersion;
+  public data: {codeA?: string, codeB?: string, system?: string, version?: string} = {};
 
-  public loading: boolean = false;
+  protected get baseUrl(): string {
+    return `${environment.termxApi}/fhir/CodeSystem`;
+  }
+
+  public onSystemSelect(cs: CodeSystem): void {
+    this.codeSystem = cs;
+    this.data.system = cs?.uri;
+    this.data.version = undefined;
+    this.versionObj = undefined;
+    this.data.codeA = undefined;
+    this.data.codeB = undefined;
+  }
+
+  public onVersionSelect(v: CodeSystemVersion): void {
+    this.versionObj = v;
+    // SNOMED needs the edition URI as the version (see $lookup); other code systems use the version string.
+    const isSnomed = this.data.system?.startsWith('http://snomed.info/sct');
+    this.data.version = (isSnomed && v?.uri) ? v.uri : v?.version;
+  }
+
+  public get command(): string {
+    const q = this.buildQuery();
+    return `GET ${this.baseUrl}/$subsumes${q ? '?' + q : ''}`;
+  }
 
   public subsumes(): void {
-    const sp = new FhirCodeSystemSubsumesParams();
-    sp.codeA = this.data.codeA || undefined;
-    sp.codeB = this.data.codeB || undefined;
-    sp.system = this.data.system || undefined;
-    sp.version = this.data.version || undefined;
-
     this.loading = true;
     this.error = undefined;
     this.response = undefined;
-
-    this.fhirCodeSystemLibService.subsumes(sp).subscribe({
+    this.fhirCodeSystemLibService.subsumes(this.buildParams()).subscribe({
       next: r => this.response = r,
       error: err => this.error = err.error
     }).add(() => this.loading = false);
@@ -61,5 +72,26 @@ export class FhirCodeSystemSubsumesComponent {
 
   public copyResult(): void {
     this.clipboardService.copy(JSON.stringify(this.response || this.error));
+  }
+
+  public copyCommand(): void {
+    this.clipboardService.copy(this.command);
+  }
+
+  private buildParams(): FhirCodeSystemSubsumesParams {
+    const sp = new FhirCodeSystemSubsumesParams();
+    sp.codeA = this.data.codeA || undefined;
+    sp.codeB = this.data.codeB || undefined;
+    sp.system = this.data.system || undefined;
+    sp.version = this.data.version || undefined;
+    return sp;
+  }
+
+  private buildQuery(): string {
+    const p = this.buildParams() as Record<string, string | undefined>;
+    return Object.keys(p)
+      .filter(k => p[k] !== undefined && p[k] !== null && p[k] !== '')
+      .map(k => `${k}=${encodeURIComponent(p[k]!)}`)
+      .join('&');
   }
 }

--- a/app/src/app/integration/fhir/code-system/fhir-code-system-validate-code.component.html
+++ b/app/src/app/integration/fhir/code-system/fhir-code-system-validate-code.component.html
@@ -9,41 +9,50 @@
       <m-button mDisplay="primary" [disabled]="!data.code || !data.url" (click)="validateCode()">{{'web.integration.send-request' | translate}}</m-button>
     </div>
 
-    <m-form-item [mLabel]="code" required>
-      <ng-template #code>
-        <div>{{'web.integration.fhir.code-system.validate-code.code' | translate}}&nbsp;</div>
-        <m-icon mCode="info-circle" m-popover mContent="{{'web.integration.fhir.code-system.validate-code.code-tooltip' | translate}}"></m-icon>
-      </ng-template>
-      <m-textarea name="code" [(ngModel)]="data.code"></m-textarea>
-    </m-form-item>
-    <m-form-item [mLabel]="version">
-      <ng-template #version>
-        <div>{{'web.integration.fhir.code-system.validate-code.version' | translate}}&nbsp;</div>
-        <m-icon mCode="info-circle" m-popover mContent="{{'web.integration.fhir.code-system.validate-code.version-tooltip' | translate}}"></m-icon>
-      </ng-template>
-      <m-textarea name="version" [(ngModel)]="data.version"></m-textarea>
-    </m-form-item>
-    <m-form-item [mLabel]="url" required>
-      <ng-template #url>
-        <div>{{'web.integration.fhir.code-system.validate-code.url' | translate}}&nbsp;</div>
-        <m-icon mCode="info-circle" m-popover [mContent]="urlContent"></m-icon>
-        <ng-template #urlContent>
-          {{'web.integration.fhir.code-system.validate-code.url-tooltip' | translate}}
-        </ng-template>
-      </ng-template>
-      <m-textarea name="url" [(ngModel)]="data.url"></m-textarea>
-    </m-form-item>
-    <m-form-item [mLabel]="display">
-      <ng-template #display>
-        <div>{{'web.integration.fhir.code-system.validate-code.display' | translate}}&nbsp;</div>
-        <m-icon mCode="info-circle" m-popover [mContent]="displayContent"></m-icon>
-        <ng-template #displayContent>
-          <span [innerHTML]="('web.integration.fhir.code-system.validate-code.display-tooltip' | translate)"></span>
-        </ng-template>
-      </ng-template>
-      <m-textarea name="display" [(ngModel)]="data.display"></m-textarea>
+    <!-- System -->
+    <m-form-item mLabel="System" required>
+      <tw-code-system-search name="system" [(ngModel)]="codeSystem" (ngModelChange)="onSystemSelect($event)"></tw-code-system-search>
+      @if (data.url) {
+        <div style="margin-top: .25rem; color: var(--color-text-secondary, #888); word-break: break-all">{{data.url}}</div>
+      }
     </m-form-item>
 
+    <!-- Version (optional) -->
+    <m-form-item mLabel="Version">
+      <tw-code-system-version-select name="version" valueType="full" [autoSelect]="false"
+        [codeSystemId]="codeSystem?.id" [disabled]="!codeSystem"
+        [(ngModel)]="versionObj" (ngModelChange)="onVersionSelect($event)"></tw-code-system-version-select>
+    </m-form-item>
+
+    <!-- Code (free text + concept autocomplete) -->
+    <m-form-item mLabel="Code" required>
+      <m-input name="code" [(ngModel)]="data.code" placeholder="Enter any code, or pick a concept below"></m-input>
+      @if (codeSystem) {
+        <div style="margin-top: .25rem">
+          <tw-concept-search name="codePick" valueType="code" displayType="codeName"
+            [codeSystem]="codeSystem.id" [codeSystemVersion]="versionObj?.version" [searchDebounce]="600"
+            [ngModel]="data.code" (ngModelChange)="data.code = $event"
+            placeholder="Search concept…"></tw-concept-search>
+        </div>
+      }
+    </m-form-item>
+
+    <!-- Display (to validate the term) -->
+    <m-form-item mLabel="Display">
+      <m-input name="display" [(ngModel)]="data.display"></m-input>
+    </m-form-item>
+
+    <!-- Request command preview -->
+    <m-form-item mLabel="Request command">
+      <div class="m-items-middle" style="align-items: flex-start">
+        <m-textarea name="command" [ngModel]="command" readonly style="flex: 1; font-family: monospace"></m-textarea>
+        <m-button (click)="copyCommand()">
+          <m-icon mCode="copy"></m-icon>
+        </m-button>
+      </div>
+    </m-form-item>
+
+    <!-- Results -->
     @if (response || error) {
       <m-card class="m-card-inside">
         <div *m-card-header class="m-items-middle">
@@ -64,6 +73,5 @@
         }
       </m-card>
     }
-
   </m-spinner>
 </m-card>

--- a/app/src/app/integration/fhir/code-system/fhir-code-system-validate-code.component.ts
+++ b/app/src/app/integration/fhir/code-system/fhir-code-system-validate-code.component.ts
@@ -1,29 +1,27 @@
 import {Clipboard} from '@angular/cdk/clipboard';
-import { Component, inject } from '@angular/core';
+import {Component, inject} from '@angular/core';
+import {environment} from 'environments/environment';
 import {FhirCodeSystemLibService, FhirCodeSystemValidateCodeParams} from 'term-web/fhir/_lib';
-import { MuiCardModule, MuiSpinnerModule, MuiButtonModule, MuiFormModule, MuiIconModule, MuiPopoverModule, MuiTextareaModule, MuiAlertModule } from '@termx-health/ui';
-import { NzBreadCrumbComponent, NzBreadCrumbItemComponent } from 'ng-zorro-antd/breadcrumb';
-import { FormsModule } from '@angular/forms';
-import { JsonPipe } from '@angular/common';
-import { TranslatePipe } from '@ngx-translate/core';
+import {CodeSystem} from 'term-web/resources/_lib/code-system/model/code-system';
+import {CodeSystemVersion} from 'term-web/resources/_lib/code-system/model/code-system-version';
+import {CodeSystemLibModule} from 'term-web/resources/_lib/code-system/code-system-lib.module';
+import {
+  MuiAlertModule, MuiButtonModule, MuiCardModule, MuiFormModule, MuiIconModule, MuiInputModule,
+  MuiPopoverModule, MuiSpinnerModule, MuiTextareaModule
+} from '@termx-health/ui';
+import {NzBreadCrumbComponent, NzBreadCrumbItemComponent} from 'ng-zorro-antd/breadcrumb';
+import {FormsModule} from '@angular/forms';
+import {JsonPipe} from '@angular/common';
+import {TranslatePipe} from '@ngx-translate/core';
+
 
 @Component({
-    templateUrl: './fhir-code-system-validate-code.component.html',
-    imports: [
-    MuiCardModule,
-    MuiSpinnerModule,
-    NzBreadCrumbComponent,
-    NzBreadCrumbItemComponent,
-    MuiButtonModule,
-    MuiFormModule,
-    MuiIconModule,
-    MuiPopoverModule,
-    MuiTextareaModule,
-    FormsModule,
-    MuiAlertModule,
-    JsonPipe,
-    TranslatePipe
-],
+  templateUrl: './fhir-code-system-validate-code.component.html',
+  imports: [
+    MuiCardModule, MuiSpinnerModule, NzBreadCrumbComponent, NzBreadCrumbItemComponent, MuiButtonModule,
+    MuiFormModule, MuiIconModule, MuiPopoverModule, MuiInputModule, MuiTextareaModule, MuiAlertModule,
+    FormsModule, JsonPipe, TranslatePipe, CodeSystemLibModule
+  ],
 })
 export class FhirCodeSystemValidateCodeComponent {
   private fhirCodeSystemLibService = inject(FhirCodeSystemLibService);
@@ -31,21 +29,41 @@ export class FhirCodeSystemValidateCodeComponent {
 
   public response?: any;
   public error?: any;
+  public loading = false;
 
+  public codeSystem?: CodeSystem;
+  public versionObj?: CodeSystemVersion;
   public data = new FhirCodeSystemValidateCodeParams();
 
-  public loading: boolean = false;
+  protected get baseUrl(): string {
+    return `${environment.termxApi}/fhir/CodeSystem`;
+  }
+
+  public onSystemSelect(cs: CodeSystem): void {
+    this.codeSystem = cs;
+    this.data.url = cs?.uri;
+    this.data.version = undefined;
+    this.versionObj = undefined;
+    this.data.code = undefined;
+  }
+
+  public onVersionSelect(v: CodeSystemVersion): void {
+    this.versionObj = v;
+    // SNOMED needs the edition URI as the version (see $lookup); other code systems use the version string.
+    const isSnomed = this.data.url?.startsWith('http://snomed.info/sct');
+    this.data.version = (isSnomed && v?.uri) ? v.uri : v?.version;
+  }
+
+  public get command(): string {
+    const q = this.buildQuery();
+    return `GET ${this.baseUrl}/$validate-code${q ? '?' + q : ''}`;
+  }
 
   public validateCode(): void {
-    this.data.code = this.data.code || undefined;
-    this.data.url = this.data.url || undefined;
-    this.data.display = this.data.display || undefined;
-    this.data.version = this.data.version || undefined;
     this.loading = true;
     this.error = undefined;
     this.response = undefined;
-
-    this.fhirCodeSystemLibService.validateCode(this.data).subscribe({
+    this.fhirCodeSystemLibService.validateCode(this.buildParams()).subscribe({
       next: r => this.response = r,
       error: err => this.error = err.error
     }).add(() => this.loading = false);
@@ -53,5 +71,26 @@ export class FhirCodeSystemValidateCodeComponent {
 
   public copyResult(): void {
     this.clipboardService.copy(JSON.stringify(this.response || this.error));
+  }
+
+  public copyCommand(): void {
+    this.clipboardService.copy(this.command);
+  }
+
+  private buildParams(): FhirCodeSystemValidateCodeParams {
+    const p = new FhirCodeSystemValidateCodeParams();
+    p.url = this.data.url || undefined;
+    p.version = this.data.version || undefined;
+    p.code = this.data.code || undefined;
+    p.display = this.data.display || undefined;
+    return p;
+  }
+
+  private buildQuery(): string {
+    const p = this.buildParams() as Record<string, string | undefined>;
+    return Object.keys(p)
+      .filter(k => p[k] !== undefined && p[k] !== null && p[k] !== '')
+      .map(k => `${k}=${encodeURIComponent(p[k]!)}`)
+      .join('&');
   }
 }

--- a/app/src/app/integration/fhir/value-set/fhir-value-set-expand.component.html
+++ b/app/src/app/integration/fhir/value-set/fhir-value-set-expand.component.html
@@ -6,33 +6,49 @@
         <nz-breadcrumb-item>ValueSet</nz-breadcrumb-item>
         <nz-breadcrumb-item>$expand</nz-breadcrumb-item>
       </nz-breadcrumb>
-      <m-button mDisplay="primary" [disabled]="!data.url || !data.valueSetVersion" (click)="expand()">{{'web.integration.send-request' | translate}}</m-button>
+      <m-button mDisplay="primary" [disabled]="!data.url" (click)="expand()">{{'web.integration.send-request' | translate}}</m-button>
     </div>
 
-    <m-form-item [mLabel]="url" required>
-      <ng-template #url>
-        <div>{{'web.integration.fhir.value-set.expand.url' | translate}}&nbsp;</div>
-        <m-icon mCode="info-circle" m-popover [mContent]="urlContent"></m-icon>
-        <ng-template #urlContent>
-          A canonical reference to a value set. The server must know the value set (e.g. it is defined explicitly in the server's value sets, or it is defined
-          implicitly by some code system known to the server
-        </ng-template>
-      </ng-template>
-      <m-textarea name="url" [(ngModel)]="data.url"></m-textarea>
-    </m-form-item>
-    <m-form-item [mLabel]="conceptMapVersion" required>
-      <ng-template #conceptMapVersion>
-        <div>{{'web.integration.fhir.value-set.expand.value-set-version' | translate}}&nbsp;</div>
-        <m-icon mCode="info-circle" m-popover [mContent]="conceptMapVersionContent"></m-icon>
-        <ng-template #conceptMapVersionContent>
-          The identifier that is used to identify a specific version of the value set to be used when generating the expansion. This is an arbitrary value
-          managed by the value set author and is not expected to be globally unique. For example, it might be a timestamp (e.g. yyyymmdd) if a managed version
-          is not available.
-        </ng-template>
-      </ng-template>
-      <m-textarea name="valueSetVersion" [(ngModel)]="data.valueSetVersion"></m-textarea>
+    <!-- ValueSet -->
+    <m-form-item mLabel="ValueSet" required>
+      <tw-value-set-search name="valueSet" [(ngModel)]="valueSet" (ngModelChange)="onValueSetSelect($event)"></tw-value-set-search>
+      @if (data.url) {
+        <div style="margin-top: .25rem; color: var(--color-text-secondary, #888); word-break: break-all">{{data.url}}</div>
+      }
     </m-form-item>
 
+    <!-- ValueSet version (optional) -->
+    <m-form-item mLabel="Version">
+      <tw-value-set-version-select name="valueSetVersion" valueType="full"
+        [valueSetId]="valueSet?.id" [disabled]="!valueSet"
+        [(ngModel)]="versionObj" (ngModelChange)="onVersionSelect($event)"></tw-value-set-version-select>
+    </m-form-item>
+
+    <!-- Include designations -->
+    <m-form-item mLabel="Include designations">
+      <m-checkbox name="includeDesignations" [(ngModel)]="data.includeDesignations"></m-checkbox>
+    </m-form-item>
+
+    <!-- Designation languages — any language selectable; the version's languages listed first -->
+    <m-form-item mLabel="Designation languages">
+      <m-select name="langs" [multiple]="true" [(ngModel)]="designationLanguages" placeholder="Languages">
+        @for (l of languageOptions; track l.code) {
+          <m-option [mValue]="l.code" [mLabel]="l.label"></m-option>
+        }
+      </m-select>
+    </m-form-item>
+
+    <!-- Request command preview -->
+    <m-form-item mLabel="Request command">
+      <div class="m-items-middle" style="align-items: flex-start">
+        <m-textarea name="command" [ngModel]="command" readonly style="flex: 1; font-family: monospace"></m-textarea>
+        <m-button (click)="copyCommand()">
+          <m-icon mCode="copy"></m-icon>
+        </m-button>
+      </div>
+    </m-form-item>
+
+    <!-- Results -->
     @if (response || error) {
       <m-card class="m-card-inside">
         <div *m-card-header class="m-items-middle">
@@ -44,7 +60,7 @@
         @if (response) {
           <pre>{{response | json}}</pre>
         }
-        @for (issue of error?.issue; track $index) {
+        @for (issue of error?.issue; track issue) {
           <div>
             <m-alert [mType]="issue.severity" mShowIcon>
               {{issue?.details?.text}}
@@ -53,6 +69,5 @@
         }
       </m-card>
     }
-
   </m-spinner>
 </m-card>

--- a/app/src/app/integration/fhir/value-set/fhir-value-set-expand.component.ts
+++ b/app/src/app/integration/fhir/value-set/fhir-value-set-expand.component.ts
@@ -1,51 +1,108 @@
 import {Clipboard} from '@angular/cdk/clipboard';
-import { Component, inject } from '@angular/core';
+import {Component, OnInit, inject} from '@angular/core';
+import {environment} from 'environments/environment';
 import {FhirValueSetExpandParams, FhirValueSetLibService} from 'term-web/fhir/_lib';
-import { MuiCardModule, MuiSpinnerModule, MuiButtonModule, MuiFormModule, MuiIconModule, MuiPopoverModule, MuiTextareaModule, MuiAlertModule } from '@termx-health/ui';
-import { NzBreadCrumbComponent, NzBreadCrumbItemComponent } from 'ng-zorro-antd/breadcrumb';
-import { FormsModule } from '@angular/forms';
-import { JsonPipe } from '@angular/common';
-import { TranslatePipe } from '@ngx-translate/core';
+import {ValueSet} from 'term-web/resources/_lib/value-set/model/value-set';
+import {ValueSetVersion} from 'term-web/resources/_lib/value-set/model/value-set-version';
+import {ValueSetVersionConcept} from 'term-web/resources/_lib/value-set/model/value-set-version-concept';
+import {ValueSetLibModule} from 'term-web/resources/_lib/value-set/value-set-lib.module';
+import {ValueSetLibService} from 'term-web/resources/_lib/value-set/services/value-set-lib.service';
+import {VsConceptUtil} from 'term-web/resources/_lib';
+import {
+  MuiAlertModule, MuiButtonModule, MuiCardModule, MuiCheckboxModule, MuiFormModule, MuiIconModule,
+  MuiPopoverModule, MuiSelectModule, MuiSpinnerModule, MuiTextareaModule
+} from '@termx-health/ui';
+import {NzBreadCrumbComponent, NzBreadCrumbItemComponent} from 'ng-zorro-antd/breadcrumb';
+import {FormsModule} from '@angular/forms';
+import {JsonPipe} from '@angular/common';
+import {TranslatePipe, TranslateService} from '@ngx-translate/core';
 
 
 @Component({
-    templateUrl: './fhir-value-set-expand.component.html',
-    imports: [
-        MuiCardModule,
-        MuiSpinnerModule,
-        NzBreadCrumbComponent,
-        NzBreadCrumbItemComponent,
-        MuiButtonModule,
-        MuiFormModule,
-        MuiIconModule,
-        MuiPopoverModule,
-        MuiTextareaModule,
-        FormsModule,
-        MuiAlertModule,
-        JsonPipe,
-        TranslatePipe,
-    ],
+  templateUrl: './fhir-value-set-expand.component.html',
+  imports: [
+    MuiCardModule, MuiSpinnerModule, NzBreadCrumbComponent, NzBreadCrumbItemComponent, MuiButtonModule,
+    MuiFormModule, MuiIconModule, MuiPopoverModule, MuiTextareaModule, MuiCheckboxModule, MuiSelectModule,
+    MuiAlertModule, FormsModule, JsonPipe, TranslatePipe, ValueSetLibModule
+  ],
+  providers: [ValueSetLibService],
 })
-export class FhirValueSetExpandComponent {
+export class FhirValueSetExpandComponent implements OnInit {
   private fhirValueSetService = inject(FhirValueSetLibService);
+  private valueSetService = inject(ValueSetLibService);
+  private translate = inject(TranslateService);
   private clipboardService = inject(Clipboard);
+
+  /** All languages from the `languages` value set, keyed by code (for the designation-language picker). */
+  private languages: {[code: string]: ValueSetVersionConcept} = {};
 
   public response?: any;
   public error?: any;
+  public loading = false;
 
+  public valueSet?: ValueSet;
+  public versionObj?: ValueSetVersion;
   public data = new FhirValueSetExpandParams();
+  public designationLanguages?: string[];
 
-  public loading: boolean = false;
+  public ngOnInit(): void {
+    this.valueSetService.expand({valueSet: 'languages'}).subscribe(concepts => {
+      concepts.forEach(c => {
+        if (c.concept?.code) { this.languages[c.concept.code] = c; }
+      });
+    });
+  }
+
+  protected get baseUrl(): string {
+    return `${environment.termxApi}/fhir/ValueSet`;
+  }
+
+  /**
+   * Designation languages: ALL languages (from the `languages` value set) are selectable,
+   * but the selected version's supported languages are listed first.
+   */
+  public get languageOptions(): {code: string, label: string}[] {
+    const lang = this.translate.currentLang;
+    const label = (code: string): string => {
+      const c = this.languages[code];
+      return c ? (VsConceptUtil.getDisplay(c, lang) || code) : code;
+    };
+    const out: {code: string, label: string}[] = [];
+    const seen = new Set<string>();
+    (this.versionObj?.supportedLanguages || []).forEach(code => {
+      if (!seen.has(code)) { seen.add(code); out.push({code, label: label(code)}); }
+    });
+    Object.keys(this.languages)
+      .filter(code => !seen.has(code))
+      .map(code => ({code, label: label(code)}))
+      .sort((a, b) => a.label.localeCompare(b.label))
+      .forEach(o => out.push(o));
+    return out;
+  }
+
+  public onValueSetSelect(vs: ValueSet): void {
+    this.valueSet = vs;
+    this.data.url = vs?.uri;
+    this.data.valueSetVersion = undefined;
+    this.versionObj = undefined;
+    this.designationLanguages = undefined;
+  }
+
+  public onVersionSelect(v: ValueSetVersion): void {
+    this.versionObj = v;
+    this.data.valueSetVersion = v?.version;
+  }
+
+  public get command(): string {
+    const q = this.buildQuery();
+    return `GET ${this.baseUrl}/$expand${q ? '?' + q : ''}`;
+  }
 
   public expand(): void {
-    this.data.url = this.data.url || undefined;
-    this.data.valueSetVersion = this.data.valueSetVersion || undefined;
-
     this.loading = true;
     this.error = undefined;
     this.response = undefined;
-
-    this.fhirValueSetService.expand(this.data).subscribe({
+    this.fhirValueSetService.expand(this.buildParams()).subscribe({
       next: r => this.response = r,
       error: err => this.error = err.error
     }).add(() => this.loading = false);
@@ -53,5 +110,26 @@ export class FhirValueSetExpandComponent {
 
   public copyResult(): void {
     this.clipboardService.copy(JSON.stringify(this.response || this.error));
+  }
+
+  public copyCommand(): void {
+    this.clipboardService.copy(this.command);
+  }
+
+  private buildParams(): FhirValueSetExpandParams {
+    const p = new FhirValueSetExpandParams();
+    p.url = this.data.url || undefined;
+    p.valueSetVersion = this.data.valueSetVersion || undefined;
+    p.includeDesignations = this.data.includeDesignations || undefined;
+    p.displayLanguage = this.designationLanguages?.length ? this.designationLanguages.join(',') : undefined;
+    return p;
+  }
+
+  private buildQuery(): string {
+    const p = this.buildParams() as Record<string, string | undefined>;
+    return Object.keys(p)
+      .filter(k => p[k] !== undefined && p[k] !== null && p[k] !== '')
+      .map(k => `${k}=${encodeURIComponent(p[k]!)}`)
+      .join('&');
   }
 }

--- a/app/src/app/integration/fhir/value-set/fhir-value-set-validate-code.component.html
+++ b/app/src/app/integration/fhir/value-set/fhir-value-set-validate-code.component.html
@@ -6,72 +6,68 @@
         <nz-breadcrumb-item>ValueSet</nz-breadcrumb-item>
         <nz-breadcrumb-item>$validate-code</nz-breadcrumb-item>
       </nz-breadcrumb>
-      <m-button mDisplay="primary" [disabled]="!data.url || !data.valueSetVersion || !data.code" (click)="validateCode()">{{'web.integration.send-request' | translate}}</m-button>
+      <m-button mDisplay="primary" [disabled]="!data.code || !data.url" (click)="validateCode()">{{'web.integration.send-request' | translate}}</m-button>
     </div>
 
-    <m-form-item [mLabel]="url" required>
-      <ng-template #url>
-        <div>{{'web.integration.fhir.value-set.validate-code.url' | translate}}&nbsp;</div>
-        <m-icon mCode="info-circle" m-popover [mContent]="urlContent"></m-icon>
-        <ng-template #urlContent>
-          Value set Canonical URL. The server must know the value set (e.g. it is defined explicitly in the server's value sets, or it is defined implicitly by
-          some code system known to the server
-        </ng-template>
-      </ng-template>
-      <m-textarea name="url" [(ngModel)]="data.url"></m-textarea>
-    </m-form-item>
-    <m-form-item [mLabel]="conceptMapVersion" required>
-      <ng-template #conceptMapVersion>
-        <div>{{'web.integration.fhir.value-set.validate-code.value-set-version' | translate}}&nbsp;</div>
-        <m-icon mCode="info-circle" m-popover [mContent]="conceptMapVersionContent"></m-icon>
-        <ng-template #conceptMapVersionContent>
-          The identifier that is used to identify a specific version of the value set to be used when validating the code. This is an arbitrary value managed
-          by the value set author and is not expected to be globally unique. For example, it might be a timestamp (e.g. yyyymmdd) if a managed version is
-          not available.
-        </ng-template>
-      </ng-template>
-      <m-textarea name="valueSetVersion" [(ngModel)]="data.valueSetVersion"></m-textarea>
+    <!-- ValueSet -->
+    <m-form-item mLabel="ValueSet" required>
+      <tw-value-set-search name="valueSet" [(ngModel)]="valueSet" (ngModelChange)="onValueSetSelect($event)"></tw-value-set-search>
+      @if (data.url) {
+        <div style="margin-top: .25rem; color: var(--color-text-secondary, #888); word-break: break-all">{{data.url}}</div>
+      }
     </m-form-item>
 
-    <m-form-item [mLabel]="code" required>
-      <ng-template #code>
-        <div>{{'web.integration.fhir.value-set.validate-code.code' | translate}}&nbsp;</div>
-        <m-icon mCode="info-circle" m-popover [mContent]="codeContent"></m-icon>
-        <ng-template #codeContent>
-          The code that is to be validated. If a code is provided, a system or a context must be provided (if a context is provided, then the server SHALL
-          ensure that the code is not ambiguous without a system)
-        </ng-template>
-      </ng-template>
-      <m-textarea name="code" [(ngModel)]="data.code"></m-textarea>
+    <!-- ValueSet version (optional) -->
+    <m-form-item mLabel="ValueSet version">
+      <tw-value-set-version-select name="valueSetVersion" valueType="version"
+        [valueSetId]="valueSet?.id" [disabled]="!valueSet"
+        [(ngModel)]="data.valueSetVersion"></tw-value-set-version-select>
     </m-form-item>
 
-    <m-form-item [mLabel]="system">
-      <ng-template #system>
-        <div>{{'web.integration.fhir.value-set.validate-code.system' | translate}}&nbsp;</div>
-        <m-icon mCode="info-circle" m-popover mContent="The system for the code that is to be validated"></m-icon>
-      </ng-template>
-      <m-textarea name="system" [(ngModel)]="data.system"></m-textarea>
+    <!-- System (code system the code belongs to) -->
+    <m-form-item mLabel="System">
+      <tw-code-system-search name="system" [(ngModel)]="codeSystem" (ngModelChange)="onSystemSelect($event)"></tw-code-system-search>
+      @if (data.system) {
+        <div style="margin-top: .25rem; color: var(--color-text-secondary, #888); word-break: break-all">{{data.system}}</div>
+      }
     </m-form-item>
 
-    <m-form-item [mLabel]="systemVersion">
-      <ng-template #systemVersion>
-        <div>{{'web.integration.fhir.value-set.validate-code.system-version' | translate}}&nbsp;</div>
-        <m-icon mCode="info-circle" m-popover mContent="The version of the system, if one was provided in the source data"></m-icon>
-      </ng-template>
-      <m-textarea name="systemVersion" [(ngModel)]="data.systemVersion"></m-textarea>
+    <!-- System version (optional) -->
+    <m-form-item mLabel="System version">
+      <tw-code-system-version-select name="systemVersion" valueType="full" [autoSelect]="false"
+        [codeSystemId]="codeSystem?.id" [disabled]="!codeSystem"
+        [(ngModel)]="systemVersionObj" (ngModelChange)="onSystemVersionSelect($event)"></tw-code-system-version-select>
     </m-form-item>
 
-    <m-form-item [mLabel]="display">
-      <ng-template #display>
-        <div>{{'web.integration.fhir.value-set.validate-code.display' | translate}}&nbsp;</div>
-        <m-icon mCode="info-circle" m-popover [mContent]="displayContent"></m-icon>
-        <ng-template #displayContent>The display associated with the code, if provided. If a display is provided a code must be provided. If no display is provided,
-          the server cannot validate the display value, but may choose to return a recommended display name using the display parameter in the outcome.
-          Whether displays are case sensitive is code system dependent</ng-template>
-      </ng-template>
-      <m-textarea name="display" [(ngModel)]="data.display"></m-textarea>
+    <!-- Code (free text + concept autocomplete from the selected system) -->
+    <m-form-item mLabel="Code" required>
+      <m-input name="code" [(ngModel)]="data.code" placeholder="Enter any code, or pick a concept below"></m-input>
+      @if (codeSystem) {
+        <div style="margin-top: .25rem">
+          <tw-concept-search name="codePick" valueType="code" displayType="codeName"
+            [codeSystem]="codeSystem.id" [codeSystemVersion]="systemVersionObj?.version" [searchDebounce]="600"
+            [ngModel]="data.code" (ngModelChange)="data.code = $event"
+            placeholder="Search concept…"></tw-concept-search>
+        </div>
+      }
     </m-form-item>
 
+    <!-- Display -->
+    <m-form-item mLabel="Display">
+      <m-input name="display" [(ngModel)]="data.display"></m-input>
+    </m-form-item>
+
+    <!-- Request command preview -->
+    <m-form-item mLabel="Request command">
+      <div class="m-items-middle" style="align-items: flex-start">
+        <m-textarea name="command" [ngModel]="command" readonly style="flex: 1; font-family: monospace"></m-textarea>
+        <m-button (click)="copyCommand()">
+          <m-icon mCode="copy"></m-icon>
+        </m-button>
+      </div>
+    </m-form-item>
+
+    <!-- Results -->
     @if (response || error) {
       <m-card class="m-card-inside">
         <div *m-card-header class="m-items-middle">
@@ -83,7 +79,7 @@
         @if (response) {
           <pre>{{response | json}}</pre>
         }
-        @for (issue of error?.issue; track $index) {
+        @for (issue of error?.issue; track issue) {
           <div>
             <m-alert [mType]="issue.severity" mShowIcon>
               {{issue?.details?.text}}
@@ -92,6 +88,5 @@
         }
       </m-card>
     }
-
   </m-spinner>
 </m-card>

--- a/app/src/app/integration/fhir/value-set/fhir-value-set-validate-code.component.ts
+++ b/app/src/app/integration/fhir/value-set/fhir-value-set-validate-code.component.ts
@@ -1,30 +1,29 @@
 import {Clipboard} from '@angular/cdk/clipboard';
-import { Component, inject } from '@angular/core';
+import {Component, inject} from '@angular/core';
+import {environment} from 'environments/environment';
 import {FhirValueSetLibService, FhirValueSetValidateCodeParams} from 'term-web/fhir/_lib';
-import { MuiCardModule, MuiSpinnerModule, MuiButtonModule, MuiFormModule, MuiIconModule, MuiPopoverModule, MuiTextareaModule, MuiAlertModule } from '@termx-health/ui';
-import { NzBreadCrumbComponent, NzBreadCrumbItemComponent } from 'ng-zorro-antd/breadcrumb';
-import { FormsModule } from '@angular/forms';
-import { JsonPipe } from '@angular/common';
-import { TranslatePipe } from '@ngx-translate/core';
+import {CodeSystem} from 'term-web/resources/_lib/code-system/model/code-system';
+import {CodeSystemVersion} from 'term-web/resources/_lib/code-system/model/code-system-version';
+import {CodeSystemLibModule} from 'term-web/resources/_lib/code-system/code-system-lib.module';
+import {ValueSet} from 'term-web/resources/_lib/value-set/model/value-set';
+import {ValueSetLibModule} from 'term-web/resources/_lib/value-set/value-set-lib.module';
+import {
+  MuiAlertModule, MuiButtonModule, MuiCardModule, MuiFormModule, MuiIconModule, MuiInputModule,
+  MuiPopoverModule, MuiSpinnerModule, MuiTextareaModule
+} from '@termx-health/ui';
+import {NzBreadCrumbComponent, NzBreadCrumbItemComponent} from 'ng-zorro-antd/breadcrumb';
+import {FormsModule} from '@angular/forms';
+import {JsonPipe} from '@angular/common';
+import {TranslatePipe} from '@ngx-translate/core';
 
 
 @Component({
-    templateUrl: './fhir-value-set-validate-code.component.html',
-    imports: [
-        MuiCardModule,
-        MuiSpinnerModule,
-        NzBreadCrumbComponent,
-        NzBreadCrumbItemComponent,
-        MuiButtonModule,
-        MuiFormModule,
-        MuiIconModule,
-        MuiPopoverModule,
-        MuiTextareaModule,
-        FormsModule,
-        MuiAlertModule,
-        JsonPipe,
-        TranslatePipe,
-    ],
+  templateUrl: './fhir-value-set-validate-code.component.html',
+  imports: [
+    MuiCardModule, MuiSpinnerModule, NzBreadCrumbComponent, NzBreadCrumbItemComponent, MuiButtonModule,
+    MuiFormModule, MuiIconModule, MuiPopoverModule, MuiInputModule, MuiTextareaModule, MuiAlertModule,
+    FormsModule, JsonPipe, TranslatePipe, CodeSystemLibModule, ValueSetLibModule
+  ],
 })
 export class FhirValueSetValidateCodeComponent {
   private fhirValueSetService = inject(FhirValueSetLibService);
@@ -32,24 +31,48 @@ export class FhirValueSetValidateCodeComponent {
 
   public response?: any;
   public error?: any;
+  public loading = false;
 
+  public valueSet?: ValueSet;
+  public codeSystem?: CodeSystem;
+  public systemVersionObj?: CodeSystemVersion;
   public data = new FhirValueSetValidateCodeParams();
 
-  public loading: boolean = false;
+  protected get baseUrl(): string {
+    return `${environment.termxApi}/fhir/ValueSet`;
+  }
+
+  public onValueSetSelect(vs: ValueSet): void {
+    this.valueSet = vs;
+    this.data.url = vs?.uri;
+    this.data.valueSetVersion = undefined;
+  }
+
+  public onSystemSelect(cs: CodeSystem): void {
+    this.codeSystem = cs;
+    this.data.system = cs?.uri;
+    this.data.systemVersion = undefined;
+    this.systemVersionObj = undefined;
+    this.data.code = undefined;
+  }
+
+  public onSystemVersionSelect(v: CodeSystemVersion): void {
+    this.systemVersionObj = v;
+    // SNOMED needs the edition URI as the version (see $lookup); other code systems use the version string.
+    const isSnomed = this.data.system?.startsWith('http://snomed.info/sct');
+    this.data.systemVersion = (isSnomed && v?.uri) ? v.uri : v?.version;
+  }
+
+  public get command(): string {
+    const q = this.buildQuery();
+    return `GET ${this.baseUrl}/$validate-code${q ? '?' + q : ''}`;
+  }
 
   public validateCode(): void {
-    this.data.code = this.data.code || undefined;
-    this.data.url = this.data.url || undefined;
-    this.data.valueSetVersion = this.data.valueSetVersion || undefined;
-    this.data.display = this.data.display || undefined;
-    this.data.system = this.data.system || undefined;
-    this.data.systemVersion = this.data.systemVersion || undefined;
-
     this.loading = true;
     this.error = undefined;
     this.response = undefined;
-
-    this.fhirValueSetService.validateCode(this.data).subscribe({
+    this.fhirValueSetService.validateCode(this.buildParams()).subscribe({
       next: r => this.response = r,
       error: err => this.error = err.error
     }).add(() => this.loading = false);
@@ -57,5 +80,28 @@ export class FhirValueSetValidateCodeComponent {
 
   public copyResult(): void {
     this.clipboardService.copy(JSON.stringify(this.response || this.error));
+  }
+
+  public copyCommand(): void {
+    this.clipboardService.copy(this.command);
+  }
+
+  private buildParams(): FhirValueSetValidateCodeParams {
+    const p = new FhirValueSetValidateCodeParams();
+    p.url = this.data.url || undefined;
+    p.valueSetVersion = this.data.valueSetVersion || undefined;
+    p.code = this.data.code || undefined;
+    p.system = this.data.system || undefined;
+    p.systemVersion = this.data.systemVersion || undefined;
+    p.display = this.data.display || undefined;
+    return p;
+  }
+
+  private buildQuery(): string {
+    const p = this.buildParams() as Record<string, string | undefined>;
+    return Object.keys(p)
+      .filter(k => p[k] !== undefined && p[k] !== null && p[k] !== '')
+      .map(k => `${k}=${encodeURIComponent(p[k]!)}`)
+      .join('&');
   }
 }

--- a/app/src/app/integration/integration.module.ts
+++ b/app/src/app/integration/integration.module.ts
@@ -32,6 +32,7 @@ import {SysLibModule} from 'term-web/sys/_lib';
 import {UserLibModule} from 'term-web/user/_lib';
 import {CoreUiModule} from 'term-web/core/ui/core-ui.module';
 import {IntegrationDashboardComponent} from 'term-web/integration/dashboard/integration-dashboard.component';
+import {IntegrationOperationsComponent} from 'term-web/integration/operations/integration-operations.component';
 import {FhirCodeSystemFindMatchesComponent} from 'term-web/integration/fhir/code-system/fhir-code-system-find-matches.component';
 import {FhirCodeSystemLookupComponent} from 'term-web/integration/fhir/code-system/fhir-code-system-lookup.component';
 import {FhirCodeSystemSubsumesComponent} from 'term-web/integration/fhir/code-system/fhir-code-system-subsumes.component';
@@ -53,14 +54,6 @@ export const INTEGRATION_ROUTES: Routes = [
   {
     path: 'dashboard', component: IntegrationDashboardComponent, children: [
       {path: 'fhir/$sync', component: IntegrationFhirSyncComponent, data: {privilege: ['*.CodeSystem.write', '*.ValueSet.write', '*.MapSet.write']}},
-      {path: 'fhir/CodeSystem/$lookup', component: FhirCodeSystemLookupComponent, data: {privilege: ['*.CodeSystem.read']}},
-      {path: 'fhir/CodeSystem/$validate-code', component: FhirCodeSystemValidateCodeComponent, data: {privilege: ['*.CodeSystem.read']}},
-      {path: 'fhir/CodeSystem/$subsumes', component: FhirCodeSystemSubsumesComponent, data: {privilege: ['*.CodeSystem.read']}},
-      {path: 'fhir/CodeSystem/$find-matches', component: FhirCodeSystemFindMatchesComponent, data: {privilege: ['*.CodeSystem.read']}},
-      {path: 'fhir/ValueSet/$expand', component: FhirValueSetExpandComponent, data: {privilege: ['*.ValueSet.read']}},
-      {path: 'fhir/ValueSet/$validate-code', component: FhirValueSetValidateCodeComponent, data: {privilege: ['*.ValueSet.read']}},
-      {path: 'fhir/ConceptMap/$translate', component: FhirConceptMapTranslateComponent, data: {privilege: ['*.MapSet.read']}},
-      {path: 'fhir/ConceptMap/$closure', component: FhirConceptMapClosureComponent, data: {privilege: ['*.MapSet.read']}},
       {path: 'atc/import', component: IntegrationAtcImportComponent, data: {privilege: ['*.CodeSystem.write']}},
       {path: 'icd-10/import', component: IntegrationIcdImportComponent, data: {privilege: ['*.CodeSystem.write']}},
       {path: 'ichi/import', component: IntegrationIchiImportComponent, data: {privilege: ['*.CodeSystem.write']}},
@@ -70,6 +63,18 @@ export const INTEGRATION_ROUTES: Routes = [
       {path: 'file-import/value-set', component: ValueSetFileImportComponent, data: {privilege: ['*.CodeSystem.write']}},
       {path: 'file-import/concept-map', component: ConceptMapFileImportComponent, data: {privilege: ['*.MapSet.write']}},
       {path: 'file-import/association', component: AssociationFileImportComponent, data: {privilege: ['*.CodeSystem.write']}}
+    ]
+  },
+  {
+    path: 'operations', component: IntegrationOperationsComponent, children: [
+      {path: 'fhir/CodeSystem/$lookup', component: FhirCodeSystemLookupComponent, data: {privilege: ['*.CodeSystem.read']}},
+      {path: 'fhir/CodeSystem/$validate-code', component: FhirCodeSystemValidateCodeComponent, data: {privilege: ['*.CodeSystem.read']}},
+      {path: 'fhir/CodeSystem/$subsumes', component: FhirCodeSystemSubsumesComponent, data: {privilege: ['*.CodeSystem.read']}},
+      {path: 'fhir/CodeSystem/$find-matches', component: FhirCodeSystemFindMatchesComponent, data: {privilege: ['*.CodeSystem.read']}},
+      {path: 'fhir/ValueSet/$expand', component: FhirValueSetExpandComponent, data: {privilege: ['*.ValueSet.read']}},
+      {path: 'fhir/ValueSet/$validate-code', component: FhirValueSetValidateCodeComponent, data: {privilege: ['*.ValueSet.read']}},
+      {path: 'fhir/ConceptMap/$translate', component: FhirConceptMapTranslateComponent, data: {privilege: ['*.MapSet.read']}},
+      {path: 'fhir/ConceptMap/$closure', component: FhirConceptMapClosureComponent, data: {privilege: ['*.MapSet.read']}}
     ]
   },
   {path: 'loinc', component: LoincDashboardComponent, data: {privilege: ['loinc.CodeSystem.read']}},
@@ -103,6 +108,7 @@ export const INTEGRATION_ROUTES: Routes = [
         NzProgressModule,
         ImportJobLogComponent,
         IntegrationDashboardComponent,
+        IntegrationOperationsComponent,
         IntegrationFhirSyncComponent,
         IntegrationAtcImportComponent,
         IntegrationIcdImportComponent,

--- a/app/src/app/integration/operations/integration-operations.component.html
+++ b/app/src/app/integration/operations/integration-operations.component.html
@@ -1,0 +1,39 @@
+<div nz-row nzGutter="12" class="m-row">
+  <div nz-col [nzMd]="6" [nzXs]="24">
+    <m-card>
+      <m-divider [mText]="'web.integration.systems.fhir' | translate" *twPrivileged="['*.CodeSystem.read', '*.ValueSet.read', '*.MapSet.read']"></m-divider>
+
+      <nz-collapse nzGhost *twPrivileged="'*.CodeSystem.read'">
+        <nz-collapse-panel nzHeader="CodeSystem">
+          <div style="display: grid">
+            <m-button mDisplay="link" [routerLink]="'./fhir/CodeSystem/$lookup'">$lookup</m-button>
+            <m-button mDisplay="link" [routerLink]="'./fhir/CodeSystem/$validate-code'">$validate-code</m-button>
+            <m-button mDisplay="link" [routerLink]="'./fhir/CodeSystem/$subsumes'">$subsumes</m-button>
+            <m-button mDisplay="link" [routerLink]="'./fhir/CodeSystem/$find-matches'">$find-matches</m-button>
+          </div>
+        </nz-collapse-panel>
+      </nz-collapse>
+
+      <nz-collapse nzGhost *twPrivileged="'*.ValueSet.read'">
+        <nz-collapse-panel nzHeader="ValueSet">
+          <div style="display: grid">
+            <m-button mDisplay="link" [routerLink]="'./fhir/ValueSet/$expand'">$expand</m-button>
+            <m-button mDisplay="link" [routerLink]="'./fhir/ValueSet/$validate-code'">$validate-code</m-button>
+          </div>
+        </nz-collapse-panel>
+      </nz-collapse>
+
+      <nz-collapse nzGhost *twPrivileged="'*.MapSet.read'">
+        <nz-collapse-panel nzHeader="ConceptMap">
+          <div style="display: grid">
+            <m-button mDisplay="link" [routerLink]="'./fhir/ConceptMap/$translate'">$translate</m-button>
+            <m-button mDisplay="link" [routerLink]="'./fhir/ConceptMap/$closure'">$closure</m-button>
+          </div>
+        </nz-collapse-panel>
+      </nz-collapse>
+    </m-card>
+  </div>
+  <div nz-col [nzMd]="18" [nzXs]="24">
+    <router-outlet></router-outlet>
+  </div>
+</div>

--- a/app/src/app/integration/operations/integration-operations.component.ts
+++ b/app/src/app/integration/operations/integration-operations.component.ts
@@ -1,0 +1,26 @@
+import {Component} from '@angular/core';
+import {NzRowDirective, NzColDirective} from 'ng-zorro-antd/grid';
+import {MuiCardModule, MuiDividerModule, MuiButtonModule} from '@termx-health/ui';
+import {PrivilegedDirective} from 'term-web/core/auth/privileges/privileged.directive';
+import {RouterLink, RouterOutlet} from '@angular/router';
+import {NzCollapseComponent, NzCollapsePanelComponent} from 'ng-zorro-antd/collapse';
+import {TranslatePipe} from '@ngx-translate/core';
+
+@Component({
+  templateUrl: './integration-operations.component.html',
+  imports: [
+    NzRowDirective,
+    NzColDirective,
+    MuiCardModule,
+    PrivilegedDirective,
+    MuiDividerModule,
+    MuiButtonModule,
+    RouterLink,
+    NzCollapseComponent,
+    NzCollapsePanelComponent,
+    RouterOutlet,
+    TranslatePipe,
+  ],
+})
+export class IntegrationOperationsComponent {
+}

--- a/app/src/app/resources/_lib/code-system/containers/concept-search.component.ts
+++ b/app/src/app/resources/_lib/code-system/containers/concept-search.component.ts
@@ -27,6 +27,8 @@ export class ConceptSearchComponent implements OnInit, OnChanges, ControlValueAc
   @Input() @BooleanInput() public multiple: string | boolean;
   @Input() @BooleanInput() public showStatus: string | boolean = false;
   @Input() public placeholder: string = 'marina.ui.inputs.select.placeholder';
+  /** Debounce (ms) before a search request is issued after typing stops. */
+  @Input() public searchDebounce: number = 250;
 
   @Input() public codeSystem?: string;
   @Input() public codeSystemVersion?: string;
@@ -46,7 +48,7 @@ export class ConceptSearchComponent implements OnInit, OnChanges, ControlValueAc
 
   public ngOnInit(): void {
     this.searchUpdate.pipe(
-      debounceTime(250),
+      debounceTime(this.searchDebounce),
       distinctUntilChanged(),
       switchMap(text => this.searchConcepts(text)),
     ).subscribe(data => this.data = data);

--- a/app/src/app/resources/code-system/containers/version/edit/code-system-version-edit.component.ts
+++ b/app/src/app/resources/code-system/containers/version/edit/code-system-version-edit.component.ts
@@ -104,9 +104,21 @@ export class CodeSystemVersionEditComponent implements OnInit {
 
   private writeVersion(version: CodeSystemVersion): CodeSystemVersion {
     version.status ??= 'draft';
-    version.releaseDate ??= new Date();
+    // The API returns dates as strings (e.g. "2026-06-03"); the date picker needs real
+    // Date objects — passing a string crashes ng-zorro with "Invalid time value".
+    version.releaseDate = this.toDate(version.releaseDate) ?? new Date();
+    version.expirationDate = this.toDate(version.expirationDate);
     version.identifiers ??= [];
     return version;
+  }
+
+  /** Coerce an API date (string | Date) into a valid Date; undefined when absent or unparseable. */
+  private toDate(value: Date | string | undefined): Date | undefined {
+    if (!value) {
+      return undefined;
+    }
+    const d = value instanceof Date ? value : new Date(value);
+    return isNaN(d.getTime()) ? undefined : d;
   }
 
   private getLastVersion(versions: CodeSystemVersion[]): CodeSystemVersion {

--- a/app/src/assets/menu.json
+++ b/app/src/assets/menu.json
@@ -151,6 +151,24 @@
             },
             {
                 "label": {
+                    "en": "Operations",
+                    "et": "Operatsioonid",
+                    "lt": "Operacijos",
+                    "de": "Operationen",
+                    "fr": "Opérations",
+                    "nl": "Operaties",
+                    "cs": "Operace"
+                },
+                "icon": "api",
+                "link": "integration/operations",
+                "privileges": [
+                    "*.CodeSystem.read",
+                    "*.ValueSet.read",
+                    "*.MapSet.read"
+                ]
+            },
+            {
+                "label": {
                     "en": "Import",
                     "et": "Import",
                     "lt": "Importavimas",


### PR DESCRIPTION
## Summary

Reworks the integration FHIR operation UIs and moves them out of **Import** into a dedicated **Operations** menu.

### Menu / navigation
- New **Operations** top-level menu item, placed **before Import**, with the same privileges. It opens an Operations page that holds all FHIR operations.
- `$sync` stays under **Import**; the moved operation routes now live under `integration/operations/...`.

### FHIR operation forms
Refactored `$lookup`, CodeSystem/ValueSet `$validate-code`, `$expand`, `$subsumes` and `$find-matches`:
- Resource (CodeSystem/ValueSet) select that shows the canonical URL.
- Version select that emits the **SNOMED edition URI** for SNOMED (so the server routes to the right edition) and the plain version string otherwise.
- Free-text code input with concept autocomplete from the selected system.
- GET/POST request command preview + results panel.
- `$lookup`: **showDesignations** checkbox + **designation-language** multiselect (any language; the version's languages listed first); debounced concept search.
- `$expand`: **includeDesignations** checkbox + **designation-language** multiselect.

### Fixes
- Code-system version edit no longer crashes on an invalid date (`Invalid time value`) — dates are coerced to `Date`.

Builds clean (`ng build`, AOT template check included).