### PR TITLE
Show property-value extensions in concept view mode

### DIFF
--- a/app/src/app/core/ui/components/inputs/property-value-input/entity-property-value-input.component.html
+++ b/app/src/app/core/ui/components/inputs/property-value-input/entity-property-value-input.component.html
@@ -155,6 +155,17 @@
             }
           </span>
         }
+
+        @if (!compact && propertyValue?.extensions?.length) {
+          <div class="extension-view">
+            @for (extension of extensionList(); track extension) {
+              <div class="extension-view__row">
+                <span class="extension-view__url">{{ extension.url }}</span>
+                <span class="extension-view__value">{{ extension | apply:extensionValue }}</span>
+              </div>
+            }
+          </div>
+        }
       </div>
     }
   </m-form-control>

--- a/app/src/app/core/ui/components/inputs/property-value-input/entity-property-value-input.component.ts
+++ b/app/src/app/core/ui/components/inputs/property-value-input/entity-property-value-input.component.ts
@@ -43,6 +43,25 @@ import { environment } from 'environments/environment';
         gap: 0.5rem;
         align-items: start;
       }
+
+      .extension-view {
+        display: grid;
+        gap: 0.15rem;
+        margin-top: 0.25rem;
+      }
+
+      .extension-view__row {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+        gap: 0.5rem;
+        font-size: 0.85em;
+        color: var(--color-text-secondary, #8c8c8c);
+        word-break: break-word;
+      }
+
+      .extension-view__url {
+        font-style: italic;
+      }
     `],
     providers: [
         { provide: NG_VALUE_ACCESSOR, useExisting: forwardRef(() => EntityPropertyValueInputComponent), multi: true },


### PR DESCRIPTION
## Summary

Property-value **extensions** were only visible while editing (behind the "Edit extensions" toggle) or as a hover tooltip in view mode. Customers want to see them on active/published concepts too.

This renders extensions as a visible read-only list under each property value in **view mode**:

```
INCLUSION-RULE   H:9823 | S:000-419,422,440-779 | B:3
                 <ext url>      <ext value>
                 ...
```

### Changes
- `entity-property-value-input.component.html` — in the `viewMode` branch, added a block that lists each extension as a two-column `url` / value row (value via the existing `extensionValue` helper). Gated by `!compact` so table/compact renderings stay clean (the concept detail view isn't compact, so it shows them).
- `entity-property-value-input.component.ts` — added `.extension-view` styles (subtle, secondary-colored, two-column).

No backend/model changes — extensions already travel on `EntityPropertyValue.extensions` and reach the component in view mode. Works for all property types. Existing hover tooltip left in place.

AOT build passes.