### PR TITLE
Default English dates to en-GB (configurable via web.env)

### DIFF
--- a/app/src/app/core/marina/marina-ui-config.module.ts
+++ b/app/src/app/core/marina/marina-ui-config.module.ts
@@ -60,14 +60,19 @@ export class MarinaUiConfigModule {
     translate.onLangChange.subscribe(({lang}) => {
       const localeImports: Record<string, () => Promise<any>> = {
         de: () => import('@angular/common/locales/de'),
-        en: () => import('@angular/common/locales/en'),
+        // English dates follow a regional locale (en-GB by default, en-US via web.env) so day/month
+        // order is unambiguous. The data is registered under the 'en' id below, so translations and
+        // the rest of the app keep using 'en' unchanged — only the date formats differ.
+        en: () => env.englishLocale === 'en-US'
+          ? import('@angular/common/locales/en')
+          : import('@angular/common/locales/en-GB'),
         et: () => import('@angular/common/locales/et'),
         fr: () => import('@angular/common/locales/fr'),
         lt: () => import('@angular/common/locales/lt'),
         nl: () => import('@angular/common/locales/nl'),
       };
       (localeImports[lang]?.() ?? Promise.reject(`No locale data for '${lang}'`))
-        .then(locale => registerLocaleData(locale.default))
+        .then(locale => registerLocaleData(locale.default, lang))
         .catch(e => console.warn(`Failed to register locale data for '${lang}'`, e));
       i18nService.use(lang);
 

--- a/app/src/environments/env.js
+++ b/app/src/environments/env.js
@@ -15,6 +15,7 @@ var twConfig = {
   "snomedBrowserUrl": "${SNOMED_BROWSER_URL}",
   "snomedBrowserDailyBuildUrl": "${SNOMED_BROWSER_DAILY_BUILD_URL}",
   "defaultLanguage": "${DEFAULT_LANGUAGE}",
+  "englishLocale": "${ENGLISH_LOCALE}",
   "uiLanguages": 'json:${UI_LANGUAGES}',
   "contentLanguages": 'json:${CONTENT_LANGUAGES}',
   "extraLanguages": 'json:${EXTRA_LANGUAGES}',

--- a/app/src/environments/environment.base.ts
+++ b/app/src/environments/environment.base.ts
@@ -9,6 +9,12 @@ export interface Environment {
   guestDisabled: boolean,
 
   defaultLanguage: string,
+  /**
+   * Regional locale used to format dates for the English UI language ('en-GB' or 'en-US').
+   * Controls day/month order: en-GB -> 15 Jun 2026 / 15/06/2026, en-US -> Jun 15, 2026 / 6/15/2026.
+   * Defaults to 'en-GB'.
+   */
+  englishLocale?: string,
   uiLanguages: string[],
   contentLanguages: string[],
   /**

--- a/app/src/environments/environment.embedded.ts
+++ b/app/src/environments/environment.embedded.ts
@@ -11,6 +11,7 @@ export const environment: Environment = {
   guestDisabled: true,
 
   defaultLanguage: 'en',
+  englishLocale: 'en-GB',
   uiLanguages: [...UI_LANGS],
   contentLanguages: [...UI_LANGS],
   extraLanguages: {},

--- a/app/src/environments/environment.prod.ts
+++ b/app/src/environments/environment.prod.ts
@@ -12,6 +12,7 @@ export const environment: Environment = {
   guestDisabled: !!dynamicEnv.guestDisabled,
 
   defaultLanguage: dynamicEnv.defaultLanguage || 'en',
+  englishLocale: dynamicEnv.englishLocale || 'en-GB',
   uiLanguages: dynamicEnv.uiLanguages || UI_LANGS,
   contentLanguages: dynamicEnv.contentLanguages || dynamicEnv.uiLanguages || UI_LANGS,
   extraLanguages: dynamicEnv.extraLanguages || {},

--- a/app/src/environments/environment.ts
+++ b/app/src/environments/environment.ts
@@ -11,6 +11,7 @@ export const environment: Environment = {
   guestDisabled: false,
 
   defaultLanguage: 'en',
+  englishLocale: 'en-GB',
   uiLanguages: [...UI_LANGS],
   contentLanguages: [...UI_LANGS],
   extraLanguages: {},


### PR DESCRIPTION
## Why

Angular's `en` locale is en-US, so English dates render month-first (`6/15/2026`) — ambiguous against the day-first convention most non-US users expect.

## What

When the UI language is English, register the configured **English regional locale's data under the `'en'` id**, so date formatting follows it while translations and everything else keep using `'en'` untouched (no decoupling of translation language from date locale):

- **en-GB (default)** → `15/06/2026` (day-first)
- **en-US (opt-in)** → `6/15/2026`

Configurable per-deployment via a new **`ENGLISH_LOCALE`** web.env setting (`englishLocale`, default `en-GB`): `env.js` placeholder + `environment.*` defaults.

## Builds against current `@termx-health/core-util` `^21.0.4`
No new library APIs are used here — this PR is self-contained and ships the **day-first ordering fix** immediately (display + pickers).

## Follow-up for the worded month (15 Jun 2026)
The unambiguous worded-month *display* (`15 Jun 2026`) comes from web-commons [#1](https://github.com/termx-health/web-commons/pull/1) (switches display pipes to the medium format). Sequence:
1. Merge web-commons #1 → publishes `@termx-health/core-util@21.0.5`.
2. Bump this app's `core-util` dep to `^21.0.5` → display becomes `15 Jun 2026` (pickers stay numeric `15/06/2026`). That bump should also switch the release-search filter in `resource-release-modal` to `getDateDisplayFormat` for consistency.

## Note
Not built locally here (install needs the GitHub Packages `NODE_AUTH_TOKEN`); changes are config + a locale-registration tweak with the `en-GB` locale data confirmed present in `@angular/common`.