### PR TITLE
Phase P frontend: wiki export, Azure DevOps, server OAuth2, cs-gov skin, data-driven global search

### DIFF
--- a/app/src/app/app.component.html
+++ b/app/src/app/app.component.html
@@ -23,6 +23,7 @@
     [mMenu]="menu$ | async" mMenuMode="horizontal"
     [mAuthenticated]="auth.isAuthenticated | async"
     [mUserInfo]="auth.user ? {initials: auth.user?.username, template: userInfoTpl} : undefined"
+    [mAccessibilityContent]="a11yThemeTpl"
     (mLangChange)="onLangChange($event)"
     (mLogin)="login()"
   >
@@ -46,6 +47,7 @@
     [mMenu]="menu$ | async" mMenuMode="horizontal"
     [mAuthenticated]="auth.isAuthenticated | async"
     [mUserInfo]="auth.user ? {initials: auth.user?.username, template: userInfoTpl} : undefined"
+    [mAccessibilityContent]="a11yThemeTpl"
     (mLangChange)="onLangChange($event)"
     (mLogin)="login()"
     (mLogout)="logout()"
@@ -66,22 +68,18 @@
 
 <ng-template #titleTpl>
   <a class="tw-app-title" style="color: inherit" [routerLink]="['/landing']">
-    @if (skin.logo) {
-      <img class="tw-app-title__logo" [src]="skin.logo" alt=""/>
+    @if (skinService.skin.logo) {
+      <img class="tw-app-title__logo" [src]="skinService.skin.logo" alt=""/>
     }
     <span>{{'web.app.header' | translate}}</span>
-    @if (skin.headerText) {
-      <span class="tw-app-title__skin">{{skin.headerText}}</span>
+    @if (skinService.skin.headerText) {
+      <span class="tw-app-title__skin">{{skinService.skin.headerText}}</span>
     }
   </a>
 </ng-template>
 
 <ng-template #userInfoTpl>
   <div class="tw-form-view">
-    <div class="tw-user-info__theme">
-      <span class="m-subtitle">{{'web.app.theme.dark' | translate}}</span>
-      <nz-switch name="theme" [ngModel]="(preferences.theme$ | async) === 'dark'" (ngModelChange)="preferences.setTheme($event ? 'dark' : 'light')"></nz-switch>
-    </div>
     <div class="tw-user-info__user">
       <div>{{auth.user?.username}}</div>
     </div>
@@ -107,4 +105,15 @@
       </m-form-item>
     </div>
   </div>
+</ng-template>
+
+<!-- Projected into marina-ui's Accessibility modal (above its font-size section). -->
+<ng-template #a11yThemeTpl>
+  <m-form-item mLabel="web.app.accessibility.appearance">
+    <nz-radio-group [ngModel]="appearance" (ngModelChange)="setAppearance($event)" style="display: flex; flex-direction: column; gap: 0.5rem">
+      <label nz-radio nzValue="white">{{'web.app.accessibility.appearance-white' | translate}}</label>
+      <label nz-radio nzValue="dark">{{'web.app.accessibility.appearance-dark' | translate}}</label>
+      <label nz-radio nzValue="ncez">{{'web.app.accessibility.appearance-ncez' | translate}}</label>
+    </nz-radio-group>
+  </m-form-item>
 </ng-template>

--- a/app/src/app/app.component.ts
+++ b/app/src/app/app.component.ts
@@ -15,7 +15,7 @@ import {ShortcutService} from 'term-web/core/shortcuts/shortcut.service';
 import {ShortcutHelpComponent} from 'term-web/core/shortcuts/shortcut-help.component';
 import { AsyncPipe, KeyValuePipe } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { NzSwitchComponent } from 'ng-zorro-antd/switch';
+import { NzRadioModule } from 'ng-zorro-antd/radio';
 import { NoPrivilegeComponent } from 'term-web/core/components/no-privilege';
 
 
@@ -33,16 +33,34 @@ const getRouteLastChild = (snap: ActivatedRouteSnapshot): ActivatedRouteSnapshot
 @Component({
     templateUrl: 'app.component.html',
     styleUrls: ['app.component.less'],
-    imports: [MarinPageLayoutModule, MuiCoreModule, RouterLink, MuiFormModule, RouterOutlet, NoPrivilegeComponent, AsyncPipe, KeyValuePipe, TranslatePipe, HasAnyPrivilegePipe, ApplyPipe, FormsModule, NzSwitchComponent, ShortcutHelpComponent]
+    imports: [MarinPageLayoutModule, MuiCoreModule, RouterLink, MuiFormModule, RouterOutlet, NoPrivilegeComponent, AsyncPipe, KeyValuePipe, TranslatePipe, HasAnyPrivilegePipe, ApplyPipe, FormsModule, NzRadioModule, ShortcutHelpComponent]
 })
 export class AppComponent {
   protected auth = inject(AuthService);
+  protected preferences = inject(PreferencesService);
+
+  /** Appearance preset shown in the Accessibility modal: White (main skin), Dark (dark theme), NCEZ (cs-gov skin). */
+  protected get appearance(): 'white' | 'dark' | 'ncez' {
+    if (this.preferences.theme === 'dark') {
+      return 'dark';
+    }
+    return this.skinService.skinId === 'cs-gov' ? 'ncez' : 'white';
+  }
+
+  protected setAppearance(value: 'white' | 'dark' | 'ncez'): void {
+    if (value === 'dark') {
+      this.skinService.setSkin('main');
+      this.preferences.setTheme('dark');
+    } else {
+      this.preferences.setTheme('light');
+      this.skinService.setSkin(value === 'ncez' ? 'cs-gov' : 'main');
+    }
+  }
   protected router = inject(Router);
   private route = inject(ActivatedRoute);
   private http = inject(HttpClient);
   private translateService = inject(TranslateService);
-  protected preferences = inject(PreferencesService);
-  protected skin = inject(SkinService).skin;
+  protected skinService = inject(SkinService);
   private shortcutService = inject(ShortcutService);
 
   protected menu$ = this.translateService.onLangChange.pipe(

--- a/app/src/app/core/auth/auth.service.ts
+++ b/app/src/app/core/auth/auth.service.ts
@@ -140,7 +140,12 @@ export class AuthService {
     });
   }
 
-  private match = (upPart: string, apPart: string): boolean => upPart === apPart || upPart === '*' || apPart === '*';
+  private match = (upPart: string, apPart: string): boolean =>
+    this.normAction(upPart) === this.normAction(apPart) || upPart === '*' || apPart === '*';
+
+  // Route guards use read/write vocabulary; the backend privilege model uses view/edit/publish.
+  // Treat them as synonyms so view/edit privileges satisfy read/write guards (the backend remains the real enforcer).
+  private normAction = (part: string): string => part === 'read' ? 'view' : part === 'write' ? 'edit' : part;
 
 
   public hasPrivilege(privilege: string): boolean {

--- a/app/src/app/core/skin/skin.service.ts
+++ b/app/src/app/core/skin/skin.service.ts
@@ -24,9 +24,39 @@ const ALLOWED_KEYS: (keyof SkinConfig)[] = [
 export class SkinService {
   private http = inject(HttpClient);
   private _skin: SkinDefinition = BUILTIN_SKINS['main'];
+  private appliedVarKeys: string[] = [];
+
+  private static readonly STORAGE_KEY = 'tw-skin';
+  // Inline CSS custom properties this service sets; cleared before each apply so switching skins resets cleanly.
+  private static readonly RESET_PROPS = ['--color-primary', '--primary-color', '--skin-header-color'];
 
   public get skin(): SkinDefinition {
     return this._skin;
+  }
+
+  public get skinId(): string {
+    return this._skin.id || 'main';
+  }
+
+  /** Switch the active built-in skin at runtime and persist the choice (overrides the deployment default). */
+  public setSkin(id: string): void {
+    let resolved: SkinDefinition = {...(BUILTIN_SKINS[id] || BUILTIN_SKINS['main'])};
+    if (environment.branding) {
+      resolved = {...resolved, ...this.sanitize(environment.branding)};
+    }
+    this._skin = resolved;
+    this.applySkin();
+    try {
+      localStorage.setItem(SkinService.STORAGE_KEY, this._skin.id);
+    } catch { /* storage unavailable */ }
+  }
+
+  private readStoredSkin(): string | null {
+    try {
+      return localStorage.getItem(SkinService.STORAGE_KEY);
+    } catch {
+      return null;
+    }
   }
 
   /** Resolve the active skin then apply it. Never throws — falls back to 'main'. */
@@ -42,7 +72,8 @@ export class SkinService {
   public async resolve(): Promise<SkinDefinition> {
     let resolved: SkinDefinition = {...BUILTIN_SKINS['main']};
 
-    const ref = environment.skinUrl || environment.skin;
+    // A user-selected skin (from the Accessibility modal) overrides the deployment default.
+    const ref = this.readStoredSkin() || environment.skinUrl || environment.skin;
     if (ref && this.isExternal(ref)) {
       const ext = await this.fetchExternal(ref);
       // External skins are CSS/branding only — drop any code hook.
@@ -61,6 +92,11 @@ export class SkinService {
   public applySkin(): void {
     const skin = this._skin;
     const root = document.documentElement;
+
+    // Reset properties set by the previously-applied skin so runtime switching doesn't leak vars.
+    [...SkinService.RESET_PROPS, ...this.appliedVarKeys].forEach(p => root.style.removeProperty(p));
+    this.appliedVarKeys = [];
+
     root.setAttribute('data-skin', skin.id || 'main');
 
     if (skin.primaryColor) {
@@ -71,7 +107,10 @@ export class SkinService {
       root.style.setProperty('--skin-header-color', skin.headerColor);
     }
     if (skin.cssVars) {
-      Object.entries(skin.cssVars).forEach(([k, v]) => root.style.setProperty(k, v));
+      Object.entries(skin.cssVars).forEach(([k, v]) => {
+        root.style.setProperty(k, v);
+        this.appliedVarKeys.push(k);
+      });
     }
     (skin.stylesheets || []).forEach(href => this.injectStylesheet(href));
 

--- a/app/src/app/core/skin/skin.ts
+++ b/app/src/app/core/skin/skin.ts
@@ -24,8 +24,13 @@ const BLACK: SkinDefinition = {id: 'black'};
 /** Czech NCEZ / MZČR (Ministry of Health) skin — branding-only by default. */
 const CS_GOV: SkinDefinition = {
   id: 'cs-gov',
-  primaryColor: '#1464C0',
-  headerText: 'NCEZ',
+  // Authentic NCEZ brand palette (extracted from the NCEZ logo): navy primary + amber accent.
+  primaryColor: '#183C62',
+  headerColor: '#183C62',
+  // NCEZ palette: navy primary, amber accent; magenta + lime are tertiary marks (kept available
+  // as CSS vars for small accents — not applied prominently to avoid competing with navy/amber).
+  cssVars: {'--skin-accent': '#F7B935', '--skin-accent-2': '#D21747', '--skin-accent-3': '#C2CD21'},
+  logo: 'assets/skins/cs-gov/ncez-rgb.png',
   landingLogos: [
     'assets/skins/cs-gov/generated_image.png',
     'assets/skins/cs-gov/CS_FundedbytheEU_RGB_POS.svg',

--- a/app/src/app/global-search/containers/global-search-dashboard.component.ts
+++ b/app/src/app/global-search/containers/global-search-dashboard.component.ts
@@ -3,7 +3,6 @@ import {Router} from '@angular/router';
 import {ComponentStateStore, HttpCacheService, LoadingManager, SearchResult} from '@termx-health/core-util';
 import {TranslateService} from '@ngx-translate/core';
 import {catchError, forkJoin, map, Observable, of} from 'rxjs';
-import {environment} from 'environments/environment';
 import {AuthService} from 'term-web/core/auth';
 import {Space, SpaceLibService, SpaceSearchParams} from 'term-web/sys/_lib/space';
 import {SnomedConcept, SnomedConceptSearchParams, SnomedLibService} from 'term-web/integration/_lib';
@@ -91,21 +90,16 @@ export class GlobalSearchDashboardComponent implements OnInit {
   }
 
   private loadSpaceButtons(): void {
-    const codes = environment.globalSearchSpaces;
-    if (!codes?.length) {
-      return;
-    }
+    // Quick-filter buttons are the spaces flagged "Global search" (Space.globalSearch).
     const q = new SpaceSearchParams();
-    q.codes = codes.join(',');
-    q.limit = codes.length;
+    q.globalSearch = true;
+    q.limit = -1;
     this.spaceService.search(q).pipe(
       map(r => r.data),
       catchError(() => of([] as Space[]))
     ).subscribe(spaces => {
-      // Preserve the configured order.
-      this.spaceButtons = codes
-        .map(code => spaces.find(s => s.code === code))
-        .filter((s): s is Space => !!s)
+      this.spaceButtons = spaces
+        .sort((a, b) => (a.code || '').localeCompare(b.code || ''))
         .map(s => ({code: s.code, id: s.id}));
     });
   }

--- a/app/src/app/landing/landing-page.component.html
+++ b/app/src/app/landing/landing-page.component.html
@@ -7,7 +7,7 @@
      summaries) use <m-page> with extra context directives that happen to keep DI happy;
      landing doesn't need any of that, just the full-bleed layout — keep .wrapper styles
      intact and skip the page chrome entirely. -->
-<div style="width:100%">
+<div class="tw-landing">
   <div class="wrapper animated">
     <!-- Resources -->
     @if ((['*.CodeSystem.read', '*.ValueSet.read', '*.MapSet.read'] | twPrivileged) && (modules | includes: 'terminology')) {
@@ -108,9 +108,9 @@
     }
   </div>
 
-  @if (skin.landingLogos?.length) {
+  @if (skinService.skin.landingLogos?.length) {
     <div class="tw-skin-branding">
-      @for (logo of skin.landingLogos; track logo) {
+      @for (logo of skinService.skin.landingLogos; track logo) {
         <img class="tw-skin-branding__logo" [src]="logo" alt=""/>
       }
     </div>

--- a/app/src/app/landing/landing-page.component.less
+++ b/app/src/app/landing/landing-page.component.less
@@ -4,6 +4,21 @@
   background: linear-gradient(45deg, var(--color-primary-4), var(--color-primary-6), var(--color-primary-8));
 }
 
+// Landing fills its (flex-sized) content area so the branding footer sticks to the bottom
+// instead of floating mid-page. Uses 100% of the parent rather than 100vh math, which
+// over-counted the header and overflowed below the fold (notably in Safari).
+:host {
+  display: block;
+  height: 100%;
+}
+
+.tw-landing {
+  width: 100%;
+  min-height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
 .tw-skin-branding {
   display: flex;
   flex-wrap: wrap;
@@ -11,7 +26,7 @@
   justify-content: center;
   gap: 2rem;
   padding: 2rem 1rem;
-  margin-top: 1rem;
+  margin-top: auto;
   border-top: 1px solid var(--color-borders);
 
   &__logo {

--- a/app/src/app/landing/landing-page.component.ts
+++ b/app/src/app/landing/landing-page.component.ts
@@ -33,7 +33,7 @@ export class LandingPageComponent {
   private spaceService = inject(SpaceLibService);
   private pageService = inject(PageLibService);
   private taskService = inject(TaskLibService);
-  protected skin = inject(SkinService).skin;
+  protected skinService = inject(SkinService);
 
   protected data: {
     codeSystemCount?: number,

--- a/app/src/app/sys/_lib/space/model/server.ts
+++ b/app/src/app/sys/_lib/space/model/server.ts
@@ -36,9 +36,11 @@ export class ServerHeader {
 }
 
 export class ServerAuthConfig {
+  public authType?: 'none' | 'basic' | 'oauth2' | 'apikey';
   public accessTokenUrl?: string;
   public clientId?: string;
   public clientSecret?: string;
+  public scope?: string;
 }
 
 export class AuthoritativeResource {

--- a/app/src/app/sys/_lib/space/model/space-search-params.ts
+++ b/app/src/app/sys/_lib/space/model/space-search-params.ts
@@ -4,4 +4,5 @@ export class SpaceSearchParams extends QueryParams {
   public codes?: string;
   public textContains?: string;
   public resource?: string;
+  public globalSearch?: boolean;
 }

--- a/app/src/app/sys/_lib/space/model/space.ts
+++ b/app/src/app/sys/_lib/space/model/space.ts
@@ -7,6 +7,7 @@ export class Space {
   public names?: LocalizedName;
   public active?: boolean;
   public shared?: boolean;
+  public globalSearch?: boolean;
   public acl?: {owners?: string, editors?: string, viewers?: string};
   public terminologyServers?: string[];
   public packages?: Package[];

--- a/app/src/app/sys/space/containers/server/server-edit.component.html
+++ b/app/src/app/sys/space/containers/server/server-edit.component.html
@@ -57,9 +57,19 @@
             </div>
             @if (server.authConfig; as conf) {
               <div style="border-left: 1px solid var(--color-borders); padding: 0.5rem 0 0.5rem 1rem; margin-top: 0.5rem;">
-                <div><strong>{{'web.server.auth-config.access-token-url' | translate}}:</strong> {{conf.accessTokenUrl}}</div>
-                <div><strong>{{'web.server.auth-config.client-id' | translate}}:</strong> {{conf.clientId}}</div>
-                <div><strong>{{'web.server.auth-config.client-secret' | translate}}:</strong> ●●●●●●●●</div>
+                <div><strong>{{'web.server.auth-config.auth-type' | translate}}:</strong> {{('web.server.auth-config.auth-type-' + (conf.authType || 'oauth2')) | translate}}</div>
+                @if (conf.authType !== 'apikey' && conf.authType !== 'none') {
+                  @if (conf.authType !== 'basic') {
+                    <div><strong>{{'web.server.auth-config.access-token-url' | translate}}:</strong> {{conf.accessTokenUrl}}</div>
+                  }
+                  <div><strong>{{'web.server.auth-config.client-id' | translate}}:</strong> {{conf.clientId}}</div>
+                }
+                @if (conf.authType !== 'none') {
+                  <div><strong>{{'web.server.auth-config.client-secret' | translate}}:</strong> ●●●●●●●●</div>
+                }
+                @if (conf.authType === 'oauth2' && conf.scope) {
+                  <div><strong>{{'web.server.auth-config.scope' | translate}}:</strong> {{conf.scope}}</div>
+                }
               </div>
             }
           </m-form-item>
@@ -191,7 +201,7 @@
                   @if (server.authConfig) {
                     <m-checkbox mChecked (mCheckedChange)="server.authConfig = undefined"/>
                   } @else {
-                    <m-checkbox (mCheckedChange)="server.authConfig = {}"/>
+                    <m-checkbox (mCheckedChange)="server.authConfig = {authType: 'oauth2'}"/>
                   }
                   <m-divider mVertical/>
                   <m-checkbox name="open" [(ngModel)]="server.open">{{'entities.server.open' | translate}}</m-checkbox>
@@ -204,21 +214,42 @@
 
               @if (server.authConfig; as conf) {
                 <div style="border-left: 1px solid var(--color-borders); padding: 0.5rem 0 0.5rem 1rem">
-                  <m-form-item mName="oauth-url" mLabel="web.server.auth-config.access-token-url" required>
-                    <m-input name="oauth-url" [(ngModel)]="conf.accessTokenUrl" required/>
+                  <m-form-item mName="auth-type" mLabel="web.server.auth-config.auth-type">
+                    <m-select name="auth-type" [(ngModel)]="conf.authType">
+                      @for (t of authTypeOptions; track t) {
+                        <m-option [mValue]="t" [mLabel]="'web.server.auth-config.auth-type-' + t | translate"/>
+                      }
+                    </m-select>
                   </m-form-item>
-                  <m-form-item mName="oauth-client-id" mLabel="web.server.auth-config.client-id" required>
-                    <m-input name="oauth-client-id" [(ngModel)]="conf.clientId" required/>
-                  </m-form-item>
-                  <m-form-item mName="oauth-client-secret" mLabel="web.server.auth-config.client-secret"
-                               class="tw-input-group" [required]="!conf['_masked']">
-                    @if (conf['_masked']) {
-                      <span>●●●●●●●● <m-icon class="m-clickable" mCode="edit" (click)="conf['_masked'] = false"/></span>
-                    }
-                    @if (!conf['_masked']) {
-                      <m-input name="oauth-client-secret" [(ngModel)]="conf.clientSecret" required/>
-                    }
-                  </m-form-item>
+
+                  @if (conf.authType === 'oauth2') {
+                    <m-form-item mName="oauth-url" mLabel="web.server.auth-config.access-token-url" required>
+                      <m-input name="oauth-url" [(ngModel)]="conf.accessTokenUrl" required/>
+                    </m-form-item>
+                  }
+                  @if (conf.authType === 'oauth2' || conf.authType === 'basic') {
+                    <m-form-item mName="oauth-client-id"
+                                 [mLabel]="conf.authType === 'basic' ? 'web.server.auth-config.username' : 'web.server.auth-config.client-id'" required>
+                      <m-input name="oauth-client-id" [(ngModel)]="conf.clientId" required/>
+                    </m-form-item>
+                  }
+                  @if (conf.authType && conf.authType !== 'none') {
+                    <m-form-item mName="oauth-client-secret"
+                                 [mLabel]="conf.authType === 'basic' ? 'web.server.auth-config.password' : (conf.authType === 'apikey' ? 'web.server.auth-config.api-key' : 'web.server.auth-config.client-secret')"
+                                 class="tw-input-group" [required]="!conf['_masked']">
+                      @if (conf['_masked']) {
+                        <span>●●●●●●●● <m-icon class="m-clickable" mCode="edit" (click)="conf['_masked'] = false"/></span>
+                      }
+                      @if (!conf['_masked']) {
+                        <m-input name="oauth-client-secret" [(ngModel)]="conf.clientSecret" required/>
+                      }
+                    </m-form-item>
+                  }
+                  @if (conf.authType === 'oauth2') {
+                    <m-form-item mName="oauth-scope" mLabel="web.server.auth-config.scope">
+                      <m-input name="oauth-scope" [(ngModel)]="conf.scope"/>
+                    </m-form-item>
+                  }
                 </div>
               }
             </m-form-item>

--- a/app/src/app/sys/space/containers/server/server-edit.component.ts
+++ b/app/src/app/sys/space/containers/server/server-edit.component.ts
@@ -36,6 +36,7 @@ export class ServerEditComponent implements OnInit {
   protected readonly operationOptions = ['$expand', '$validate-code', '$lookup', '$translate', '$subsumes', '$closure'];
   protected readonly fhirVersionOptions = ['R3', 'R4', 'R4B', 'R5', 'R6'];
   protected readonly strategyOptions = ['inline', 'cached', 'local'];
+  protected readonly authTypeOptions = ['none', 'basic', 'oauth2', 'apikey'];
 
   @ViewChild("form") public form?: NgForm;
 
@@ -69,9 +70,13 @@ export class ServerEditComponent implements OnInit {
   private initServer(server: Server): void {
     server.fhirVersions = server.fhirVersions?.length ? server.fhirVersions : [{}];
     this.server = server;
+    if (server.authConfig && isNil(server.authConfig.authType)) {
+      server.authConfig.authType = 'oauth2'; // legacy configs predate authType
+    }
     if (server.id) {
       if (server.authConfig) {
-        server.authConfig['_masked'] = isDefined(server.authConfig.clientId) && isNil(server.authConfig.clientSecret);
+        const conf = server.authConfig;
+        server.authConfig['_masked'] = isNil(conf.clientSecret) && (isDefined(conf.clientId) || conf.authType === 'apikey');
       }
       if (server.headers) {
         server.headers.filter(h => "Authorization" === h.key && isNil(h.value)).forEach(h => h['_masked'] = true);

--- a/app/src/app/sys/space/containers/space/space-edit.component.html
+++ b/app/src/app/sys/space/containers/space/space-edit.component.html
@@ -18,6 +18,9 @@
             <m-form-item mName="active" mLabel="entities.space.active">
               <m-checkbox name="active" [(ngModel)]="space.active"></m-checkbox>
             </m-form-item>
+            <m-form-item mName="globalSearch" mLabel="entities.space.global-search">
+              <m-checkbox name="globalSearch" [(ngModel)]="space.globalSearch"></m-checkbox>
+            </m-form-item>
             <m-form-item mName="servers" mLabel="entities.space.servers">
               <m-select name="servers" [(ngModel)]="space.terminologyServers" multiple>
                 @for (ts of terminologyServers; track ts) {
@@ -67,6 +70,32 @@
                       </m-form-item>
                     }
                   </div>
+                }
+              }
+            }
+            @if (msDevOpsFeature) {
+              <m-divider>
+                <span>{{'web.space.msdevops-integration' | translate}}</span>
+                <m-checkbox style="padding-left: 10px" [(mChecked)]="msDevOpsEnabled"></m-checkbox>
+              </m-divider>
+              @if (msDevOpsEnabled) {
+                @if (msDevOpsProviders) {
+                  <m-form-item mName="msdevops" mLabel="entities.space.msdevops" class="tw-input-group">
+                    <span class="tw-input-group-addon ant-input-group-addon">https://dev.azure.com/</span>
+                    <m-input name="msdevops" [(ngModel)]="space.integration.msDevops.repo" placeholder="organization/project"></m-input>
+                  </m-form-item>
+                }
+                @if (space.integration.msDevops.repo) {
+                  @if (msDevOpsProviders) {
+                    <div class="github-dirs">
+                      @for (p of msDevOpsProviders | keys | apply:sort; track p) {
+                        <m-form-item mName="msdevops-{{p}}" class="tw-input-group">
+                          <span class="tw-input-group-addon ant-input-group-addon">{{p}}</span>
+                          <m-input name="msdevops-{{p}}" [(ngModel)]="space.integration.msDevops.dirs[p]"></m-input>
+                        </m-form-item>
+                      }
+                    </div>
+                  }
                 }
               }
             }

--- a/app/src/app/sys/space/containers/space/space-edit.component.ts
+++ b/app/src/app/sys/space/containers/space/space-edit.component.ts
@@ -3,11 +3,13 @@ import { Component, OnInit, ViewChild, inject } from '@angular/core';
 import { NgForm, FormsModule } from '@angular/forms';
 import {ActivatedRoute, Router} from '@angular/router';
 import { validateForm, ApplyPipe, KeysPipe } from '@termx-health/core-util';
-import {forkJoin} from 'rxjs';
+import {forkJoin, of} from 'rxjs';
 import {Package, Space, Server, ServerLibService} from 'term-web/sys/_lib/space';
 import {SpaceGithubService} from 'term-web/sys/space/services/space-github.service';
+import {SpaceMsDevOpsService} from 'term-web/sys/space/services/space-ms-dev-ops.service';
 import {PackageService} from 'term-web/sys/space/services/package.service';
 import {SpaceService} from 'term-web/sys/space/services/space.service';
+import {environment} from 'environments/environment';
 import { MuiFormModule, MuiSpinnerModule, MuiCardModule, MuiTextareaModule, MuiMultiLanguageInputModule, MuiCheckboxModule, MuiSelectModule, MuiDividerModule, MuiListModule, MuiCoreModule, MuiPopconfirmModule, MuiIconModule, MuiInputModule, MuiButtonModule } from '@termx-health/ui';
 import { TranslatePipe } from '@ngx-translate/core';
 import { MarinaUtilModule } from '@termx-health/util';
@@ -17,6 +19,9 @@ import { MarinaUtilModule } from '@termx-health/util';
     styles: [`
     ::ng-deep .github-dirs {
       padding-left: 40px;
+      margin-top: 1rem;
+      border-top: 1px solid var(--color-borders);
+      padding-top: 1rem;
       & .ant-input-group-addon {
         text-align: right;
         min-width: 160px;
@@ -28,6 +33,7 @@ import { MarinaUtilModule } from '@termx-health/util';
 export class SpaceEditComponent implements OnInit {
   private spaceService = inject(SpaceService);
   private spaceGithubService = inject(SpaceGithubService);
+  private spaceMsDevOpsService = inject(SpaceMsDevOpsService);
   private packageService = inject(PackageService);
   private serverService = inject(ServerLibService);
   private route = inject(ActivatedRoute);
@@ -39,6 +45,9 @@ export class SpaceEditComponent implements OnInit {
   public terminologyServers?: Server[];
   public githubProviders: {[k: string]: string};
   public githubEnabled: boolean;
+  public msDevOpsProviders: {[k: string]: string};
+  public msDevOpsEnabled: boolean;
+  protected readonly msDevOpsFeature = environment.msDevOpsEnabled;
 
   public loading = false;
   public mode: 'add' | 'edit' = 'add';
@@ -62,9 +71,11 @@ export class SpaceEditComponent implements OnInit {
     forkJoin([
       this.spaceService.load(id),
       this.spaceService.loadPackages(id),
-      this.spaceGithubService.getProviders()
-    ]).subscribe(([space, packages, githubProviders]) => {
+      this.spaceGithubService.getProviders(),
+      this.msDevOpsFeature ? this.spaceMsDevOpsService.getProviders() : of({})
+    ]).subscribe(([space, packages, githubProviders, msDevOpsProviders]) => {
       this.githubProviders = githubProviders;
+      this.msDevOpsProviders = msDevOpsProviders;
       this.space = this.writeSpace(space);
       this.packages = packages;
     }).add(() => this.loading = false);
@@ -76,6 +87,7 @@ export class SpaceEditComponent implements OnInit {
     }
     this.loading = true;
     this.space.integration.github = this.githubEnabled ? this.space.integration.github : null;
+    this.space.integration.msDevops = this.msDevOpsEnabled ? this.space.integration.msDevops : null;
     this.spaceService.save(this.space)
       .subscribe(() => this.location.back())
       .add(() => this.loading = false);
@@ -83,10 +95,13 @@ export class SpaceEditComponent implements OnInit {
 
   private writeSpace(s: Space): Space {
     this.githubEnabled = !!s.integration?.github;
+    this.msDevOpsEnabled = !!s.integration?.msDevops;
     s.acl ??= {};
     s.integration ??= {};
     s.integration.github ??= {dirs: this.githubProviders};
     s.integration.github.dirs ??= {};
+    s.integration.msDevops ??= {dirs: this.msDevOpsProviders};
+    s.integration.msDevops.dirs ??= {};
     return s;
   }
 

--- a/app/src/app/wiki/page/components/wiki-space-overview.component.html
+++ b/app/src/app/wiki/page/components/wiki-space-overview.component.html
@@ -2,11 +2,26 @@
   {{space?.names | localName: space?.code ?? '...'}}
 </div>
 
-<div class="m-items-top">
-  <h1 class="m-bold" style="margin-top: 1rem">
-    {{'web.wiki-page.overview.pages' | translate}}
-  </h1>
-  <span style="margin-top: 1rem">{{totalPages}}</span>
+<div class="m-items-top m-justify-between">
+  <div class="m-items-top">
+    <h1 class="m-bold" style="margin-top: 1rem">
+      {{'web.wiki-page.overview.pages' | translate}}
+    </h1>
+    <span style="margin-top: 1rem">{{totalPages}}</span>
+  </div>
+  @if (space) {
+    <m-dropdown style="margin-top: 1rem">
+      <m-button *m-dropdown-container mDisplay="text" [mLoading]="loader.state['export']">
+        <m-icon mCode="download"/>&nbsp;{{'web.wiki-page.overview.export' | translate}}
+      </m-button>
+      <a *m-dropdown-item class="m-items-middle" (click)="exportSpace('pdf')">
+        <m-icon mCode="download"/>&nbsp;{{'web.wiki-page.header.export-space-pdf' | translate}}
+      </a>
+      <a *m-dropdown-item class="m-items-middle" (click)="exportSpace('html')">
+        <m-icon mCode="download"/>&nbsp;{{'web.wiki-page.header.export-space-html' | translate}}
+      </a>
+    </m-dropdown>
+  }
 </div>
 
 

--- a/app/src/app/wiki/page/components/wiki-space-overview.component.ts
+++ b/app/src/app/wiki/page/components/wiki-space-overview.component.ts
@@ -4,10 +4,11 @@ import {Space} from 'term-web/sys/_lib/space';
 import {PageContent} from 'term-web/wiki/_lib';
 import {PageService} from 'term-web/wiki/page/services/page.service';
 
-import { MuiSkeletonModule, MuiCoreModule, MuiIconModule } from '@termx-health/ui';
+import { MuiSkeletonModule, MuiCoreModule, MuiIconModule, MuiButtonModule, MuiDropdownModule } from '@termx-health/ui';
 import { RouterLink } from '@angular/router';
 import { TranslatePipe } from '@ngx-translate/core';
 import { MarinaUtilModule } from '@termx-health/util';
+import {saveAs} from 'file-saver';
 
 @Component({
     selector: 'tw-wiki-space-overview',
@@ -19,7 +20,7 @@ import { MarinaUtilModule } from '@termx-health/util';
       gap: 1rem;
     }
   `],
-    imports: [MuiSkeletonModule, MuiCoreModule, RouterLink, MuiIconModule, TranslatePipe, MarinaUtilModule, AbbreviatePipe, ApplyPipe, LocalDateTimePipe]
+    imports: [MuiSkeletonModule, MuiCoreModule, RouterLink, MuiIconModule, MuiButtonModule, MuiDropdownModule, TranslatePipe, MarinaUtilModule, AbbreviatePipe, ApplyPipe, LocalDateTimePipe]
 })
 export class WikiSpaceOverviewComponent implements OnChanges {
   private pageService = inject(PageService);
@@ -53,5 +54,17 @@ export class WikiSpaceOverviewComponent implements OnChanges {
         });
       }
     }
+  }
+
+  protected exportSpace(format: 'pdf' | 'html'): void {
+    const req$ = this.pageService.exportWiki(format, this.space.id);
+    this.loader.wrap('export', req$).subscribe(resp => {
+      const fallback = `Wiki-${this.space?.code}.${format}`;
+      saveAs(resp.body, this.parseFilename(resp.headers.get('Content-Disposition')) ?? fallback);
+    });
+  }
+
+  private parseFilename(contentDisposition: string): string {
+    return contentDisposition?.match(/filename=([^;]+)/)?.[1]?.trim().replace(/^"|"$/g, '') || undefined;
   }
 }

--- a/app/src/app/wiki/page/containers/wiki-page-details.component.html
+++ b/app/src/app/wiki/page/containers/wiki-page-details.component.html
@@ -19,6 +19,14 @@
           <m-icon mCode="copy"/>
           {{'web.wiki-page.header.copy-raw' | translate}}
         </a>
+        <a *m-dropdown-item class="m-items-middle" (click)="export('pdf')">
+          <m-icon mCode="download"/>
+          {{'web.wiki-page.header.export-page-pdf' | translate}}
+        </a>
+        <a *m-dropdown-item class="m-items-middle" (click)="export('html')">
+          <m-icon mCode="download"/>
+          {{'web.wiki-page.header.export-page-html' | translate}}
+        </a>
         <a *mDropdownItemIf="'edit' | twPrivileged" class="m-items-middle" (click)="pageModal.open({links:[{sourceId: page?.id, orderNumber: 1}]})">
           <m-icon mCode="file-add"/>
           {{'web.wiki-page.header.add-subpage' | translate}}

--- a/app/src/app/wiki/page/containers/wiki-page-details.component.ts
+++ b/app/src/app/wiki/page/containers/wiki-page-details.component.ts
@@ -22,6 +22,7 @@ import { WikiPageCommentsComponent } from 'term-web/wiki/page/components/wiki-pa
 import { WikiPageSetupModalComponent } from 'term-web/wiki/page/components/wiki-page-setup-modal.component';
 import { TranslatePipe } from '@ngx-translate/core';
 import { PrivilegedPipe } from 'term-web/core/auth/privileges/privileged.pipe';
+import {saveAs} from 'file-saver';
 
 @Component({
     selector: 'tw-wiki-page-details',
@@ -155,6 +156,18 @@ export class WikiPageDetailsComponent implements OnChanges, OnInit {
 
   protected openHistory(): void {
     this.router.navigate(this.viewHistoryRoute(this.slug));
+  }
+
+  protected export(format: 'pdf' | 'html'): void {
+    const req$ = this.pageService.exportWiki(format, this.space.id, this.page?.id);
+    this.loader.wrap('export', req$).subscribe(resp => {
+      const fallback = `Wiki-${this.space?.code}-${this.slug}.${format}`;
+      saveAs(resp.body, this.parseFilename(resp.headers.get('Content-Disposition')) ?? fallback);
+    });
+  }
+
+  private parseFilename(contentDisposition: string): string {
+    return contentDisposition?.match(/filename=([^;]+)/)?.[1]?.trim().replace(/^"|"$/g, '') || undefined;
   }
 
   /* WikiComments */

--- a/app/src/app/wiki/page/services/page.service.ts
+++ b/app/src/app/wiki/page/services/page.service.ts
@@ -1,3 +1,4 @@
+import {HttpParams, HttpResponse} from '@angular/common/http';
 import {Injectable} from '@angular/core';
 import {isDefined} from '@termx-health/core-util';
 import {map, Observable} from 'rxjs';
@@ -5,6 +6,16 @@ import {Page, PageAttachment, PageContent, PageLibService} from 'term-web/wiki/_
 
 @Injectable()
 export class PageService extends PageLibService {
+  // export
+
+  public exportWiki(format: 'pdf' | 'html', spaceId: number, pageId?: number): Observable<HttpResponse<Blob>> {
+    let params = new HttpParams().set('spaceId', spaceId);
+    if (isDefined(pageId)) {
+      params = params.set('pageId', pageId);
+    }
+    return this.http.get(`${this.baseUrl}/wiki-export/export-${format}`, {params, responseType: 'blob', observe: 'response'});
+  }
+
   // page
 
   public savePage(page: Page, pageContent: PageContent): Observable<Page> {

--- a/app/src/assets/i18n/en.json
+++ b/app/src/assets/i18n/en.json
@@ -721,7 +721,9 @@
 			"active": "Active",
 			"code": "Code",
 			"editors": "Editors",
+			"global-search": "Global search",
 			"github": "Github",
+			"msdevops": "Azure DevOps repository",
 			"name": "Name",
 			"owners": "Owners",
 			"packages": "Packages",
@@ -963,6 +965,19 @@
 		},
 		"app": {
 			"header": "TermX",
+			"accessibility": {
+				"title": "Accessibility",
+				"appearance": "Appearance",
+				"appearance-white": "White",
+				"appearance-dark": "Dark",
+				"appearance-ncez": "NCEZ",
+				"font-size": "Font size",
+				"font-normal": "Normal",
+				"font-large": "Large",
+				"font-extra-large": "Extra large",
+				"apply": "Apply",
+				"reset": "Reset"
+			},
 			"theme": {
 				"dark": "Dark mode"
 			}
@@ -2332,6 +2347,7 @@
 			"github-commit-message": "Commit message",
 			"github-empty": "Nothing to commit",
 			"github-integration": "Github integration",
+			"msdevops-integration": "Azure DevOps integration",
 			"github-pull": "Pull diff from",
 			"github-pull-confirm": "Are you sure you want to replace current data with the data from repository?",
 			"github-pull-confirm-achtung": "CAUTION: THIS ACTION IS IRREVERSIBLE! YOU MAY LOSE DATA",
@@ -2544,9 +2560,18 @@
 			"add-header": "Add server",
 			"authoritative": "Authoritative Resources",
 			"auth-config": {
+				"auth-type": "Authentication type",
+				"auth-type-none": "None",
+				"auth-type-basic": "Basic",
+				"auth-type-oauth2": "OAuth 2.0",
+				"auth-type-apikey": "API key",
 				"access-token-url": "Access Token URL",
 				"client-id": "Client ID",
-				"client-secret": "Client Secret"
+				"client-secret": "Client Secret",
+				"username": "Username",
+				"password": "Password",
+				"api-key": "API key",
+				"scope": "Scope"
 			},
 			"edit-header": "Edit server",
 			"export-ecosystem": "Export to FHIR Ecosystem format",
@@ -2847,6 +2872,10 @@
 			"header": {
 				"add-subpage": "Add subpage",
 				"copy-raw": "Copy raw file",
+				"export-page-pdf": "Export page to PDF",
+				"export-page-html": "Export page to HTML",
+				"export-space-pdf": "Export space to PDF",
+				"export-space-html": "Export space to HTML",
 				"modified": "<b>{{user}}</b> edited this page on {{date}}"
 			},
 			"history": {
@@ -2873,6 +2902,7 @@
 			},
 			"overview": {
 				"pages": "Pages",
+				"export": "Export",
 				"recently-modified": {
 					"created": "Created {{date}}",
 					"header": "Recently modified",

--- a/app/src/environments/env.js
+++ b/app/src/environments/env.js
@@ -24,8 +24,7 @@ var twConfig = {
   "skin": "${SKIN}",
   "skinUrl": "${SKIN_URL}",
   "branding": 'json:${BRANDING}',
-  "msDevOpsEnabled": 'json:${MS_DEVOPS_ENABLED}',
-  "globalSearchSpaces": 'json:${GLOBAL_SEARCH_SPACES}'
+  "msDevOpsEnabled": 'json:${MS_DEVOPS_ENABLED}'
 };
 
 for (const [key, val] of Object.entries(twConfig)) {

--- a/app/src/environments/environment.base.ts
+++ b/app/src/environments/environment.base.ts
@@ -60,9 +60,6 @@ export interface Environment {
 
   /** Enables the Space → MS DevOps (Azure) integration UI. Off until termx-server provides /spaces/{id}/msdevops/*. */
   msDevOpsEnabled?: boolean,
-
-  /** Space codes surfaced as one-click quick-filter buttons on the global-search dashboard (deployment-specific). */
-  globalSearchSpaces?: string[],
 }
 
 /**

--- a/app/src/environments/environment.prod.ts
+++ b/app/src/environments/environment.prod.ts
@@ -38,5 +38,4 @@ export const environment: Environment = {
   skinUrl: dynamicEnv.skinUrl,
   branding: dynamicEnv.branding || {},
   msDevOpsEnabled: !!dynamicEnv.msDevOpsEnabled,
-  globalSearchSpaces: dynamicEnv.globalSearchSpaces || [],
 };

--- a/app/src/styles/theme.less
+++ b/app/src/styles/theme.less
@@ -8,6 +8,65 @@ html {
   background-color: var(--skin-header-color, @mui-bg-component);
 }
 
+// Skin: 'cs-gov' — Czech NCEZ/MZČR. Blue header bar (via --skin-header-color) needs light
+// text/icons for contrast so the branding is clearly visible on every page.
+html[data-skin="cs-gov"] .m-header {
+  color: #fff;
+  position: relative;
+
+  a,
+  span,
+  button,
+  .m-icon {
+    color: #fff !important;
+  }
+
+  // NCEZ logo has navy text/marks; sit it on a white chip so it stays legible on the navy bar.
+  .tw-app-title__logo {
+    height: 1.7rem;
+    background: #fff;
+    padding: 3px 6px;
+    border-radius: 4px;
+    box-sizing: content-box;
+  }
+
+  // NCEZ brand accent stripe under the navy bar: magenta + amber + lime (the logo's mark colours).
+  &::after {
+    content: "";
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    height: 3px;
+    background: linear-gradient(90deg,
+      var(--skin-accent-2, #D21747) 0 33.33%,
+      var(--skin-accent, #F7B935) 33.33% 66.66%,
+      var(--skin-accent-3, #C2CD21) 66.66% 100%);
+  }
+}
+
+// Skin: 'cs-gov' — ng-zorro/marina controls are themed at LESS compile time (@primary-color),
+// so they don't follow the runtime skin. Re-point the primary-coloured controls to NCEZ navy
+// so buttons/checkboxes/switches/radios match the navy header instead of the default blue.
+@cs-gov-navy: #183C62;
+@cs-gov-navy-hover: #2A5183;
+html[data-skin="cs-gov"] {
+  .ant-btn-primary {
+    background-color: @cs-gov-navy;
+    border-color: @cs-gov-navy;
+
+    &:hover, &:focus {
+      background-color: @cs-gov-navy-hover;
+      border-color: @cs-gov-navy-hover;
+    }
+  }
+  .ant-checkbox-checked .ant-checkbox-inner { background-color: @cs-gov-navy; border-color: @cs-gov-navy; }
+  .ant-checkbox-checked::after { border-color: @cs-gov-navy; }
+  .ant-switch-checked { background-color: @cs-gov-navy; }
+  .ant-radio-checked .ant-radio-inner { border-color: @cs-gov-navy; }
+  .ant-radio-inner::after { background-color: @cs-gov-navy; }
+}
+
 // Skin: 'black' — a curated dark palette via marina-ui CSS variables (NOT the
 // filter:invert() hack used by the per-user dark theme). Orthogonal to the
 // light/dark toggle. Deeper ng-zorro component theming would additionally need

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@termx-health/markdown-parser": "^21.0.4",
         "@termx-health/quill": "^21.0.4",
         "@termx-health/structure-definition-viewer": "5.0.7",
-        "@termx-health/ui": "^21.0.4",
+        "@termx-health/ui": "^21.0.5",
         "@termx-health/util": "^21.0.4",
         "angular-auth-oidc-client": "^21.0.0",
         "codemirror": "^6.0.1",
@@ -6828,9 +6828,9 @@
       "integrity": "sha512-RPd/WDlkaY7StEoeKKoZuY9bCcivsuMRpniznGAMaX0Ub2ZyjzV9a7JrfSq+/9teqiCOmewzkgaJ66l3DIIx1A=="
     },
     "node_modules/@termx-health/ui": {
-      "version": "21.0.4",
-      "resolved": "https://npm.pkg.github.com/download/@termx-health/ui/21.0.4/f695372a1694145d805aa54098cdfc7026596129",
-      "integrity": "sha512-vKuMxZaXoGq1wZLKsBftWxn6wN0BrEaCZKrMAVWiTKDsGzelgPPmlPAFp6jB9AHrZ6851xMoJw4Ge/kxEKWCXQ==",
+      "version": "21.0.5",
+      "resolved": "https://npm.pkg.github.com/download/@termx-health/ui/21.0.5/058b0f96c20a4b38f53ef3fefcaf8d46e24e0a66",
+      "integrity": "sha512-QQ6aA3jt+HPZT7swViyMKkmiPmDo5gjCJJbW8VdiMNKYKTOuHYdPApr9QR7RYIUujdldiD7xYhPmhWtcRWLimA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@termx-health/core-util": "^21.0.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@termx-health/markdown-parser": "^21.0.4",
     "@termx-health/quill": "^21.0.4",
     "@termx-health/structure-definition-viewer": "5.0.7",
-    "@termx-health/ui": "^21.0.4",
+    "@termx-health/ui": "^21.0.5",
     "@termx-health/util": "^21.0.4",
     "angular-auth-oidc-client": "^21.0.0",
     "codemirror": "^6.0.1",


### PR DESCRIPTION
## Summary
Frontend ports for Phase P, paired with the cz-termx-server backend changes.

### Wiki PDF/HTML export
- `PageService.exportWiki(format, spaceId, pageId?)` returns the blob.
- Export menu items on both the wiki page (page-only) and the space overview (whole space).

### Azure DevOps git sync
- New Azure DevOps integration section in the space edit form (mirrors the GitHub one). PAT-based, no per-user OAuth.

### Terminology server OAuth2
- Server edit form gains `authType` (none/basic/oauth2/apikey) + `scope`, with conditional fields and a masked secret.

### Data-driven global search
- Global search dashboard lists spaces by a new per-space **Global search** flag instead of the hardcoded `GLOBAL_SEARCH_SPACES` env list.
- Removed `GLOBAL_SEARCH_SPACES` / `globalSearchSpaces` from `env.js` and `environment.*`.

### Accessibility & cs-gov skin
- Theme/appearance selector is projected into marina-ui's native accessibility modal via the new `mAccessibilityContent` input (requires `@termx-health/ui ^21.0.5`).
- cs-gov skin: NCEZ navy/amber/magenta palette, logo, tricolor header stripe, landing footer logos with a sticky footer.

### Auth
- Route guards using `read`/`write` are aliased to the backend `view`/`edit` privilege vocabulary.

## Dependencies
- Requires `@termx-health/ui ^21.0.5` (web-commons PR #3, already published).
- Backend counterpart: cz-termx-server `feature/phase-p-backend-ports`.