### PR TITLE
i18n: StructureDefinition UML tab labels for cs/de/et/fr/lt/nl

### DIFF
--- a/app/src/assets/i18n/cs.json
+++ b/app/src/assets/i18n/cs.json
@@ -2336,6 +2336,21 @@
         "fixed-uri": "Pevné URI",
         "fsh-header": "FSH",
         "json-header": "JSON",
+        "uml-header": "UML",
+        "uml": {
+          "title": "UML diagram",
+          "diagram": "Diagram",
+          "view": "Zobrazení",
+          "export": "Exportovat jako",
+          "filename": "Název souboru",
+          "show-constraints": "Zobrazit omezení",
+          "show-bindings": "Zobrazit vazby",
+          "hide-removed-objects": "Skrýt odebrané objekty",
+          "reduce-slice-classes": "Zredukovat slice třídy",
+          "hide-legend": "Skrýt legendu",
+          "generate": "Generovat",
+          "empty": "Zatím nebyl vygenerován žádný diagram"
+        },
         "modal": {
           "content": "Máte neuložené změny!",
           "no-save-proceed": "Pokračovat",

--- a/app/src/assets/i18n/de.json
+++ b/app/src/assets/i18n/de.json
@@ -2222,6 +2222,21 @@
         "fixed-uri": "Fixed URI",
         "fsh-header": "FSH",
         "json-header": "JSON",
+        "uml-header": "UML",
+        "uml": {
+          "title": "UML-Diagramm",
+          "diagram": "Diagramm",
+          "view": "Ansicht",
+          "export": "Exportieren als",
+          "filename": "Dateiname",
+          "show-constraints": "Einschränkungen anzeigen",
+          "show-bindings": "Bindungen anzeigen",
+          "hide-removed-objects": "Entfernte Objekte ausblenden",
+          "reduce-slice-classes": "Slice-Klassen reduzieren",
+          "hide-legend": "Legende ausblenden",
+          "generate": "Generieren",
+          "empty": "Noch kein Diagramm generiert"
+        },
         "modal": {
           "content": "You have unsaved changes!",
           "no-save-proceed": "Fortfahren",

--- a/app/src/assets/i18n/et.json
+++ b/app/src/assets/i18n/et.json
@@ -2101,6 +2101,21 @@
 				"fixed-uri": "Fikseeritud URI",
 				"fsh-header": "FSH",
 				"json-header": "JSON",
+				"uml-header": "UML",
+				"uml": {
+					"title": "UML-diagramm",
+					"diagram": "Diagramm",
+					"view": "Vaade",
+					"export": "Ekspordi kujul",
+					"filename": "Faili nimi",
+					"show-constraints": "Näita kitsendusi",
+					"show-bindings": "Näita seoseid",
+					"hide-removed-objects": "Peida eemaldatud objektid",
+					"reduce-slice-classes": "Vähenda slice-klasse",
+					"hide-legend": "Peida legend",
+					"generate": "Genereeri",
+					"empty": "Diagrammi pole veel genereeritud"
+				},
 				"modal": {
 					"content": "Teil on salvestamata muudatused!",
 					"no-save-proceed": "Jätka",

--- a/app/src/assets/i18n/fr.json
+++ b/app/src/assets/i18n/fr.json
@@ -2222,6 +2222,21 @@
         "fixed-uri": "Fixed URI",
         "fsh-header": "FSH",
         "json-header": "JSON",
+        "uml-header": "UML",
+        "uml": {
+          "title": "Diagramme UML",
+          "diagram": "Diagramme",
+          "view": "Vue",
+          "export": "Exporter en",
+          "filename": "Nom du fichier",
+          "show-constraints": "Afficher les contraintes",
+          "show-bindings": "Afficher les liaisons",
+          "hide-removed-objects": "Masquer les objets supprimés",
+          "reduce-slice-classes": "Réduire les classes de slice",
+          "hide-legend": "Masquer la légende",
+          "generate": "Générer",
+          "empty": "Aucun diagramme généré"
+        },
         "modal": {
           "content": "You have unsaved changes!",
           "no-save-proceed": "Continuer",

--- a/app/src/assets/i18n/lt.json
+++ b/app/src/assets/i18n/lt.json
@@ -2271,6 +2271,21 @@
         "fixed-uri": "Fiksuotasis URI",
         "fsh-header": "FSH",
         "json-header": "JSON",
+        "uml-header": "UML",
+        "uml": {
+          "title": "UML diagrama",
+          "diagram": "Diagrama",
+          "view": "Rodinys",
+          "export": "Eksportuoti kaip",
+          "filename": "Failo pavadinimas",
+          "show-constraints": "Rodyti apribojimus",
+          "show-bindings": "Rodyti susiejimus",
+          "hide-removed-objects": "Slėpti pašalintus objektus",
+          "reduce-slice-classes": "Sumažinti slice klases",
+          "hide-legend": "Slėpti legendą",
+          "generate": "Generuoti",
+          "empty": "Diagrama dar nesugeneruota"
+        },
         "modal": {
           "content": "Turite neišsaugotų pakeitimų!",
           "no-save-proceed": "Tęsti",

--- a/app/src/assets/i18n/nl.json
+++ b/app/src/assets/i18n/nl.json
@@ -2226,6 +2226,21 @@
         "fixed-uri": "Fixed URI",
         "fsh-header": "FSH",
         "json-header": "JSON",
+        "uml-header": "UML",
+        "uml": {
+          "title": "UML-diagram",
+          "diagram": "Diagram",
+          "view": "Weergave",
+          "export": "Exporteren als",
+          "filename": "Bestandsnaam",
+          "show-constraints": "Beperkingen tonen",
+          "show-bindings": "Bindingen tonen",
+          "hide-removed-objects": "Verwijderde objecten verbergen",
+          "reduce-slice-classes": "Slice-klassen verminderen",
+          "hide-legend": "Legenda verbergen",
+          "generate": "Genereren",
+          "empty": "Nog geen diagram gegenereerd"
+        },
         "modal": {
           "content": "You have unsaved changes!",
           "no-save-proceed": "Doorgaan",


### PR DESCRIPTION
Follow-up to #97, which shipped the UML tab with **English-only** labels. This adds the `uml-header` + `uml.*` keys to the other six UI languages (`cs`, `de`, `et`, `fr`, `lt`, `nl`).

- Key set matches `en.json` exactly (verified: 13 keys each, no missing/extra).
- Harmless until the feature is enabled (the tab is gated on `fhirUmlConverterApi`), but prevents raw translation keys from showing in non-English deployments once it is.
- `ng build` (development) passes.

⚠️ Translations are **best-effort** (standard UI terms) and worth a native-speaker review before relying on them — same caveat as the earlier LT hlx-ui labels work.