### PR TITLE
Version algorithm select for StructureDefinition; trust backend version order

### DIFF
--- a/app/src/app/modeler/_lib/structure-definition/structure-definition.ts
+++ b/app/src/app/modeler/_lib/structure-definition/structure-definition.ts
@@ -38,4 +38,5 @@ export class StructureDefinitionVersion {
   public status?: string;
   public releaseDate?: string;
   public description?: LocalizedName;
+  public algorithm?: string;
 }

--- a/app/src/app/modeler/structure-definition/containers/summary/widgets/structure-definition-versions-widget.component.html
+++ b/app/src/app/modeler/structure-definition/containers/summary/widgets/structure-definition-versions-widget.component.html
@@ -4,7 +4,7 @@
 
 @if (versions?.length > 0) {
   <m-list mSeparated>
-    @for (version of versions | sort: 'version' : 'descend'; track version) {
+    @for (version of versions; track version) {
       <m-list-item mClickable (mClick)="versionSelected.emit(version.version)">
         <div class="m-justify-between">
           <div class="m-items-middle">

--- a/app/src/app/modeler/structure-definition/containers/summary/widgets/structure-definition-versions-widget.component.ts
+++ b/app/src/app/modeler/structure-definition/containers/summary/widgets/structure-definition-versions-widget.component.ts
@@ -1,6 +1,6 @@
 import {Component, EventEmitter, Input, Output, ViewChild, inject} from '@angular/core';
 import {NgForm, FormsModule} from '@angular/forms';
-import {LoadingManager, validateForm, ApplyPipe, LocalDatePipe, SortPipe} from '@termx-health/core-util';
+import {LoadingManager, validateForm, ApplyPipe, LocalDatePipe} from '@termx-health/core-util';
 import {MuiNoDataModule, MuiListModule, MuiDropdownModule, MuiIconModule, MuiModalModule, MuiFormModule, MuiButtonModule, MuiDividerModule, MarinPageLayoutModule} from '@termx-health/ui';
 import {MarinaUtilModule} from '@termx-health/util';
 import {TranslatePipe} from '@ngx-translate/core';
@@ -17,7 +17,7 @@ import {PrivilegedDirective} from 'term-web/core/auth/privileges/privileged.dire
       MuiListModule, MuiNoDataModule, MuiDropdownModule, MuiIconModule, MuiModalModule, MuiFormModule,
       MuiButtonModule, MuiDividerModule, MarinPageLayoutModule, FormsModule,
       TranslatePipe, StatusTagComponent, SemanticVersionSelectComponent, PrivilegedDirective, ApplyPipe,
-      LocalDatePipe, SortPipe, MarinaUtilModule
+      LocalDatePipe, MarinaUtilModule
     ]
 })
 export class StructureDefinitionVersionsWidgetComponent {

--- a/app/src/app/modeler/structure-definition/containers/version/structure-definition-version-edit.component.html
+++ b/app/src/app/modeler/structure-definition/containers/version/structure-definition-version-edit.component.html
@@ -52,6 +52,11 @@
                 <m-multi-language-input name="description" [(ngModel)]="version.description" mInputType="textarea"/>
               </m-form-item>
             </m-form-row>
+            <m-form-row>
+              <m-form-item *mFormCol mName="algorithm" mLabel="entities.resource.version.algorithm">
+                <tw-value-set-concept-select name="algorithm" [(ngModel)]="version.algorithm" valueSet="version-algorithm"></tw-value-set-concept-select>
+              </m-form-item>
+            </m-form-row>
           </form>
         }
 

--- a/app/src/app/modeler/structure-definition/containers/version/structure-definition-version-edit.component.ts
+++ b/app/src/app/modeler/structure-definition/containers/version/structure-definition-version-edit.component.ts
@@ -10,6 +10,7 @@ import {StructureDefinition, StructureDefinitionVersion} from 'term-web/modeler/
 import {StructureDefinitionService} from 'term-web/modeler/structure-definition/services/structure-definition.service';
 import {ResourceContextComponent} from 'term-web/resources/resource/components/resource-context.component';
 import {StatusTagComponent} from 'term-web/core/ui/components/publication-status-tag/status-tag.component';
+import {ValueSetConceptSelectComponent} from 'term-web/resources/_lib/value-set/containers/value-set-concept-select.component';
 import {TranslatePipe} from '@ngx-translate/core';
 
 @Component({
@@ -17,7 +18,8 @@ import {TranslatePipe} from '@ngx-translate/core';
     imports: [
       ResourceContextComponent, MuiFormModule, MuiSpinnerModule, MuiCardModule, MuiInputModule,
       MuiDatePickerModule, MuiSelectModule, MuiButtonModule, MuiIconModule, MuiMultiLanguageInputModule,
-      FormsModule, StatusTagComponent, TranslatePipe, SemanticVersionSelectComponent, AsyncPipe, ApplyPipe
+      FormsModule, StatusTagComponent, TranslatePipe, SemanticVersionSelectComponent, AsyncPipe, ApplyPipe,
+      ValueSetConceptSelectComponent
     ]
 })
 export class StructureDefinitionVersionEditComponent implements OnInit {

--- a/app/src/app/resources/code-system/containers/summary/widgets/code-system-versions-widget.component.html
+++ b/app/src/app/resources/code-system/containers/summary/widgets/code-system-versions-widget.component.html
@@ -4,7 +4,7 @@
 
 @if (versions?.length > 0) {
   <m-list mSeparated>
-    @for (version of versions | sort: 'version' : 'descend' | sort: 'releaseDate': 'descend'; track version) {
+    @for (version of versions; track version) {
       <m-list-item mClickable (mClick)="openVersionSummary(version.version)">
         <div class="m-justify-between">
           <div class="m-items-middle">

--- a/app/src/app/resources/code-system/containers/summary/widgets/code-system-versions-widget.component.ts
+++ b/app/src/app/resources/code-system/containers/summary/widgets/code-system-versions-widget.component.ts
@@ -1,7 +1,7 @@
 import { Component, EventEmitter, Input, Output, ViewChild, OnChanges, SimpleChanges, inject } from '@angular/core';
 import { NgForm, FormsModule } from '@angular/forms';
 import { Router, RouterLink } from '@angular/router';
-import { LoadingManager, validateForm, collect, ApplyPipe, JoinPipe, LocalDatePipe, SortPipe } from '@termx-health/core-util';
+import { LoadingManager, validateForm, collect, ApplyPipe, JoinPipe, LocalDatePipe } from '@termx-health/core-util';
 import { LocalizedName, MarinaUtilModule } from '@termx-health/util';
 import {CodeSystemVersion} from 'term-web/resources/_lib';
 import {AuthService} from 'term-web/core/auth';
@@ -23,7 +23,7 @@ import { PrivilegedPipe } from 'term-web/core/auth/privileges/privileged.pipe';
 @Component({
     selector: 'tw-code-system-versions-widget',
     templateUrl: 'code-system-versions-widget.component.html',
-    imports: [MuiNoDataModule, MuiListModule, MuiDividerModule, MuiCoreModule, StatusTagComponent, PrivilegedDirective, MuiDropdownModule, MuiIconModule, MuiPopconfirmModule, RouterLink, MuiModalModule, MarinPageLayoutModule, FormsModule, MuiFormModule, SemanticVersionSelectComponent, MuiButtonModule, ResourceReleaseModalComponent_1, ValueSetVersionSaveModalComponent_1, TranslatePipe, MarinaUtilModule, ApplyPipe, JoinPipe, LocalDatePipe, SortPipe, HasAnyPrivilegePipe, PrivilegedPipe]
+    imports: [MuiNoDataModule, MuiListModule, MuiDividerModule, MuiCoreModule, StatusTagComponent, PrivilegedDirective, MuiDropdownModule, MuiIconModule, MuiPopconfirmModule, RouterLink, MuiModalModule, MarinPageLayoutModule, FormsModule, MuiFormModule, SemanticVersionSelectComponent, MuiButtonModule, ResourceReleaseModalComponent_1, ValueSetVersionSaveModalComponent_1, TranslatePipe, MarinaUtilModule, ApplyPipe, JoinPipe, LocalDatePipe, HasAnyPrivilegePipe, PrivilegedPipe]
 })
 export class CodeSystemVersionsWidgetComponent implements OnChanges {
   private router = inject(Router);

--- a/app/src/app/resources/map-set/containers/summary/widgets/map-set-versions-widget.component.html
+++ b/app/src/app/resources/map-set/containers/summary/widgets/map-set-versions-widget.component.html
@@ -4,7 +4,7 @@
 
 @if (versions?.length > 0) {
   <m-list mSeparated>
-    @for (version of versions | sort: 'version' : 'descend' | sort: 'releaseDate': 'descend'; track version) {
+    @for (version of versions; track version) {
       <m-list-item mClickable (mClick)="openVersionSummary(version.version)">
         <div class="m-justify-between">
           <div class="m-items-middle">

--- a/app/src/app/resources/map-set/containers/summary/widgets/map-set-versions-widget.component.ts
+++ b/app/src/app/resources/map-set/containers/summary/widgets/map-set-versions-widget.component.ts
@@ -1,7 +1,7 @@
 import { Component, EventEmitter, Input, Output, ViewChild, SimpleChanges, OnChanges, inject } from '@angular/core';
 import { NgForm, FormsModule } from '@angular/forms';
 import {Router} from '@angular/router';
-import { LoadingManager, validateForm, collect, ApplyPipe, JoinPipe, LocalDatePipe, SortPipe } from '@termx-health/core-util';
+import { LoadingManager, validateForm, collect, ApplyPipe, JoinPipe, LocalDatePipe } from '@termx-health/core-util';
 import { LocalizedName, MarinaUtilModule } from '@termx-health/util';
 import {MapSetVersion} from 'term-web/resources/_lib';
 import {AuthService} from 'term-web/core/auth';
@@ -20,7 +20,7 @@ import { PrivilegedPipe } from 'term-web/core/auth/privileges/privileged.pipe';
 @Component({
     selector: 'tw-map-set-versions-widget',
     templateUrl: 'map-set-versions-widget.component.html',
-    imports: [MuiNoDataModule, MuiListModule, MuiDividerModule, StatusTagComponent, PrivilegedDirective, MuiDropdownModule, MuiCoreModule, MuiIconModule, MuiPopconfirmModule, MuiModalModule, MarinPageLayoutModule, FormsModule, MuiFormModule, SemanticVersionSelectComponent, MuiButtonModule, ResourceReleaseModalComponent_1, TranslatePipe, MarinaUtilModule, ApplyPipe, JoinPipe, LocalDatePipe, SortPipe, PrivilegedPipe]
+    imports: [MuiNoDataModule, MuiListModule, MuiDividerModule, StatusTagComponent, PrivilegedDirective, MuiDropdownModule, MuiCoreModule, MuiIconModule, MuiPopconfirmModule, MuiModalModule, MarinPageLayoutModule, FormsModule, MuiFormModule, SemanticVersionSelectComponent, MuiButtonModule, ResourceReleaseModalComponent_1, TranslatePipe, MarinaUtilModule, ApplyPipe, JoinPipe, LocalDatePipe, PrivilegedPipe]
 })
 export class MapSetVersionsWidgetComponent implements OnChanges{
   private router = inject(Router);

--- a/app/src/app/resources/value-set/containers/summary/widgets/value-set-versions-widget.component.html
+++ b/app/src/app/resources/value-set/containers/summary/widgets/value-set-versions-widget.component.html
@@ -4,7 +4,7 @@
 
 @if (versions?.length > 0) {
   <m-list mSeparated>
-    @for (version of versions | sort: 'version' : 'descend' | sort: 'releaseDate': 'descend'; track version) {
+    @for (version of versions; track version) {
       <m-list-item mClickable (mClick)="openVersionSummary(version.version)">
         <div class="m-justify-between">
           <div class="m-items-middle">

--- a/app/src/app/resources/value-set/containers/summary/widgets/value-set-versions-widget.component.ts
+++ b/app/src/app/resources/value-set/containers/summary/widgets/value-set-versions-widget.component.ts
@@ -1,7 +1,7 @@
 import { Component, EventEmitter, Input, Output, ViewChild, SimpleChanges, OnChanges, inject } from '@angular/core';
 import { NgForm, FormsModule } from '@angular/forms';
 import {Router} from '@angular/router';
-import { LoadingManager, validateForm, collect, ApplyPipe, JoinPipe, LocalDatePipe, MapPipe, SortPipe } from '@termx-health/core-util';
+import { LoadingManager, validateForm, collect, ApplyPipe, JoinPipe, LocalDatePipe, MapPipe } from '@termx-health/core-util';
 import { LocalizedName, MarinaUtilModule } from '@termx-health/util';
 import {ValueSetVersion} from 'term-web/resources/_lib';
 import {AuthService} from 'term-web/core/auth';
@@ -21,7 +21,7 @@ import { PrivilegedPipe } from 'term-web/core/auth/privileges/privileged.pipe';
 @Component({
     selector: 'tw-value-set-versions-widget',
     templateUrl: 'value-set-versions-widget.component.html',
-    imports: [MuiNoDataModule, MuiListModule, MuiDividerModule, StatusTagComponent, PrivilegedDirective, MuiDropdownModule, MuiCoreModule, MuiIconModule, MuiPopconfirmModule, MuiAbbreviateModule, EntityPropertyValueInputComponent, FormsModule, MuiModalModule, MarinPageLayoutModule, MuiFormModule, SemanticVersionSelectComponent, MuiButtonModule, ResourceReleaseModalComponent_1, TranslatePipe, MarinaUtilModule, ApplyPipe, JoinPipe, LocalDatePipe, MapPipe, SortPipe, PrivilegedPipe]
+    imports: [MuiNoDataModule, MuiListModule, MuiDividerModule, StatusTagComponent, PrivilegedDirective, MuiDropdownModule, MuiCoreModule, MuiIconModule, MuiPopconfirmModule, MuiAbbreviateModule, EntityPropertyValueInputComponent, FormsModule, MuiModalModule, MarinPageLayoutModule, MuiFormModule, SemanticVersionSelectComponent, MuiButtonModule, ResourceReleaseModalComponent_1, TranslatePipe, MarinaUtilModule, ApplyPipe, JoinPipe, LocalDatePipe, MapPipe, PrivilegedPipe]
 })
 export class ValueSetVersionsWidgetComponent implements OnChanges{
   private router = inject(Router);


### PR DESCRIPTION
## Problem 2 (web side)
Companion to termx-server termx-health/termx-server#187.

### Version list ordering
The CodeSystem / ValueSet / ConceptMap / StructureDefinition version-list widgets sorted client-side with a string `sort` pipe, so `1.0.10` rendered *below* `1.0.9`/`1.0.8`. The backend now returns each resource's versions already ordered by their FHIR `versionAlgorithm`, so the widgets iterate the list as-is. The now-unused `SortPipe` import is removed from all four widgets.

### StructureDefinition algorithm select
CodeSystem / ValueSet / ConceptMap version edit forms already had a `version-algorithm` select; StructureDefinition was missing it. Added:
- `algorithm` field on the `StructureDefinitionVersion` model,
- the `tw-value-set-concept-select valueSet="version-algorithm"` picker on the SD version edit form (same idiom as the other three).

## Verification
`ng build` (development) succeeds — templates and TypeScript typecheck clean.

Depends on termx-health/termx-server#187 (which persists `algorithm` for SD and sorts versions server-side).