### PR TITLE
info: web build metadata + show backend build on /info

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,16 @@ jobs:
 #      - name: Test
 #        run: npm test
 
+      - name: Build metadata
+        env:
+          HEAD_MSG: ${{ github.event.head_commit.message }}
+        run: |
+          echo "BUILD_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_ENV"
+          echo "GIT_COMMIT=${GITHUB_SHA::8}" >> "$GITHUB_ENV"
+          # On a merge to main the commit subject is "Merge pull request #NNN from ..."
+          pr=$(printf '%s' "$HEAD_MSG" | grep -oE '#[0-9]+' | head -1 | tr -d '#' || true)
+          echo "PR_NUMBER=$pr" >> "$GITHUB_ENV"
+
       - name: Build
         run: npm run build
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 /out-tsc
 src/styles/build
 
+# generated at build (etc/generate-version.mjs)
+/app/src/assets/base/version.json
+
 # dependencies
 /node_modules
 

--- a/app/src/app/core/info/info.component.ts
+++ b/app/src/app/core/info/info.component.ts
@@ -18,7 +18,23 @@ import {InfoService} from 'term-web/core/info/info.service';
         <div *m-form-col class="tw-flex-container" style="gap: 2rem">
           <h1 style="margin-top: 2.5rem">
             <div>{{ env.appVersion }}</div>
-            <div class="m-subtitle small">{{ version | async }}</div>
+            @if (webBuild | async; as wb) {
+              <div class="m-subtitle small">
+                @if (wb.buildTime) {<span>built {{ wb.buildTime }}</span>}
+                @if (wb.pr) {<span> · PR #{{ wb.pr }}</span>}
+                @if (wb.commit) {<span> · {{ wb.commit }}</span>}
+              </div>
+            }
+            @if (serviceInfo | async; as si) {
+              <div class="m-subtitle small">service: {{ si.version }}</div>
+              @if (si.buildTime || si.pr || si.commit) {
+                <div class="m-subtitle small">
+                  @if (si.buildTime) {<span>built {{ si.buildTime }}</span>}
+                  @if (si.pr) {<span> · PR #{{ si.pr }}</span>}
+                  @if (si.commit) {<span> · {{ si.commit }}</span>}
+                </div>
+              }
+            }
           </h1>
       
           <section>
@@ -114,6 +130,7 @@ export default class InfoComponent {
   protected service = inject(InfoService);
   protected env = environment;
 
-  protected version = this.service.version();
   protected modules = this.service.modules();
+  protected webBuild = this.service.webBuild();
+  protected serviceInfo = this.service.serviceInfo();
 }

--- a/app/src/app/core/info/info.service.ts
+++ b/app/src/app/core/info/info.service.ts
@@ -22,7 +22,27 @@ export class InfoService {
     return this.cache.put('version', this.http.get<{version: string}>(`${this.baseUrl}`, {context: SKIP_HTTP_ERROR})).pipe(map(r => r.version));
   }
 
+  /** Full backend build metadata from /info (version + build-time/commit/pr, the latter populated after PR #175 lands). */
+  public serviceInfo(): Observable<WebBuild | null> {
+    return this.cache.put('service-info', this.http.get<Record<string, string>>(`${this.baseUrl}`, {context: SKIP_HTTP_ERROR})).pipe(
+      map(r => ({version: r?.['version'], buildTime: r?.['build-time'], commit: r?.['commit'], pr: r?.['pr']})),
+      catchError(() => of(null))
+    );
+  }
+
   public modules(): Observable<string[]> {
     return this.cache.put('modules', this.http.get<string[]>(`${this.baseUrl}/modules`, {context: SKIP_HTTP_ERROR}));
   }
+
+  /** Build metadata of the deployed web bundle (etc/generate-version.mjs → /version.json). Null if absent (e.g. `ng serve`). */
+  public webBuild(): Observable<WebBuild | null> {
+    return this.http.get<WebBuild>(`${environment.baseHref}version.json`, {context: SKIP_HTTP_ERROR}).pipe(catchError(() => of(null)));
+  }
+}
+
+export interface WebBuild {
+  version?: string;
+  buildTime?: string;
+  commit?: string;
+  pr?: string;
 }

--- a/etc/generate-version.mjs
+++ b/etc/generate-version.mjs
@@ -1,0 +1,33 @@
+// Generates app/src/assets/base/version.json (served at /version.json) with build metadata,
+// so a deployed web bundle can be traced back to an exact build. Values come from CI env
+// (BUILD_TIME / GIT_COMMIT / PR_NUMBER) when present, otherwise fall back to git / now.
+// Run from the `prebuild` npm hook, before `ng build`.
+import {execSync} from 'node:child_process';
+import {readFileSync, writeFileSync, mkdirSync} from 'node:fs';
+import {dirname, join} from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const git = (cmd) => {
+  try {
+    return execSync(cmd, {cwd: root, stdio: ['ignore', 'pipe', 'ignore']}).toString().trim();
+  } catch {
+    return '';
+  }
+};
+
+const version = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8')).version;
+const buildTime = process.env.BUILD_TIME || new Date().toISOString();
+const commit = process.env.GIT_COMMIT || git('git rev-parse --short HEAD');
+// On a merge to main the commit subject is "Merge pull request #NNN from ...".
+let pr = process.env.PR_NUMBER || '';
+if (!pr) {
+  const match = git('git log -1 --pretty=%s').match(/#(\d+)/);
+  pr = match ? match[1] : '';
+}
+
+const info = {version, buildTime, commit, pr};
+const dir = join(root, 'app/src/assets/base');
+mkdirSync(dir, {recursive: true});
+writeFileSync(join(dir, 'version.json'), JSON.stringify(info, null, 2) + '\n');
+console.log('Generated version.json:', info);

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "ng serve",
     "start:embedded": "ng serve --configuration embedded",
     "version:sync": "node -e \"const v=require('fs').readFileSync('VERSION','utf8').trim(); const p=require('./package.json'); p.version=v; require('fs').writeFileSync('package.json', JSON.stringify(p,null,2)+'\\n')\"",
-    "prebuild": "npm run version:sync",
+    "prebuild": "npm run version:sync && node etc/generate-version.mjs",
     "build": "ng build",
     "watch:lib": "ng build lib --watch --configuration production",
     "test": "ng test",


### PR DESCRIPTION
## Summary

`/info` showed only the web's package version and the backend version string (`latest` on dev). This surfaces real build metadata for both.

### Web
- `etc/generate-version.mjs` (run from the `prebuild` hook) writes `app/src/assets/base/version.json` → served at **`/version.json`** with `{version, buildTime, commit, pr}`. Values come from CI env (`BUILD_TIME`/`GIT_COMMIT`/`PR_NUMBER`) or fall back to git / now. `build.yml` computes them before `npm run build`. The file is gitignored (build output).
- `InfoService.webBuild()` fetches `/version.json`; the `/info` page shows `built <time> · PR #<n> · <commit>` for the web bundle.

### Backend (on the same page)
- `InfoService.serviceInfo()` reads the full `/info` payload (`version` + `build-time`/`commit`/`pr` — added in termx-server #175) and `/info` renders the backend **version and build line** too.

Takes effect on the next web build/deploy. Before the backend redeploys (#175) the backend build fields are simply absent and only its version shows. AOT build passes; `version.json` lands at `dist/app/version.json`.