### PR TITLE
fix(structure-definition): generate snapshot for UML via chef v2

### DIFF
--- a/app/src/app/integration/_lib/chef/services/chef.service.ts
+++ b/app/src/app/integration/_lib/chef/services/chef.service.ts
@@ -25,6 +25,25 @@ export class ChefService {
     return this.http.post(`${environment.chefUrl}/fsh2fhir`, req).pipe(catchError(err => of(err.error)));
   }
 
+  /**
+   * FSH -> FHIR via the chef v2 endpoint, which accepts a `snapshot` option so SUSHI generates
+   * the snapshot. Needed for UML rendering: FSH-authored definitions (logical models, profiles)
+   * otherwise ship only a differential, and the FHIR->UML converter renders from the snapshot.
+   * v2 takes raw FSH as the body with options in the Content-Type header.
+   */
+  public fshToFhirV2(fsh: string, options?: {fhirVersion?: string; snapshot?: boolean; canonical?: string; version?: string}): Observable<FshToFhirResponse> {
+    const opts: {[key: string]: string | boolean} = {
+      fhirVersion: `${environment.chefFhirVersion}` || '5.0.0',
+      ...options
+    };
+    const params = Object.entries(opts)
+      .filter(([, v]) => v !== undefined && v !== null && v !== '')
+      .map(([k, v]) => `${k}=${v}`)
+      .join('; ');
+    const headers = {'Content-Type': `application/fsh${params ? '; ' + params : ''}`};
+    return this.http.post(`${environment.chefUrl}/v2/fsh2fhir`, fsh, {headers}).pipe(catchError(err => of(err.error)));
+  }
+
   public fhirToFsh(req: FhirToFshRequest, version: string = '5.0.0'): Observable<FhirToFshResponse> {
     const igResource = {
       resourceType: 'ImplementationGuide',

--- a/app/src/app/modeler/structure-definition/containers/version/structure-definition-version-uml.component.ts
+++ b/app/src/app/modeler/structure-definition/containers/version/structure-definition-version-uml.component.ts
@@ -81,7 +81,9 @@ export class StructureDefinitionVersionUmlComponent implements OnInit {
       this.contentFhir = content;
       return of(undefined);
     }
-    return this.loader.wrap('content', this.chefService.fshToFhir({fsh: content}).pipe(map(r => {
+    // Request a generated snapshot: the FHIR->UML converter renders from the snapshot, but
+    // FSH-authored definitions (logical models, profiles) ship only a differential otherwise.
+    return this.loader.wrap('content', this.chefService.fshToFhirV2(content, {snapshot: true}).pipe(map(r => {
       r.errors?.forEach(e => this.notificationService.error('FSH to FHIR conversion failed', e.message!, {duration: 0, closable: true}));
       this.contentFhir = JSON.stringify(r.fhir?.[0], null, 2);
     })));


### PR DESCRIPTION
## Problem
The StructureDefinition **UML tab** showed the PlantUML *"Welcome to PlantUML!"* placeholder for FSH-authored **logical models** (and any FSH profile without a snapshot).

## Cause
The tab converts FSH→FHIR via `ChefService.fshToFhir` → chef **v1** `/fsh2fhir`, which returns the FHIR with **only a differential** (SUSHI does not generate a snapshot by default). The external `fhir2uml` converter renders classes from the **snapshot**, so it produced an empty diagram.

## Fix
Call chef **v2** `/fsh2fhir` with `snapshot=true`, so SUSHI generates the snapshot before the FHIR reaches the converter.

- New `ChefService.fshToFhirV2(fsh, {snapshot: true, ...})` — v2 takes raw FSH as the body with options in the `Content-Type` header (`application/fsh; fhirVersion=…; snapshot=true`).
- `StructureDefinitionVersionUmlComponent.resolveFhir` uses it. Other `fshToFhir` callers (tree/content views) are untouched.

## Verified
Against `demo.termx.org/chef`: a `Logical: … Parent: Element` model returns **0** snapshot elements without the flag and **6** with `snapshot=true`; feeding that snapshot to `fhir2uml` renders a full class diagram (incl. inherited `Element` fields). Pairs with termx-health/fhir-to-uml#3 (defensive NPE guard in the converter).