### PR TITLE
FHIR tx-ecosystem conformance UI (Phase 4)

### DIFF
--- a/app/src/app/integration/fhir/conformance/fhir-conformance.component.html
+++ b/app/src/app/integration/fhir/conformance/fhir-conformance.component.html
@@ -1,0 +1,72 @@
+<div class="m-items-middle" style="flex-direction: column">
+  <m-card>
+    <div *m-card-header class="m-justify-between">
+      <div>
+        <m-title>FHIR terminology conformance</m-title>
+        <div class="m-subtitle" style="margin-top: 0.25rem;">
+          Runs the official HL7 tx-ecosystem test suite against this server's FHIR endpoint.
+        </div>
+      </div>
+      <ng-container *twPrivileged="'*.CodeSystem.write'">
+        <m-button mDisplay="primary" [mLoading]="running" (mClick)="run()">Run conformance tests</m-button>
+      </ng-container>
+    </div>
+    <div *mCardContent>
+      <m-form-row>
+        <m-form-item *mFormCol mLabel="Suite (optional, blank = all)">
+          <m-input name="suite" [(ngModel)]="suite" placeholder="e.g. simple-cases"></m-input>
+        </m-form-item>
+        <m-form-item *mFormCol mLabel="Custom test bundle (optional)">
+          @if (!bundleName) {
+            <input type="file" (change)="onFileSelected($event)"/>
+            @if (uploadProgress !== undefined) {
+              <nz-progress [nzPercent]="uploadProgress || 0"></nz-progress>
+            }
+          } @else {
+            <span>{{bundleName}} <m-button mDisplay="text" (mClick)="clearBundle()">remove</m-button></span>
+          }
+        </m-form-item>
+      </m-form-row>
+
+      @if (running) {
+        <m-form-row>
+          <m-form-item *mFormCol>
+            <div class="m-bold">{{progressNote || 'Running conformance tests…'}}</div>
+            <nz-progress [nzPercent]="progress || 0" nzStatus="active" [nzShowInfo]="false"></nz-progress>
+          </m-form-item>
+        </m-form-row>
+      }
+
+      @if (error) {
+        <m-alert mType="error" [mContent]="error"></m-alert>
+      }
+    </div>
+  </m-card>
+
+  @if (report) {
+    <m-card>
+      <div *m-card-header class="m-justify-between">
+        <m-title>Result: {{report.result}}</m-title>
+        <div class="m-items-middle">
+          <span>Score: {{report.score}}</span>
+          <span style="margin-left: 1rem;">{{passedCount}} / {{tests.length}} passed</span>
+        </div>
+      </div>
+      <m-table [mData]="tests">
+        <tr *mTableHead>
+          <th>Test</th>
+          <th>Result</th>
+        </tr>
+        @for (t of tests; track t.name) {
+          <tr>
+            <td>{{t.name}}</td>
+            <td>{{t.result}}</td>
+          </tr>
+        }
+        <tr *mTableNoData>
+          <td colspan="2">No tests</td>
+        </tr>
+      </m-table>
+    </m-card>
+  }
+</div>

--- a/app/src/app/integration/fhir/conformance/fhir-conformance.component.ts
+++ b/app/src/app/integration/fhir/conformance/fhir-conformance.component.ts
@@ -1,0 +1,137 @@
+import {Component, inject} from '@angular/core';
+import {FormsModule} from '@angular/forms';
+import {
+  MuiAlertModule,
+  MuiButtonModule,
+  MuiCardModule,
+  MuiCoreModule,
+  MuiFormModule,
+  MuiInputModule,
+  MuiNotificationService,
+  MuiTableModule
+} from '@termx-health/ui';
+import {NzProgressModule} from 'ng-zorro-antd/progress';
+import {PrivilegedDirective} from 'term-web/core/auth/privileges/privileged.directive';
+import {BobLibService, LorqueLibService} from 'term-web/sys/_lib';
+import {LorqueProcess} from 'term-web/sys/_lib/lorque/model/lorque-process';
+import {FhirConformanceService} from './fhir-conformance.service';
+
+interface TxTestRow {
+  name: string;
+  result: string;
+}
+
+/**
+ * Runs the official HL7 tx-ecosystem terminology conformance suite against this server
+ * (backend {@code POST /tx-conformance/runs}), polls the async LorqueProcess, and renders the
+ * resulting FHIR TestReport. Optionally uploads a custom test bundle to the {@code tx-conformance}
+ * Bob container first. Mirrors the SNOMED RF2 import screen.
+ */
+@Component({
+  templateUrl: './fhir-conformance.component.html',
+  imports: [
+    MuiCardModule, MuiButtonModule, MuiFormModule, MuiInputModule, MuiTableModule,
+    MuiAlertModule, MuiCoreModule, NzProgressModule, FormsModule, PrivilegedDirective
+  ],
+  providers: [FhirConformanceService]
+})
+export class FhirConformanceComponent {
+  private conformanceService = inject(FhirConformanceService);
+  private bobService = inject(BobLibService);
+  private lorqueService = inject(LorqueLibService);
+  private notificationService = inject(MuiNotificationService);
+
+  protected suite?: string;
+  protected running = false;
+  protected progress = 0;
+  protected progressNote?: string;
+
+  protected uploadProgress?: number;
+  protected bundleUuid?: string;
+  protected bundleName?: string;
+
+  protected report?: any;
+  protected tests: TxTestRow[] = [];
+  protected error?: string;
+
+  protected onFileSelected(event: Event): void {
+    const file = (event.target as HTMLInputElement).files?.[0];
+    if (!file) {
+      return;
+    }
+    this.uploadProgress = 0;
+    this.bobService.upload({container: 'tx-conformance', file, filename: file.name, meta: {kind: 'tx-test-bundle'}}).subscribe({
+      next: e => {
+        if (e.finished) {
+          this.bundleUuid = e.body?.uuid;
+          this.bundleName = file.name;
+          this.uploadProgress = undefined;
+          this.notificationService.success('Test bundle uploaded');
+        } else {
+          this.uploadProgress = e.progress;
+        }
+      },
+      error: () => {
+        this.uploadProgress = undefined;
+        this.notificationService.error('Test bundle upload failed');
+      }
+    });
+  }
+
+  protected clearBundle(): void {
+    this.bundleUuid = undefined;
+    this.bundleName = undefined;
+  }
+
+  protected run(): void {
+    this.running = true;
+    this.progress = 0;
+    this.progressNote = undefined;
+    this.report = undefined;
+    this.tests = [];
+    this.error = undefined;
+
+    this.conformanceService.run({suite: this.suite || undefined, archiveUuid: this.bundleUuid}).subscribe({
+      next: process => {
+        this.lorqueService.pollProcessProgress(process.id).subscribe({
+          next: p => {
+            this.progress = p.progressPercent ?? this.progress;
+            this.progressNote = p.progressNote;
+            if (p.status && p.status.toLowerCase() !== 'running') {
+              this.finish(p);
+            }
+          },
+          error: () => {
+            this.running = false;
+            this.error = 'Failed while polling the conformance run';
+          }
+        });
+      },
+      error: () => {
+        this.running = false;
+        this.notificationService.error('Failed to start the conformance run');
+      }
+    });
+  }
+
+  private finish(p: LorqueProcess): void {
+    this.running = false;
+    if ((p.status || '').toLowerCase() === 'failed' || !p.resultText) {
+      this.error = p.resultText || 'Conformance run failed';
+      return;
+    }
+    try {
+      this.report = JSON.parse(p.resultText);
+      this.tests = (this.report.test || []).map((t: any) => ({
+        name: t.name,
+        result: t.action?.[0]?.operation?.result || 'unknown'
+      }));
+    } catch (e) {
+      this.error = 'Could not parse the TestReport response';
+    }
+  }
+
+  protected get passedCount(): number {
+    return this.tests.filter(t => t.result === 'pass').length;
+  }
+}

--- a/app/src/app/integration/fhir/conformance/fhir-conformance.service.ts
+++ b/app/src/app/integration/fhir/conformance/fhir-conformance.service.ts
@@ -1,0 +1,23 @@
+import {HttpClient} from '@angular/common/http';
+import {Injectable, inject} from '@angular/core';
+import {environment} from 'environments/environment';
+import {Observable} from 'rxjs';
+import {LorqueProcess} from 'term-web/sys/_lib/lorque/model/lorque-process';
+
+export interface TxConformanceRunRequest {
+  suite?: string;
+  filter?: string;
+  mode?: string;
+  archiveUuid?: string;
+}
+
+@Injectable()
+export class FhirConformanceService {
+  private http = inject(HttpClient);
+  private baseUrl = `${environment.termxApi}/tx-conformance`;
+
+  /** Starts an async tx-ecosystem conformance run; poll the returned LorqueProcess for the TestReport. */
+  public run(request: TxConformanceRunRequest): Observable<LorqueProcess> {
+    return this.http.post<LorqueProcess>(`${this.baseUrl}/runs`, request);
+  }
+}

--- a/app/src/app/integration/integration.module.ts
+++ b/app/src/app/integration/integration.module.ts
@@ -41,6 +41,7 @@ import {FhirConceptMapClosureComponent} from 'term-web/integration/fhir/concept-
 import {FhirConceptMapTranslateComponent} from 'term-web/integration/fhir/concept-map/fhir-concept-map-translate.component';
 import {IntegrationFhirSyncComponent} from 'term-web/integration/fhir/integration-fhir-sync.component';
 import {FhirValueSetExpandComponent} from 'term-web/integration/fhir/value-set/fhir-value-set-expand.component';
+import {FhirConformanceComponent} from 'term-web/integration/fhir/conformance/fhir-conformance.component';
 import {FhirValueSetValidateCodeComponent} from 'term-web/integration/fhir/value-set/fhir-value-set-validate-code.component';
 import {IntegrationAtcImportComponent} from 'term-web/integration/import/atc/integration-atc-import.component';
 import {CodeSystemFileImportFormComponent} from 'term-web/integration/import/file-import/code-system/code-system-file-import-form.component';
@@ -74,7 +75,8 @@ export const INTEGRATION_ROUTES: Routes = [
       {path: 'fhir/ValueSet/$expand', component: FhirValueSetExpandComponent, data: {privilege: ['*.ValueSet.read']}},
       {path: 'fhir/ValueSet/$validate-code', component: FhirValueSetValidateCodeComponent, data: {privilege: ['*.ValueSet.read']}},
       {path: 'fhir/ConceptMap/$translate', component: FhirConceptMapTranslateComponent, data: {privilege: ['*.MapSet.read']}},
-      {path: 'fhir/ConceptMap/$closure', component: FhirConceptMapClosureComponent, data: {privilege: ['*.MapSet.read']}}
+      {path: 'fhir/ConceptMap/$closure', component: FhirConceptMapClosureComponent, data: {privilege: ['*.MapSet.read']}},
+      {path: 'fhir/conformance', component: FhirConformanceComponent, data: {privilege: ['*.CodeSystem.write']}}
     ]
   },
   {path: 'loinc', component: LoincDashboardComponent, data: {privilege: ['loinc.CodeSystem.read']}},
@@ -118,6 +120,7 @@ export const INTEGRATION_ROUTES: Routes = [
         FhirCodeSystemFindMatchesComponent,
         FhirCodeSystemValidateCodeComponent,
         FhirValueSetExpandComponent,
+        FhirConformanceComponent,
         FhirValueSetValidateCodeComponent,
         FhirConceptMapTranslateComponent,
         FhirConceptMapClosureComponent,

--- a/app/src/app/integration/operations/integration-operations.component.html
+++ b/app/src/app/integration/operations/integration-operations.component.html
@@ -31,6 +31,14 @@
           </div>
         </nz-collapse-panel>
       </nz-collapse>
+
+      <nz-collapse nzGhost *twPrivileged="'*.CodeSystem.write'">
+        <nz-collapse-panel nzHeader="Conformance">
+          <div style="display: grid">
+            <m-button mDisplay="link" [routerLink]="'./fhir/conformance'">tx-ecosystem tests</m-button>
+          </div>
+        </nz-collapse-panel>
+      </nz-collapse>
     </m-card>
   </div>
   <div nz-col [nzMd]="18" [nzXs]="24">


### PR DESCRIPTION
UI for the FHIR terminology conformance feature (backend: termx-server #208).

## What it adds
A screen under **Integration → Operations → Conformance** that:
- runs the official HL7 `tx-ecosystem` terminology test suite against this server (`POST /tx-conformance/runs`),
- polls the async `LorqueProcess` (`LorqueLibService.pollProcessProgress`) with a progress bar,
- renders the resulting FHIR **`TestReport`** — result, score, per-test pass/fail table,
- optionally uploads a custom test bundle to the `tx-conformance` Bob container (`BobLibService.upload`) and runs it via `archiveUuid`.

## Files
- `integration/fhir/conformance/fhir-conformance.{service,component}.ts` + `.html` (standalone component, per-component service — mirrors the SNOMED RF2 import screen).
- `integration.module.ts`: import + `@NgModule.imports` + child route `operations/fhir/conformance` (gated `*.CodeSystem.write`).
- `integration-operations.component.html`: a "Conformance" link.

## Notes
- ⚠️ **Not built/verified locally** — the private `@termx-health/*` deps need `NODE_AUTH_TOKEN` + `npm install`, which isn't available in my environment. All imports/selectors were cross-checked against existing proven usages (SNOMED import, Bob, Lorque), but CI/review should confirm the build.
- UI strings are inline English; i18n keys (en.json + 6 languages) are a deliberate follow-up to avoid a blind edit of the large translation files.

Depends on termx-server #208 being deployed (the `/tx-conformance` endpoint).