### PR TITLE
Fix tx-conformance UI build (m-title module, m-alert API)

### DIFF
--- a/app/src/app/integration/fhir/conformance/fhir-conformance.component.html
+++ b/app/src/app/integration/fhir/conformance/fhir-conformance.component.html
@@ -38,7 +38,7 @@
       }
 
       @if (error) {
-        <m-alert mType="error" [mContent]="error"></m-alert>
+        <m-alert mType="error">{{error}}</m-alert>
       }
     </div>
   </m-card>

--- a/app/src/app/integration/fhir/conformance/fhir-conformance.component.ts
+++ b/app/src/app/integration/fhir/conformance/fhir-conformance.component.ts
@@ -1,6 +1,7 @@
 import {Component, inject} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {
+  MarinPageLayoutModule,
   MuiAlertModule,
   MuiButtonModule,
   MuiCardModule,
@@ -30,7 +31,7 @@ interface TxTestRow {
 @Component({
   templateUrl: './fhir-conformance.component.html',
   imports: [
-    MuiCardModule, MuiButtonModule, MuiFormModule, MuiInputModule, MuiTableModule,
+    MarinPageLayoutModule, MuiCardModule, MuiButtonModule, MuiFormModule, MuiInputModule, MuiTableModule,
     MuiAlertModule, MuiCoreModule, NzProgressModule, FormsModule, PrivilegedDirective
   ],
   providers: [FhirConformanceService]


### PR DESCRIPTION
**Fixes a broken `main` build** introduced by #100 — the conformance screen failed `ng build`:

- `m-title` (`MuiPageTitleComponent`) is exported by `MarinPageLayoutModule`, which the component didn't import → `NG8001: 'm-title' is not a known element`. Added the module.
- `m-alert` takes **projected content**, not an `[mContent]` binding → `NG8002`. Changed to `<m-alert mType="error">{{error}}</m-alert>`.

Verified with a full `npm ci && ng build` (green, bundle generation complete). Should merge promptly to unbreak `main`.