### PR TITLE
feat(structure-definition): UML diagram tab via external fhir2uml converter

### DIFF
--- a/app/src/app/integration/_lib/fhir-uml-converter/model/fhir-to-uml-request.ts
+++ b/app/src/app/integration/_lib/fhir-uml-converter/model/fhir-to-uml-request.ts
@@ -1,0 +1,14 @@
+export type UmlView = 'Snapshot' | 'Differential';
+export type UmlExport = 'SVG' | 'PNG' | 'Text file';
+
+export class FhirToUmlRequest {
+  public payload: string;
+  public view: UmlView = 'Differential';
+  public exportAs: UmlExport = 'SVG';
+  public attachmentFilename = 'output';
+  public hideRemovedObjects = true;
+  public showConstraints = false;
+  public showBindings = false;
+  public reduceSliceClasses = false;
+  public hideLegend = false;
+}

--- a/app/src/app/integration/_lib/fhir-uml-converter/model/fhir-to-uml-response.ts
+++ b/app/src/app/integration/_lib/fhir-uml-converter/model/fhir-to-uml-response.ts
@@ -1,0 +1,7 @@
+export class FhirToUmlResponse {
+  public body: Blob;
+  public contentType: string;
+  public filename?: string;
+  public warnings?: string[];
+  public errors?: string[];
+}

--- a/app/src/app/integration/_lib/fhir-uml-converter/services/fhir-uml-converter.service.ts
+++ b/app/src/app/integration/_lib/fhir-uml-converter/services/fhir-uml-converter.service.ts
@@ -1,0 +1,45 @@
+import {Injectable} from '@angular/core';
+import {HttpBackend, HttpClient, HttpHeaders} from '@angular/common/http';
+import {catchError, map, Observable, throwError} from 'rxjs';
+import {environment} from 'environments/environment';
+import {FhirToUmlRequest} from '../model/fhir-to-uml-request';
+import {FhirToUmlResponse} from '../model/fhir-to-uml-response';
+
+@Injectable({providedIn: 'root'})
+export class FhirUmlConverterService {
+  private http: HttpClient;
+
+  public constructor(httpBackend: HttpBackend) {
+    // The fhir2uml converter is an external service with no termx auth — use a bare HttpClient
+    // (built off HttpBackend) so the auth interceptor doesn't attach a bearer token.
+    this.http = new HttpClient(httpBackend);
+  }
+
+  public fhirToUml(req: FhirToUmlRequest): Observable<FhirToUmlResponse> {
+    const contentType = req.exportAs === 'PNG' ? 'image/png'
+      : req.exportAs === 'SVG' ? 'image/svg+xml'
+        : 'text/plain';
+
+    const headers = new HttpHeaders({
+      'Accept': `application/json; view=${req.view}`,
+      'Content-Type': contentType,
+      'X-Hide-Removed-Objects': String(req.hideRemovedObjects),
+      'X-Show-Constraints': String(req.showConstraints),
+      'X-Show-Bindings': String(req.showBindings),
+      'X-Reduce-Slice-Classes': String(req.reduceSliceClasses),
+      'X-Hide-Legend': String(req.hideLegend)
+    });
+
+    return this.http.post(`${environment.fhirUmlConverterApi}/fhir2uml`, req.payload, {
+      headers,
+      observe: 'response',
+      responseType: 'blob'
+    }).pipe(
+      map(r => ({
+        body: r.body!,
+        contentType: r.headers.get('Content-Type') ?? ''
+      } as FhirToUmlResponse)),
+      catchError(err => throwError(() => err))
+    );
+  }
+}

--- a/app/src/app/integration/_lib/index.ts
+++ b/app/src/app/integration/_lib/index.ts
@@ -34,3 +34,6 @@ export * from 'term-web/integration/_lib/snomed/pipe/snomed-concept-name-pipe';
 export * from 'term-web/integration/_lib/snomed/services/snomed-lib.service';
 export * from 'term-web/integration/_lib/snomed/services/snomed-translation-lib.service';
 export * from 'term-web/integration/_lib/snomed/util/snomed-util';
+export * from 'term-web/integration/_lib/fhir-uml-converter/model/fhir-to-uml-request';
+export * from 'term-web/integration/_lib/fhir-uml-converter/model/fhir-to-uml-response';
+export * from 'term-web/integration/_lib/fhir-uml-converter/services/fhir-uml-converter.service';

--- a/app/src/app/modeler/structure-definition/containers/version/structure-definition-version-uml.component.html
+++ b/app/src/app/modeler/structure-definition/containers/version/structure-definition-version-uml.component.html
@@ -1,0 +1,69 @@
+<tw-resource-context resourceType="StructureDefinition" [resource]="$any(structureDefinition)" [versions]="$any(versions)" [version]="$any(version)" mode="uml"></tw-resource-context>
+
+<m-page [mLoading]="loader.isLoading">
+  <m-card>
+    <m-title *m-card-header mTitle="web.structure-definition.form.uml.title">
+      <ng-container mControls>
+        <m-button mDisplay="primary" [mLoading]="loader.state['generate']" [disabled]="!contentFhir" (mClick)="generate()">
+          <m-icon mCode="play-circle"></m-icon>&nbsp;{{'web.structure-definition.form.uml.generate' | translate}}
+        </m-button>
+      </ng-container>
+    </m-title>
+
+    <form #form="ngForm">
+      <m-form-row>
+        <m-form-item *mFormCol mName="view" [mLabel]="'web.structure-definition.form.uml.view'">
+          <m-select name="view" [(ngModel)]="request.view">
+            @for (v of views; track v) {
+              <m-option [mLabel]="v" [mValue]="v"></m-option>
+            }
+          </m-select>
+        </m-form-item>
+        <m-form-item *mFormCol mName="exportAs" [mLabel]="'web.structure-definition.form.uml.export'">
+          <m-select name="exportAs" [(ngModel)]="request.exportAs">
+            @for (e of exports; track e) {
+              <m-option [mLabel]="e" [mValue]="e"></m-option>
+            }
+          </m-select>
+        </m-form-item>
+        <m-form-item *mFormCol mName="filename" [mLabel]="'web.structure-definition.form.uml.filename'">
+          <m-input name="filename" [(ngModel)]="request.attachmentFilename"></m-input>
+        </m-form-item>
+      </m-form-row>
+
+      <m-form-row>
+        <div *mFormCol style="display: flex; flex-wrap: wrap; gap: 1rem">
+          <m-checkbox name="showConstraints" [(ngModel)]="request.showConstraints">{{'web.structure-definition.form.uml.show-constraints' | translate}}</m-checkbox>
+          <m-checkbox name="showBindings" [(ngModel)]="request.showBindings">{{'web.structure-definition.form.uml.show-bindings' | translate}}</m-checkbox>
+          <m-checkbox name="hideRemovedObjects" [(ngModel)]="request.hideRemovedObjects">{{'web.structure-definition.form.uml.hide-removed-objects' | translate}}</m-checkbox>
+          <m-checkbox name="reduceSliceClasses" [(ngModel)]="request.reduceSliceClasses">{{'web.structure-definition.form.uml.reduce-slice-classes' | translate}}</m-checkbox>
+          <m-checkbox name="hideLegend" [(ngModel)]="request.hideLegend">{{'web.structure-definition.form.uml.hide-legend' | translate}}</m-checkbox>
+        </div>
+      </m-form-row>
+    </form>
+  </m-card>
+
+  <m-card style="margin-top: 1rem">
+    <m-title *m-card-header mTitle="web.structure-definition.form.uml.diagram">
+      <ng-container mControls>
+        @if (imageUrl || umlText) {
+          <m-button mDisplay="text" m-tooltip mTitle="core.btn.download" (mClick)="download()">
+            <m-icon mCode="download"></m-icon>
+          </m-button>
+        }
+      </ng-container>
+    </m-title>
+
+    <m-spinner [mLoading]="loader.state['generate']">
+      @if (!imageUrl && !umlText) {
+        <m-no-data></m-no-data>
+      }
+      @if (imageUrl) {
+        <img [src]="imageUrl" alt="UML diagram" style="max-width: 100%"/>
+      }
+      @if (umlText) {
+        <pre style="white-space: pre-wrap; word-break: break-word">{{umlText}}</pre>
+      }
+    </m-spinner>
+  </m-card>
+</m-page>

--- a/app/src/app/modeler/structure-definition/containers/version/structure-definition-version-uml.component.ts
+++ b/app/src/app/modeler/structure-definition/containers/version/structure-definition-version-uml.component.ts
@@ -1,0 +1,152 @@
+import {Component, OnInit, inject} from '@angular/core';
+import {ActivatedRoute} from '@angular/router';
+import {FormsModule} from '@angular/forms';
+import {LoadingManager} from '@termx-health/core-util';
+import {MuiNotificationService, MuiCardModule, MuiButtonModule, MuiFormModule, MuiInputModule, MuiSelectModule, MuiCheckboxModule, MuiIconModule, MuiSpinnerModule, MuiTooltipModule, MuiNoDataModule, MarinPageLayoutModule} from '@termx-health/ui';
+import {forkJoin, map, Observable, of} from 'rxjs';
+import {Fhir} from 'fhir/fhir';
+import {ChefService, FhirToUmlRequest, FhirUmlConverterService, UmlExport} from 'term-web/integration/_lib';
+import {StructureDefinition, StructureDefinitionVersion} from 'term-web/modeler/_lib';
+import {StructureDefinitionService} from 'term-web/modeler/structure-definition/services/structure-definition.service';
+import {ResourceContextComponent} from 'term-web/resources/resource/components/resource-context.component';
+import {DomSanitizer, SafeUrl} from '@angular/platform-browser';
+import {TranslatePipe} from '@ngx-translate/core';
+
+@Component({
+  templateUrl: 'structure-definition-version-uml.component.html',
+  imports: [
+    ResourceContextComponent, MuiCardModule, MuiButtonModule, MuiFormModule, MuiInputModule, MuiSelectModule,
+    MuiCheckboxModule, MuiIconModule, MuiSpinnerModule, MuiTooltipModule, MuiNoDataModule, MarinPageLayoutModule,
+    FormsModule, TranslatePipe
+  ]
+})
+export class StructureDefinitionVersionUmlComponent implements OnInit {
+  private route = inject(ActivatedRoute);
+  private structureDefinitionService = inject(StructureDefinitionService);
+  private chefService = inject(ChefService);
+  private fhirUmlConverterService = inject(FhirUmlConverterService);
+  private notificationService = inject(MuiNotificationService);
+  private sanitizer = inject(DomSanitizer);
+
+  protected structureDefinition?: StructureDefinition;
+  protected versions?: StructureDefinitionVersion[];
+  protected version?: StructureDefinitionVersion;
+  protected contentFhir?: string;
+
+  protected request = new FhirToUmlRequest();
+  protected readonly views = ['Snapshot', 'Differential'];
+  protected readonly exports: UmlExport[] = ['SVG', 'PNG', 'Text file'];
+
+  protected imageUrl?: SafeUrl;
+  protected umlText?: string;
+  private generatedBlob?: Blob;
+  private objectUrl?: string;
+  protected generatedExportAs?: UmlExport;
+  protected loader = new LoadingManager();
+
+  public ngOnInit(): void {
+    this.route.paramMap.subscribe(pm => this.loadData(Number(pm.get('id')), pm.get('versionCode')));
+  }
+
+  protected get isImageResponse(): boolean {
+    return this.generatedExportAs === 'SVG' || this.generatedExportAs === 'PNG';
+  }
+
+  private loadData(id: number, versionCode: string): void {
+    this.clearResult();
+    this.loader.wrap('load', forkJoin([
+      this.structureDefinitionService.load(id),
+      this.structureDefinitionService.loadVersion(id, versionCode),
+      this.structureDefinitionService.listVersions(id)
+    ])).subscribe(([sd, version, versions]) => {
+      this.structureDefinition = sd;
+      this.version = version;
+      this.versions = versions;
+      this.request.attachmentFilename = sd?.code || 'structure-definition';
+      this.resolveFhir(version).subscribe();
+    });
+  }
+
+  /** Ensure we have the version's FHIR JSON (convert from FSH when the content is stored as FSH). */
+  private resolveFhir(version: StructureDefinitionVersion): Observable<void> {
+    let content = version?.content;
+    if (!content) {
+      this.contentFhir = undefined;
+      return of(undefined);
+    }
+    if (version.contentFormat === 'json') {
+      if (content.startsWith('<')) {
+        content = String(new Fhir().xmlToObj(content));
+      }
+      this.contentFhir = content;
+      return of(undefined);
+    }
+    return this.loader.wrap('content', this.chefService.fshToFhir({fsh: content}).pipe(map(r => {
+      r.errors?.forEach(e => this.notificationService.error('FSH to FHIR conversion failed', e.message!, {duration: 0, closable: true}));
+      this.contentFhir = JSON.stringify(r.fhir?.[0], null, 2);
+    })));
+  }
+
+  public generate(): void {
+    if (!this.contentFhir) {
+      this.notificationService.warning('No content', 'This version has no FHIR content to render.');
+      return;
+    }
+    this.clearResult();
+    this.request.payload = this.contentFhir;
+    this.loader.wrap('generate', this.fhirUmlConverterService.fhirToUml(this.request)).subscribe({
+      next: resp => {
+        this.generatedExportAs = this.request.exportAs;
+        this.generatedBlob = resp.body;
+        if (this.isImageResponse) {
+          this.objectUrl = URL.createObjectURL(resp.body);
+          this.imageUrl = this.sanitizer.bypassSecurityTrustUrl(this.objectUrl);
+        } else {
+          resp.body.text().then(t => this.umlText = t);
+        }
+      },
+      error: err => this.handleError(err)
+    });
+  }
+
+  public download(): void {
+    if (!this.generatedBlob) {
+      return;
+    }
+    const ext = this.generatedExportAs === 'PNG' ? 'png' : this.generatedExportAs === 'SVG' ? 'svg' : 'txt';
+    const url = URL.createObjectURL(this.generatedBlob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${this.request.attachmentFilename || 'output'}.${ext}`;
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+
+  private clearResult(): void {
+    if (this.objectUrl) {
+      URL.revokeObjectURL(this.objectUrl);
+      this.objectUrl = undefined;
+    }
+    this.imageUrl = undefined;
+    this.umlText = undefined;
+    this.generatedBlob = undefined;
+    this.generatedExportAs = undefined;
+  }
+
+  private handleError(err: any): void {
+    if (err?.error instanceof Blob && err.error.type?.includes('application/json')) {
+      err.error.text().then((t: string) => {
+        let msg = t;
+        try {
+          const parsed = JSON.parse(t);
+          msg = parsed?.message || parsed?.error || t;
+        } catch {
+          // keep raw text
+        }
+        this.notificationService.error('Generation failed', msg);
+      });
+    } else {
+      this.notificationService.error('Generation failed', 'An error occurred while generating the UML diagram.');
+    }
+  }
+}

--- a/app/src/app/modeler/structure-definition/structure-definition.module.ts
+++ b/app/src/app/modeler/structure-definition/structure-definition.module.ts
@@ -14,6 +14,7 @@ import {StructureDefinitionSummaryComponent} from 'term-web/modeler/structure-de
 import {StructureDefinitionVersionSummaryComponent} from 'term-web/modeler/structure-definition/containers/version/structure-definition-version-summary.component';
 import {StructureDefinitionVersionContentComponent} from 'term-web/modeler/structure-definition/containers/version/structure-definition-version-content.component';
 import {StructureDefinitionVersionEditComponent} from 'term-web/modeler/structure-definition/containers/version/structure-definition-version-edit.component';
+import {StructureDefinitionVersionUmlComponent} from 'term-web/modeler/structure-definition/containers/version/structure-definition-version-uml.component';
 import {StructureDefinitionService} from 'term-web/modeler/structure-definition/services/structure-definition.service';
 
 export const STRUCTURE_DEFINITION_ROUTES: Routes = [
@@ -28,6 +29,7 @@ export const STRUCTURE_DEFINITION_ROUTES: Routes = [
   {path: 'structure-definitions/:id/versions/:versionCode/elements', component: StructureDefinitionVersionContentComponent, data: {privilege: ['{id}.StructureDefinition.read'], contentMode: 'elements'}},
   {path: 'structure-definitions/:id/versions/:versionCode/fsh', component: StructureDefinitionVersionContentComponent, data: {privilege: ['{id}.StructureDefinition.read'], contentMode: 'fsh'}},
   {path: 'structure-definitions/:id/versions/:versionCode/json', component: StructureDefinitionVersionContentComponent, data: {privilege: ['{id}.StructureDefinition.read'], contentMode: 'json'}},
+  {path: 'structure-definitions/:id/versions/:versionCode/uml', component: StructureDefinitionVersionUmlComponent, data: {privilege: ['{id}.StructureDefinition.read']}},
   // {path: 'structure-definitions/:id/view', component: StructureDefinitionViewComponent, data: {privilege: ['{id}.StructureDefinition.read']}},
 ];
 
@@ -45,6 +47,7 @@ export const STRUCTURE_DEFINITION_ROUTES: Routes = [
         StructureDefinitionVersionSummaryComponent,
         StructureDefinitionVersionContentComponent,
         StructureDefinitionVersionEditComponent,
+        StructureDefinitionVersionUmlComponent,
         StructureDefinitionTypeListComponent,
         StructureDefinitionConstraintListComponent
     ],

--- a/app/src/app/resources/resource/components/resource-context.component.html
+++ b/app/src/app/resources/resource/components/resource-context.component.html
@@ -45,6 +45,11 @@
                 <a class="submenu__item" [routerLink]="navigate('json')" routerLinkActive="active">
                   <ng-container *ngTemplateOutlet="tabTpl; context: {title: 'web.structure-definition.form.json-header', icon: 'file-text'}"/>
                 </a>
+                @if (umlEnabled) {
+                  <a class="submenu__item" [routerLink]="navigate('uml')" routerLinkActive="active">
+                    <ng-container *ngTemplateOutlet="tabTpl; context: {title: 'web.structure-definition.form.uml-header', icon: 'apartment'}"/>
+                  </a>
+                }
               }
               @if (!(['TerminologyServer', 'StructureDefinition'] | includes: resourceType)) {
                 <a class="submenu__item" [routerLink]="navigate('provenances')" routerLinkActive="active">

--- a/app/src/app/resources/resource/components/resource-context.component.ts
+++ b/app/src/app/resources/resource/components/resource-context.component.ts
@@ -8,6 +8,7 @@ import { TranslatePipe } from '@ngx-translate/core';
 import { MarinaUtilModule } from '@termx-health/util';
 import { ApplyPipe, IncludesPipe } from '@termx-health/core-util';
 import { PrivilegedPipe } from 'term-web/core/auth/privileges/privileged.pipe';
+import { environment } from 'environments/environment';
 
 @Component({
     selector: 'tw-resource-context',
@@ -37,7 +38,10 @@ export class ResourceContextComponent {
   @Input() public conceptCode: string;
   @Input() public version: ResourceVersion;
   @Input() public versions: ResourceVersion[];
-  @Input() public mode: 'summary' | 'details' | 'concept-list' | 'concept-edit' | 'concept-view' | 'provenance' | 'properties' | 'checklist' | 'resources' | 'elements' | 'fsh' | 'json' = 'summary';
+  @Input() public mode: 'summary' | 'details' | 'concept-list' | 'concept-edit' | 'concept-view' | 'provenance' | 'properties' | 'checklist' | 'resources' | 'elements' | 'fsh' | 'json' | 'uml' = 'summary';
+
+  /** The StructureDefinition UML tab is shown only when an external fhir2uml service is configured. */
+  protected umlEnabled = !!environment.fhirUmlConverterApi;
 
   protected typeMap = {'CodeSystem': 'code-systems', 'ValueSet': 'value-sets', 'MapSet': 'map-sets', 'ImplementationGuide': 'implementation-guides', 'TerminologyServer': 'servers', 'StructureDefinition': 'structure-definitions'};
   protected routePrefix = (type: string): string => type === 'TerminologyServer' ? '/' : type === 'StructureDefinition' ? '/modeler' : '/resources';
@@ -57,7 +61,8 @@ export class ResourceContextComponent {
         'checklist': [...base, 'checklists'],
         'elements': [...base, 'summary'],
         'fsh': [...base, 'summary'],
-        'json': [...base, 'summary']
+        'json': [...base, 'summary'],
+        'uml': [...base, 'summary']
       };
       this.router.navigate(commands[this.mode], {replaceUrl: true});
     } else {
@@ -80,6 +85,7 @@ export class ResourceContextComponent {
       'elements': [...base, 'elements'],
       'fsh': [...base, 'fsh'],
       'json': [...base, 'json'],
+      'uml': [...base, 'uml'],
     };
     this.router.navigate(commands[this.mode], {replaceUrl: true});
   }

--- a/app/src/assets/i18n/en.json
+++ b/app/src/assets/i18n/en.json
@@ -2373,6 +2373,21 @@
 				"fixed-uri": "Fixed URI",
 				"fsh-header": "FSH",
 				"json-header": "JSON",
+				"uml-header": "UML",
+				"uml": {
+					"title": "UML diagram",
+					"diagram": "Diagram",
+					"view": "View",
+					"export": "Export as",
+					"filename": "File name",
+					"show-constraints": "Show constraints",
+					"show-bindings": "Show bindings",
+					"hide-removed-objects": "Hide removed objects",
+					"reduce-slice-classes": "Reduce slice classes",
+					"hide-legend": "Hide legend",
+					"generate": "Generate",
+					"empty": "No diagram generated yet"
+				},
 				"modal": {
 					"content": "You have unsaved changes!",
 					"no-save-proceed": "Proceed",

--- a/app/src/environments/env.js
+++ b/app/src/environments/env.js
@@ -10,6 +10,7 @@ var twConfig = {
   "chefFhirVersion": "${CHEF_FHIR_VERSION}",
   "plantUmlUrl": "${PLANT_UML_URL}",
   "fmlEditor": "${FML_EDITOR}",
+  "fhirUmlConverterApi": "${FHIR_UML_CONVERTER_API}",
   "snowstormUrl": "${SNOWSTORM_URL}",
   "snowstormDailyBuildUrl": "${SNOWSTORM_DAILY_BUILD_URL}",
   "snomedBrowserUrl": "${SNOMED_BROWSER_URL}",

--- a/app/src/environments/environment.base.ts
+++ b/app/src/environments/environment.base.ts
@@ -40,6 +40,8 @@ export interface Environment {
   chefFhirVersion?: string,
   plantUmlUrl?: string,
   fmlEditor?: string,
+  /** Base URL of the external FHIR→UML converter (fhir2uml). When unset, the StructureDefinition UML tab is hidden. */
+  fhirUmlConverterApi?: string,
 
   snowstormUrl?: string,
   snomedBrowserUrl?: string,

--- a/app/src/environments/environment.prod.ts
+++ b/app/src/environments/environment.prod.ts
@@ -27,6 +27,7 @@ export const environment: Environment = {
   chefFhirVersion: dynamicEnv.chefFhirVersion || '5.0.0',
   plantUmlUrl: dynamicEnv.plantUmlUrl || '/plantuml',
   fmlEditor: dynamicEnv.fmlEditor || '/fml-editor',
+  fhirUmlConverterApi: dynamicEnv.fhirUmlConverterApi,
 
   snowstormUrl: dynamicEnv.snowstormUrl,
   snomedBrowserUrl: dynamicEnv.snomedBrowserUrl,

--- a/app/src/environments/environment.ts
+++ b/app/src/environments/environment.ts
@@ -33,6 +33,8 @@ export const environment: Environment = {
   chefFhirVersion: '5.0.0',
   plantUmlUrl: 'https://demo.termx.org/plantuml',
   fmlEditor: 'https://demo.termx.org/fml-editor',
+  // Set to a reachable fhir2uml service base URL to enable the StructureDefinition UML tab, e.g.:
+  // fhirUmlConverterApi: 'http://localhost:8080/api',
 
   snowstormUrl: 'https://snowstorm.termx.org/',
   snomedBrowserUrl: 'https://snomed.termx.org/',

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -78,6 +78,7 @@ web.env (env vars)  ──envsubst──▶  assets/env.js  ──▶  window.tw
 | `CHEF_FHIR_VERSION` | `5.0.0` | FHIR version passed to Chef. |
 | `PLANT_UML_URL` | `/plantuml` | PlantUML server endpoint (diagram rendering). |
 | `FML_EDITOR` | `/fml-editor` | FHIR Mapping Language editor endpoint. |
+| `FHIR_UML_CONVERTER_API` | *(empty)* | Base URL of the external [fhir2uml](https://fhir-uml-converter.online) converter. When set, the StructureDefinition **UML** diagram tab appears (it renders a class diagram from the version's FHIR content via this service); empty/unset hides the tab. |
 
 ## 6. SNOMED CT browsing links (optional)
 


### PR DESCRIPTION
Re-implements the old `fhir-uml-converter` branch against the **current** StructureDefinition UI (the original was built on the pre-migration component and couldn't be rebased). Adds a **"UML" tab** on the SD version view that renders a class diagram from the version's FHIR content via an external `fhir2uml` service.

## What's included
- **`integration/_lib/fhir-uml-converter/`** — `FhirToUmlRequest`/`FhirToUmlResponse` models + a token-less `FhirUmlConverterService` (POSTs the SD to `${fhirUmlConverterApi}/fhir2uml`, returns SVG/PNG/text), following the existing **`chef`** integration pattern.
- **`StructureDefinitionVersionUmlComponent`** (new routed component): loads the version, resolves its FHIR JSON (converts FSH→FHIR via chef when needed), exposes view (Snapshot/Differential), export (SVG/PNG/Text) and the constraint/binding/legend/slice/removed toggles, renders the diagram inline + download.
- **Tab** wired into `tw-resource-context`, next to FSH/JSON — **shown only when `environment.fhirUmlConverterApi` is configured** (`umlEnabled`), per request. Route + module declaration added.
- **`fhirUmlConverterApi`** env var (interface + commented example) — **unset by default**, so the tab stays hidden until a backend is configured. `en.json` labels added.

## Caveats
- **External backend, off by default.** `fhir2uml` is a third-party/self-hosted service (the old published host `fhir-uml-converter.online` is currently down). The feature is inert until you set `fhirUmlConverterApi` to a reachable instance (dev option: `http://localhost:8080/api`).
- **Runtime-unverified.** `ng build` (development) passes, but the live generate flow can't be exercised without a reachable `fhir2uml` service.
- i18n labels are **en-only** for now (other languages fall back to English) — can add LT/RU/ET in a follow-up.

## Verification
`ng build --configuration development` succeeds (after `npm ci` to pick up the core-util 21.0.5 bump from #95).