### PR TITLE
#47: surface supplement base in the value set rule editor

### DIFF
--- a/app/src/app/resources/value-set/containers/version/rule/value-set-rule-form.component.html
+++ b/app/src/app/resources/value-set/containers/version/rule/value-set-rule-form.component.html
@@ -29,6 +29,14 @@
             </m-select>
           </m-form-item>
         </m-form-row>
+        @if (supplementBaseCs) {
+          <m-form-row>
+            <m-form-item *mFormCol mName="supplementBase" mLabel="entities.value-set-rule-set.rule.supplement-of">
+              <m-alert mType="info">{{supplementBaseCs}}</m-alert>
+            </m-form-item>
+            <div *mFormCol></div>
+          </m-form-row>
+        }
         <m-form-row>
           <m-form-item *mFormCol mName="codeSystemProperties" mLabel="entities.value-set-rule-set.rule.properties">
             <m-select name="codeSystemProperties" [(ngModel)]="rule.properties" multiple>

--- a/app/src/app/resources/value-set/containers/version/rule/value-set-rule-form.component.ts
+++ b/app/src/app/resources/value-set/containers/version/rule/value-set-rule-form.component.ts
@@ -2,7 +2,7 @@ import { AsyncPipe } from '@angular/common';
 import { Component, Input, OnChanges, SimpleChanges, ViewChild, inject } from '@angular/core';
 import { NgForm, FormsModule } from '@angular/forms';
 import { ApplyPipe, BooleanInput, JoinPipe, LoadingManager, validateForm } from '@termx-health/core-util';
-import { MarinPageLayoutModule, MuiButtonModule, MuiCardModule, MuiFormModule, MuiIconModule, MuiNoDataModule, MuiRadioModule, MuiSelectModule } from '@termx-health/ui';
+import { MarinPageLayoutModule, MuiAlertModule, MuiButtonModule, MuiCardModule, MuiFormModule, MuiIconModule, MuiNoDataModule, MuiRadioModule, MuiSelectModule } from '@termx-health/ui';
 import { TranslatePipe } from '@ngx-translate/core';
 import { map, Observable } from 'rxjs';
 import { CodeSystemLibService, CodeSystemVersion, EntityProperty, ValueSetLibService, ValueSetVersionConcept, ValueSetVersionRule } from 'term-web/resources/_lib';
@@ -24,6 +24,7 @@ import { ValueSetRuleFilterListComponent } from 'term-web/resources/value-set/co
         MuiIconModule,
         MuiNoDataModule,
         MuiRadioModule,
+        MuiAlertModule,
         CodeSystemSearchComponent,
         MuiSelectModule,
         ValueSetRuleConceptListComponent,
@@ -65,6 +66,7 @@ export class ValueSetRuleFormComponent implements OnChanges {
       this.ruleBase = this.rule.valueSet ? 'value-set' : 'code-system';
       this.conceptsBase = this.rule.filters.length > 0 ? 'filter' : this.rule.concepts.length > 0 ? 'exact' : 'all';
       this.loadCodeSystemVersions(this.rule.codeSystem);
+      this.loadSupplementBase(this.rule.codeSystem);
     }
     if (changes['rule'] || changes['inactiveConcepts']) {
       this.expansionPreview = undefined;
@@ -108,6 +110,22 @@ export class ValueSetRuleFormComponent implements OnChanges {
   protected codeSystemChanged(): void {
     this.rule.codeSystemVersion = undefined;
     this.loadCodeSystemVersions(this.rule.codeSystem);
+    this.loadSupplementBase(this.rule.codeSystem);
+  }
+
+  // When the selected code system is a supplement (content=supplement), surface its base so the
+  // editor sees the rule is supplement-bound — the server derives codeSystemBaseUri and emits the
+  // valueset-supplement extension on export. Issue #47.
+  protected supplementBaseCs?: string;
+
+  private loadSupplementBase(codeSystem?: string): void {
+    this.supplementBaseCs = undefined;
+    if (!codeSystem) {
+      return;
+    }
+    this.codeSystemService.load(codeSystem).subscribe(cs => {
+      this.supplementBaseCs = cs?.content === 'supplement' ? cs.baseCodeSystem : undefined;
+    });
   }
 
   private loadCodeSystemVersions(codeSystem?: string): void {

--- a/app/src/assets/i18n/en.json
+++ b/app/src/assets/i18n/en.json
@@ -871,6 +871,7 @@
 				"concepts": "Concepts",
 				"filters": "Filters",
 				"properties": "Properties",
+				"supplement-of": "Supplement of",
 				"value-set": "Value set",
 				"value-set-version": "Value set version"
 			},


### PR DESCRIPTION
Closes the termx-web side of #47 (item 2). Supplement code systems are already selectable in the rule's code-system picker (the search applies no content filter), and the server derives `codeSystemBaseUri` + emits the `valueset-supplement` extension on export. This adds the missing **visibility**: when the selected code system is a supplement (`content=supplement`), the rule editor shows its base read-only ("Supplement of: <base>"), so the user sees the rule is supplement-bound.

Verified with `ng build` (AOT compile clean). New i18n key `entities.value-set-rule-set.rule.supplement-of` added to en.json (other locales fall back until translated).