### PR TITLE
Fix version status/delete guards to use maintain instead of publish

### DIFF
--- a/app/src/app/core/auth/auth.service.ts
+++ b/app/src/app/core/auth/auth.service.ts
@@ -143,9 +143,12 @@ export class AuthService {
   private match = (upPart: string, apPart: string): boolean =>
     this.normAction(upPart) === this.normAction(apPart) || upPart === '*' || apPart === '*';
 
-  // Route guards use read/write vocabulary; the backend privilege model uses view/edit/publish.
-  // Treat them as synonyms so view/edit privileges satisfy read/write guards (the backend remains the real enforcer).
-  private normAction = (part: string): string => part === 'read' ? 'view' : part === 'write' ? 'edit' : part;
+  // The backend privilege model uses read/write/maintain (plus triage); some legacy route guards and
+  // templates still use the older view/edit/publish vocabulary. Treat them as synonyms so the guards
+  // resolve against the granted privileges (the backend remains the real enforcer):
+  //   read <-> view, write <-> edit, maintain <-> publish.
+  private normAction = (part: string): string =>
+    part === 'read' ? 'view' : part === 'write' ? 'edit' : part === 'publish' ? 'maintain' : part;
 
 
   public hasPrivilege(privilege: string): boolean {

--- a/app/src/app/implementation-guide/container/version/summary/widgets/implementation-guide-version-info-widget.component.html
+++ b/app/src/app/implementation-guide/container/version/summary/widgets/implementation-guide-version-info-widget.component.html
@@ -29,7 +29,7 @@
       <span>{{'web.implementation-guide-version.summary.last-modified' | translate}}:
       {{(version.date | localDate) || ('web.implementation-guide-version.summary.none' | translate)}} </span>
     </div>
-    <div class="m-items-middle" *twPrivileged="'publish'">
+    <div class="m-items-middle" *twPrivileged="'maintain'">
       <m-icon mCode="tool"></m-icon>
       @if (version.status !== 'draft') {
         <a (mClick)="changeVersionStatus('draft')">{{'web.implementation-guide-version.summary.make-draft' | translate}}</a>

--- a/app/src/app/resources/code-system/containers/version/summary/widgets/code-system-version-info-widget.component.html
+++ b/app/src/app/resources/code-system/containers/version/summary/widgets/code-system-version-info-widget.component.html
@@ -68,7 +68,7 @@
         {{'web.code-system-version.summary.info.create-approve' | translate}}</a>
       </div>
     }
-    <div class="m-items-middle" *twPrivileged="'publish'">
+    <div class="m-items-middle" *twPrivileged="'maintain'">
       <m-icon mCode="tool"></m-icon>
       @if (version.status !== 'draft') {
         <a (mClick)="changeVersionStatus('draft')">{{'web.code-system-version.summary.info.make-draft' | translate}}</a>

--- a/app/src/app/resources/map-set/containers/summary/widgets/map-set-versions-widget.component.html
+++ b/app/src/app/resources/map-set/containers/summary/widgets/map-set-versions-widget.component.html
@@ -21,7 +21,7 @@
                 <a *m-dropdown-item (click)="duplicateModalData.version = version.version;duplicateModalData.visible = true">
                   <m-icon mCode="copy"></m-icon>&nbsp;{{'core.btn.duplicate' | translate}}
                 </a>
-                @if (version.status === 'draft' && versions?.length > 1 && ('publish' | twPrivileged)) {
+                @if (version.status === 'draft' && versions?.length > 1 && ('maintain' | twPrivileged)) {
                   <a *m-dropdown-item m-popconfirm mPopconfirmTitle="core.delete-confirm" (mOnConfirm)="deleteVersion(version.version)">
                     <m-icon mCode="delete"></m-icon>&nbsp;{{'core.btn.delete' | translate}}
                   </a>

--- a/app/src/app/resources/value-set/containers/summary/widgets/value-set-versions-widget.component.html
+++ b/app/src/app/resources/value-set/containers/summary/widgets/value-set-versions-widget.component.html
@@ -20,7 +20,7 @@
                 <a *m-dropdown-item (click)="duplicateModalData.version = version.version;duplicateModalData.visible = true">
                   <m-icon mCode="copy"></m-icon>&nbsp;{{'core.btn.duplicate' | translate}}
                 </a>
-                @if (version.status === 'draft' && versions?.length > 1 && ('publish' | twPrivileged)) {
+                @if (version.status === 'draft' && versions?.length > 1 && ('maintain' | twPrivileged)) {
                   <a *m-dropdown-item m-popconfirm mPopconfirmTitle="core.delete-confirm" (mOnConfirm)="deleteVersion(version.version)">
                     <m-icon  mCode="delete"></m-icon>&nbsp;{{'core.btn.delete' | translate}}
                   </a>

--- a/app/src/app/task/containers/task-edit.component.ts
+++ b/app/src/app/task/containers/task-edit.component.ts
@@ -399,7 +399,7 @@ export class TaskEditComponent implements OnInit {
       .flatMap(c => {
         const resource = this.taskContextResourceMap[c.type];
         const id = c.type == 'snomed-translation' ? 'snomed-ct' : c.id;
-        return [[id, resource, 'edit'].join('.'), [id, resource, 'publish'].join('.')];
+        return [[id, resource, 'edit'].join('.'), [id, resource, 'maintain'].join('.')];
       });
   };
 


### PR DESCRIPTION
## Problem

The version status-change controls (activate/retire/set-to-draft for **CodeSystem** and **ImplementationGuide**, delete-version for **ValueSet** and **MapSet**) and the task context privileges were guarded on a `publish` action via `*twPrivileged="'publish'"`. The backend privilege model has no `publish` action — it uses `read / triage / write / maintain`, and every one of these operations is enforced server-side with `@Authorized(Privilege.*_MAINTAIN)`.

`AuthService.normAction` only mapped `read↔view` and `write↔edit`, so a `'publish'` guard expanded to `<id>.<Resource>.publish` and matched **nothing a normal role is ever granted** — only the Admin wildcard `*.*.*`. Result: users correctly granted `<id>.<Resource>.maintain` could not see the status-change or delete-version controls, even though the API would have authorized them.

## Fix

- Replace the five `'publish'` guards with `'maintain'` so the templates name the privilege the backend actually enforces.
- Add `publish → maintain` to `AuthService.normAction`, alongside the existing `read↔view` / `write↔edit` synonyms, so any lingering `publish` reference resolves correctly.
- Correct the outdated comment that claimed the backend uses `view/edit/publish`.

## Effect

- A non-admin user with `<id>.<Resource>.maintain` now sees the version status-change / delete-version controls.
- `write`-only users are unaffected — those controls remain `maintain`-gated, matching server-side enforcement.

## Files

- `core/auth/auth.service.ts` — `normAction` + comment
- `resources/code-system/.../code-system-version-info-widget.component.html`
- `resources/value-set/.../value-set-versions-widget.component.html`
- `resources/map-set/.../map-set-versions-widget.component.html`
- `implementation-guide/.../implementation-guide-version-info-widget.component.html`
- `task/containers/task-edit.component.ts`