### PR TITLE
Bump core-util to 21.0.5 (worded-month date display)

### DIFF
--- a/app/src/app/resources/resource/components/resource-release-modal-component.ts
+++ b/app/src/app/resources/resource/components/resource-release-modal-component.ts
@@ -1,7 +1,7 @@
 import { Component, EventEmitter, Input, Output, ViewChild, OnInit, inject } from '@angular/core';
 import { NgForm, FormsModule } from '@angular/forms';
 import {Router} from '@angular/router';
-import { DestroyService, LoadingManager, validateForm, format, getDateFormat, JoinPipe, LocalDatePipe } from '@termx-health/core-util';
+import { DestroyService, LoadingManager, validateForm, format, getDateDisplayFormat, JoinPipe, LocalDatePipe } from '@termx-health/core-util';
 import { LocalizedName, MarinaUtilModule } from '@termx-health/util';
 import { TranslateService, TranslatePipe } from '@ngx-translate/core';
 import {NzSelectItemInterface} from 'ng-zorro-antd/select';
@@ -66,8 +66,8 @@ export class ResourceReleaseModalComponent implements OnInit {
     return release?.code?.toLowerCase().includes(_input.toLowerCase()) ||
       Object.values(release?.names)?.filter(n => n?.toLowerCase()?.includes(_input.toLowerCase()))?.length > 0 ||
       release?.authors?.filter(a => a?.toLowerCase()?.includes(_input.toLowerCase()))?.length > 0 ||
-      format(release?.planned, getDateFormat(this.translateService.currentLang))?.toLowerCase()?.includes(_input.toLowerCase()) ||
-      format(release?.releaseDate, getDateFormat(this.translateService.currentLang))?.toLowerCase()?.includes(_input.toLowerCase());
+      format(release?.planned, getDateDisplayFormat(this.translateService.currentLang))?.toLowerCase()?.includes(_input.toLowerCase()) ||
+      format(release?.releaseDate, getDateDisplayFormat(this.translateService.currentLang))?.toLowerCase()?.includes(_input.toLowerCase());
   };
 
   public openReleaseManagement(): void {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "termx",
       "version": "3.2.1",
+      "hasInstallScript": true,
       "dependencies": {
         "@angular/animations": "^21.0.0",
         "@angular/cdk": "^21.0.0",
@@ -21,7 +22,7 @@
         "@codemirror/lang-markdown": "^6.2.0",
         "@ctrl/tinycolor": "^4.2.0",
         "@ngx-translate/core": "^17.0.0",
-        "@termx-health/core-util": "^21.0.4",
+        "@termx-health/core-util": "^21.0.5",
         "@termx-health/markdown": "^21.0.4",
         "@termx-health/markdown-parser": "^21.0.4",
         "@termx-health/quill": "^21.0.4",
@@ -6742,9 +6743,9 @@
       "license": "MIT"
     },
     "node_modules/@termx-health/core-util": {
-      "version": "21.0.4",
-      "resolved": "https://npm.pkg.github.com/download/@termx-health/core-util/21.0.4/413e6c64b6c81204bf5bfc2a735639f0fe338d5a",
-      "integrity": "sha512-Hmmzed8DuTsr1jkh1LxP3VKFf6BcWu3loAdCppgU8MwBQ557MlE5XeCrcuZH1yAsv5l6SFNkgZrwO4u8c07TAA==",
+      "version": "21.0.5",
+      "resolved": "https://npm.pkg.github.com/download/@termx-health/core-util/21.0.5/f54e97542f62d8be4d64320fc7ae657f54c201df",
+      "integrity": "sha512-azuj6EtTCNuMj2NK7pEQZigrzDRf3o/BSbiR1fqg8QrnwlRX+z6LfZ7KZjl0PTruKaq5jYgBLA8aqkF5QBXo3Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@angular/cdk": ">=21.0.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@codemirror/lang-markdown": "^6.2.0",
     "@ctrl/tinycolor": "^4.2.0",
     "@ngx-translate/core": "^17.0.0",
-    "@termx-health/core-util": "^21.0.4",
+    "@termx-health/core-util": "^21.0.5",
     "@termx-health/markdown": "^21.0.4",
     "@termx-health/markdown-parser": "^21.0.4",
     "@termx-health/quill": "^21.0.4",


### PR DESCRIPTION
**Draft — depends on [web-commons #1](https://github.com/termx-health/web-commons/pull/1) being merged & published first.**

Final step of the date-format work. Picks up `@termx-health/core-util@21.0.5`, whose `localDate`/`localDateTime` pipes render the **medium worded-month** format — e.g. **15 Jun 2026** (en-GB) — while date inputs stay numeric (`15/06/2026`).

## Changes
- `package.json`: `@termx-health/core-util` `^21.0.4` → `^21.0.5`.
- `resource-release-modal`: search filter uses `getDateDisplayFormat` (new in 21.0.5) so it matches the displayed worded dates.

## ⚠️ Before this can merge (must happen after 21.0.5 publishes)
`package-lock.json` can't be resolved until 21.0.5 is on the registry. Once web-commons #1 is merged and the publish workflow runs:
```
git checkout chore/bump-core-util-21.0.5
npm install        # refreshes package-lock.json to core-util@21.0.5
git commit -am 'chore: update lockfile for core-util 21.0.5'
git push
```
Then CI goes green and this can be marked ready & merged.

## Full sequence recap
1. Merge web-commons #1 → publishes `core-util@21.0.5`.
2. Merge termx-web #94 → English = en-GB (`15/06/2026`).
3. Refresh lockfile here (above) → merge → display becomes `15 Jun 2026`.