### PR TITLE
i18n: fill missing lt / cs / et UI translations

### DIFF
--- a/app/src/assets/i18n/cs.json
+++ b/app/src/assets/i18n/cs.json
@@ -2,8 +2,8 @@
   "core": {
     "back": "Zpět",
     "shortcut": {
-        "help-title": "Klávesové zkratky",
-        "help": "Zobrazit klávesové zkratky"
+      "help-title": "Klávesové zkratky",
+      "help": "Zobrazit klávesové zkratky"
     },
     "btn": {
       "add": "Přidat",
@@ -24,7 +24,11 @@
       "save": "Uložit",
       "search": "Vyhledat",
       "select": "Vybrat",
-      "send": "Odeslat"
+      "send": "Odeslat",
+      "change": "Změnit",
+      "download": "Stáhnout",
+      "yes": "Ano",
+      "no": "Ne"
     },
     "confirm": "Jste si jistý?",
     "data-lost-warning": "Vaše změny nebudou uloženy!",
@@ -70,6 +74,10 @@
     "session-expiration-warning": "Relace vyprší za méně než 5 minut!",
     "version-select": {
       "custom": "Vlastní"
+    },
+    "bool": {
+      "yes": "Ano",
+      "no": "Ne"
     }
   },
   "entities": {
@@ -707,7 +715,9 @@
       "shared": "Sdílené",
       "singular": "Prostor",
       "servers": "Servery",
-      "viewers": "Prohlížeči"
+      "viewers": "Prohlížeči",
+      "global-search": "Globální vyhledávání",
+      "msdevops": "Repozitář Azure DevOps"
     },
     "structure-definition": {
       "code": "Kód",
@@ -720,11 +730,19 @@
       "publisher": "Vydavatel",
       "status": "Stav",
       "url": "URL",
-      "version": "Verze"
+      "version": "Verze",
+      "description": "Popis",
+      "experimental": "Experimentální",
+      "purpose": "Účel",
+      "title": "Název"
     },
     "structure-definition-version": {
       "content-type": "Content type",
-      "description": "Description"
+      "description": "Description",
+      "content-format": "Formát obsahu",
+      "release-date": "Datum distribuce",
+      "status": "Stav",
+      "version": "Verze"
     },
     "task": {
       "assignee": "Přiřazený",
@@ -770,7 +788,17 @@
       "root-url": "Hlavní URL",
       "singular": "Server",
       "supported-operations": "Supported operations",
-      "usage": "Usage"
+      "usage": "Usage",
+      "cache-period": "Doba platnosti mezipaměti (hodiny)",
+      "cert": "Ověření certifikátem",
+      "oauth": "OAuth",
+      "open": "Otevřený přístup",
+      "smart": "SMART on FHIR",
+      "strategy": "Strategie",
+      "token": "Ověření tokenem",
+      "authoritative-conceptmaps": "Authoritative ConceptMaps",
+      "authoritative-structuredefinitions": "Authoritative StructureDefinitions",
+      "authoritative-structuremaps": "Authoritative StructureMaps"
     },
     "transformation-definition": {
       "name": "Název",
@@ -858,7 +886,8 @@
         "filters": "Filtry",
         "properties": "Vlastnosti",
         "value-set": "Sada hodnot",
-        "value-set-version": "Verze sady hodnot"
+        "value-set-version": "Verze sady hodnot",
+        "supplement-of": "Doplněk k"
       },
       "rules": "Pravidla"
     },
@@ -883,6 +912,16 @@
       "designations": "Označení",
       "display": "Zobrazení",
       "order-number": "Číslo pořadí"
+    },
+    "ecosystem": {
+      "active": "Aktivní",
+      "code": "Kód",
+      "description": "Popis",
+      "format-version": "Verze formátu",
+      "name": "Název",
+      "plural": "Ekosystémy",
+      "servers": "Servery",
+      "singular": "Ekosystém"
     }
   },
   "language": {
@@ -968,7 +1007,20 @@
     "app": {
       "header": "TermX",
       "theme": {
-            "dark": "Tmavý režim"
+        "dark": "Tmavý režim"
+      },
+      "accessibility": {
+        "title": "Přístupnost",
+        "appearance": "Vzhled",
+        "appearance-white": "Světlý",
+        "appearance-dark": "Tmavý",
+        "appearance-ncez": "NCEZ",
+        "font-size": "Velikost písma",
+        "font-normal": "Normální",
+        "font-large": "Velké",
+        "font-extra-large": "Extra velké",
+        "apply": "Použít",
+        "reset": "Obnovit"
       }
     },
     "association-type": {
@@ -1118,6 +1170,24 @@
           "version": "Verze"
         },
         "versions": "Verze"
+      },
+      "coding-refresh": {
+        "action": "Aktualizovat odkazy",
+        "header": "Aktualizovat odkazy na jiné kódové systémy",
+        "allowed-statuses": "Povolené cílové stavy",
+        "allowed-statuses-desc": "Při výběru nejnovější verze se berou v úvahu pouze verze odpovídající jednomu z těchto stavů.",
+        "preview-btn": "Náhled změn",
+        "apply-btn": "Použít",
+        "preview-desc": "Bude aktualizováno {{count}} odkazů:",
+        "property": "Vlastnost",
+        "target": "Cíl",
+        "current": "Aktuální verze",
+        "candidate": "Nová verze",
+        "up-to-date": "Všechny odkazy jsou aktuální",
+        "up-to-date-desc": "Nebyly nalezeny žádné hodnoty vlastností odkazující na starší verzi.",
+        "applied": "Odkazy aktualizovány",
+        "queued": "Odkazy zařazeny do fronty k aktualizaci",
+        "validator-desc": "Prohledá hodnoty vlastností v této verzi kódového systému a aktualizuje odkazy na nejnovější dostupnou verzi jejich cílových kódových systémů."
       }
     },
     "code-system-association": {
@@ -1236,7 +1306,8 @@
         "add-supplement": "Přidat doplněk",
         "coding-value-system": "Systém hodnot kódování",
         "delete-property-value": "Smazat hodnotu vlastnosti",
-        "edit-property-value": "Upravit hodnotu vlastnosti"
+        "edit-property-value": "Upravit hodnotu vlastnosti",
+        "edit-composite-values": "Upravit rozšíření"
       }
     },
     "code-system-validator": {
@@ -1355,12 +1426,11 @@
     "global-search": {
       "dashboard": {
         "all": "Vše",
-        "filter": "Filtr",
-        "code-systems": "Kódové systémy",
-        "concepts": "Koncepty",
         "filter": {
           "space": "Space"
         },
+        "code-systems": "Kódové systémy",
+        "concepts": "Koncepty",
         "header": "Vyhledávání",
         "map-sets": "Sady map",
         "measurement-unit": "Měrná jednotka",
@@ -2066,7 +2136,8 @@
       "metadata": "Metadata",
       "properties": "Vlastnosti",
       "provenance": "Původ",
-      "summary": "Shrnutí"
+      "summary": "Shrnutí",
+      "resources": "Zdroje"
     },
     "resource-form": {
       "add-other-title": "Přidat jiný název",
@@ -2311,7 +2382,8 @@
       "resource-import-success-message": "Import zdroje byl úspěšný",
       "resources": "Zdroje",
       "select-context": "Vybrat kontext",
-      "sync-resources": "Synchronizovat všechny zdroje (z aktuální instalace na cílový server)"
+      "sync-resources": "Synchronizovat všechny zdroje (z aktuální instalace na cílový server)",
+      "msdevops-integration": "Integrace s Azure DevOps"
     },
     "struct-definition-constraint": {
       "list": {
@@ -2391,7 +2463,8 @@
         "import-url": "URL",
         "manual": "Vytvořit ručně",
         "open-fhir": "Otevřít v FHIR",
-        "title": "Definice struktur"
+        "title": "Definice struktur",
+        "last-version": "Poslední verze"
       },
       "summary": {
         "add-task": "Add task",
@@ -2402,7 +2475,11 @@
         "related-artifacts": "Related artifacts",
         "versions": "Versions",
         "viewer": "Preview",
-        "recalculate-references": "Recalculate"
+        "recalculate-references": "Recalculate",
+        "duplicate-version-modal": {
+          "header": "Duplikovat verzi definice struktury",
+          "version": "Nová verze"
+        }
       },
       "version-summary": {
         "version-info": "Version info",
@@ -2411,7 +2488,16 @@
       "view": {
         "binding": "Vazba",
         "fixed": "Pevné"
-      }
+      },
+      "code": "Kód",
+      "url": "URL",
+      "name": "Název",
+      "title": "Název",
+      "publisher": "Vydavatel",
+      "content-type": "Typ obsahu",
+      "description": "Popis",
+      "parent": "Rodič",
+      "experimental": "Experimentální"
     },
     "structure-definition-version": {
       "form": {
@@ -2421,20 +2507,20 @@
     },
     "structure-definition-constraint": {
       "list": {
-        "add-constraint": "Add constraint",
-        "header": "Constraint(s)"
+        "add-constraint": "Přidat omezení",
+        "header": "Omezení"
       },
       "modal": {
-        "add-header": "Add constraint",
-        "edit-header": "Edit constraint",
-        "error": "Error",
-        "expression": "Expression",
-        "human": "Human",
-        "key": "Key",
-        "requirements": "Requirements",
-        "severity": "Severity",
-        "source": "Source",
-        "warning": "Warning"
+        "add-header": "Přidat omezení",
+        "edit-header": "Upravit omezení",
+        "error": "Chyba",
+        "expression": "Výraz",
+        "human": "Lidský",
+        "key": "Klíč",
+        "requirements": "Požadavky",
+        "severity": "Závažnost",
+        "source": "Zdroj",
+        "warning": "Upozornění"
       }
     },
     "structure-definition-type": {
@@ -2493,7 +2579,16 @@
       "auth-config": {
         "access-token-url": "URL pro přístupový token",
         "client-id": "ID klienta",
-        "client-secret": "Tajný klíč klienta"
+        "client-secret": "Tajný klíč klienta",
+        "auth-type": "Typ ověření",
+        "auth-type-none": "Žádné",
+        "auth-type-basic": "Basic",
+        "auth-type-oauth2": "OAuth 2.0",
+        "auth-type-apikey": "API klíč",
+        "username": "Uživatelské jméno",
+        "password": "Heslo",
+        "api-key": "API klíč",
+        "scope": "Rozsah"
       },
       "edit-header": "Upravit server",
       "export-ecosystem": "Export to FHIR Ecosystem format",
@@ -2508,7 +2603,27 @@
         "snomed": "SNOMED server",
         "terminology": "Terminologie server"
       },
-      "test": "Test"
+      "test": "Test",
+      "authoritative": "Authoritative Resources",
+      "tab": {
+        "summary": "Shrnutí",
+        "metadata": "Metadata",
+        "resources": "Zdroje"
+      },
+      "view-header": "Detaily serveru",
+      "authoritative-code-systems": "Authoritative Code Systems",
+      "authoritative-value-sets": "Authoritative Value Sets",
+      "authoritative-concept-maps": "Authoritative Concept Maps",
+      "authoritative-structure-definitions": "Authoritative Structure Definitions",
+      "authoritative-structure-maps": "Authoritative Structure Maps",
+      "authoritative-description-code-systems": "Určete, pro které kódové systémy je tento server autoritativní.",
+      "authoritative-description-value-sets": "Určete, pro které sady hodnot je tento server autoritativní.",
+      "authoritative-description-concept-maps": "Určete, pro které konceptové mapy je tento server autoritativní.",
+      "authoritative-description-structure-definitions": "Určete, pro které definice struktur je tento server autoritativní.",
+      "authoritative-description-structure-maps": "Určete, pro které mapy struktur je tento server autoritativní.",
+      "authoritative-preview-btn": "Náhled",
+      "authoritative-preview": "Odpovídající zdroje",
+      "structure-maps": "Mapy struktur"
     },
     "tools": {
       "terminology-service-api": {
@@ -2556,7 +2671,7 @@
         "fml-generation-failed": "Generování FML selhalo",
         "generate": "Generovat",
         "invalid-resource-url": "Nelze načíst platnou definici struktury",
-        "map-set": "ConceptMap",
+        "map-set": "Mapování konceptů",
         "mapping": "Mapování struktury",
         "preview-hide": "Skrýt",
         "preview-show": "Náhled",
@@ -2858,7 +2973,11 @@
       "header": {
         "add-subpage": "Přidat podstránku",
         "copy-raw": "Zkopírovat surový soubor",
-        "modified": "<b>{{user}}</b> upravil tuto stránku {{date}}"
+        "modified": "<b>{{user}}</b> upravil tuto stránku {{date}}",
+        "export-page-pdf": "Exportovat stránku do PDF",
+        "export-page-html": "Exportovat stránku do HTML",
+        "export-space-pdf": "Exportovat prostor do PDF",
+        "export-space-html": "Exportovat prostor do HTML"
       },
       "history": {
         "header": {
@@ -2888,7 +3007,8 @@
           "created": "Vytvořeno {{date}}",
           "header": "Nedávno upraveno",
           "updated": "Aktualizováno {{date}}"
-        }
+        },
+        "export": "Exportovat"
       },
       "setup": {
         "add-header": "Přidat stránku",
@@ -2935,6 +3055,12 @@
           }
         }
       }
+    },
+    "ecosystem": {
+      "add-btn": "Přidat ekosystém",
+      "add-header": "Přidat ekosystém",
+      "edit-header": "Upravit ekosystém",
+      "select-servers": "Vyberte servery..."
     }
   }
 }

--- a/app/src/assets/i18n/et.json
+++ b/app/src/assets/i18n/et.json
@@ -2,8 +2,8 @@
 	"core": {
 		"back": "Tagasi",
 		"shortcut": {
-				"help-title": "Klaviatuuri otseteed",
-				"help": "Näita klaviatuuri otseteid"
+			"help-title": "Klaviatuuri otseteed",
+			"help": "Näita klaviatuuri otseteid"
 		},
 		"btn": {
 			"add": "Lisa",
@@ -15,16 +15,20 @@
 			"copy": "Kopeeri",
 			"custom": "Kohanda",
 			"delete": "Kustuta",
-		"duplicate": "Tee koopia",
-		"edit": "Muuda",
-		"export": "Ekspordi",
-		"import": "Impordi",
-		"proceed": "Jätka",
+			"duplicate": "Tee koopia",
+			"edit": "Muuda",
+			"export": "Ekspordi",
+			"import": "Impordi",
+			"proceed": "Jätka",
 			"query": "Päri",
 			"save": "Salvesta",
 			"search": "Otsi",
 			"select": "Vali",
-			"send": "Saada"
+			"send": "Saada",
+			"change": "Muuda",
+			"download": "Laadi alla",
+			"yes": "Jah",
+			"no": "Ei"
 		},
 		"error": {
 			"403": {
@@ -52,6 +56,10 @@
 		},
 		"version-select": {
 			"custom": "Kohanda"
+		},
+		"bool": {
+			"yes": "Jah",
+			"no": "Ei"
 		}
 	},
 	"entities": {
@@ -64,7 +72,15 @@
 			"verification": "Teostaja",
 			"severity": "Raskusaste",
 			"active": "Aktiivne",
-			"resource-type": "Ressursi tüüp"
+			"resource-type": "Ressursi tüüp",
+			"codeSystem": "Koodisüsteem",
+			"valueSet": "Loend",
+			"mapSet": "Vastendustabel",
+			"design": "Tekst",
+			"concept": "Mõiste",
+			"release": "Väljalase",
+			"human": "Inimene",
+			"software": "Tarkvara"
 		},
 		"checklist": {
 			"rule": "Reegel",
@@ -125,7 +141,8 @@
 			"title": "Nimetus",
 			"uri": "URI",
 			"uri-short": "URI",
-			"versions": "Versioonid"
+			"versions": "Versioonid",
+			"single": "Koodisüsteem"
 		},
 		"code-system-association": {
 			"status": "Staatus",
@@ -139,7 +156,8 @@
 			"code-system": "Koodisüsteem",
 			"description": "Mõiste kirjeldus",
 			"type": "Tüüp",
-			"versions": "Mõiste versioonid"
+			"versions": "Mõiste versioonid",
+			"plural": "Mõisted"
 		},
 		"code-system-entity": {
 			"type": "Tüüp",
@@ -158,7 +176,8 @@
 			"id": "ID",
 			"property-values": "Tunnused",
 			"references": "Viited",
-			"status": "Staatus"
+			"status": "Staatus",
+			"designation": "Tekst"
 		},
 		"code-system-version": {
 			"base-version": "Aluskoodisüsteemi versioon",
@@ -173,7 +192,8 @@
 			"status": "Staatus",
 			"supported-languages": "Toetatud keeled",
 			"type": "Tüüp",
-			"version": "Versioon"
+			"version": "Versioon",
+			"single": "Koodisüsteemi versioon"
 		},
 		"common": {
 			"privileges": "Õigused",
@@ -266,7 +286,8 @@
 			},
 			"single": "Versioon",
 			"template": "Mall",
-			"version": "Versioon"
+			"version": "Versioon",
+			"github-branch": "Haru"
 		},
 		"map-set": {
 			"associations": "Assotsiatsioon",
@@ -572,7 +593,11 @@
 			"luvs": "Viimane kasutatud väärtus",
 			"pattern": "Mall",
 			"restart": "Taaskäivita",
-			"start-from": "Alates"
+			"start-from": "Alates",
+			"daily": "iga päev",
+			"monthly": "iga kuu",
+			"yearly": "iga aasta",
+			"never": "mitte kunagi"
 		},
 		"sequence-luv": {
 			"luv": "Viimane kasutatud väärtus",
@@ -672,7 +697,9 @@
 			"shared": "Jagatud",
 			"singular": "Ruum",
 			"servers": "Terminoloogiaserver",
-			"viewers": "Vaatajad"
+			"viewers": "Vaatajad",
+			"global-search": "Üldotsing",
+			"msdevops": "Azure DevOps repositoorium"
 		},
 		"structure-definition": {
 			"code": "Kood",
@@ -685,11 +712,19 @@
 			"publisher": "Väljaandja",
 			"status": "Staatus",
 			"url": "URL",
-			"version": "Versioon"
+			"version": "Versioon",
+			"description": "Kirjeldus",
+			"experimental": "Eksperimentaalne",
+			"purpose": "Eesmärk",
+			"title": "Pealkiri"
 		},
 		"structure-definition-version": {
 			"content-type": "Content type",
-			"description": "Description"
+			"description": "Description",
+			"content-format": "Sisu vorming",
+			"release-date": "Avaldamise kuupäev",
+			"status": "Staatus",
+			"version": "Versioon"
 		},
 		"task": {
 			"assignee": "Teostaja",
@@ -722,7 +757,30 @@
 			"name": "Nimi",
 			"plural": "Serverid",
 			"root-url": "Juur URL",
-			"singular": "Server"
+			"singular": "Server",
+			"cache-period": "Vahemälu kehtivus (tundi)",
+			"cert": "Sertifikaadiga autentimine",
+			"oauth": "OAuth",
+			"open": "Avalik juurdepääs",
+			"smart": "SMART on FHIR",
+			"strategy": "Strateegia",
+			"token": "Tokeniga autentimine",
+			"access-info": "Juurdepääsu info",
+			"usage": "Kasutus",
+			"supported-operations": "Toetatud toimingud",
+			"fhir-versions": "FHIR versioonid",
+			"fhir-version": "Versioon",
+			"fhir-version-url": "URL",
+			"authoritative": "Autoriteetsed koodisüsteemid",
+			"authoritative-valuesets": "Autoriteetsed loendid",
+			"authoritative-conceptmaps": "Autoriteetsed vastendustabelid",
+			"authoritative-structuredefinitions": "Autoriteetsed struktuuri definitsioonid",
+			"authoritative-structuremaps": "Autoriteetsed struktuuri transformatsioonid",
+			"exclusions": "Erandid",
+			"auth-url": "URL",
+			"auth-name": "Nimi",
+			"auth-version": "Versioon",
+			"auth-status": "Staatus"
 		},
 		"transformation-definition": {
 			"name": "Nimi",
@@ -778,7 +836,8 @@
 				"filters": "Filtrid",
 				"properties": "Tunnused",
 				"value-set": "Loend",
-				"value-set-version": "Loendi versioon"
+				"value-set-version": "Loendi versioon",
+				"supplement-of": "Supplement millele"
 			},
 			"rules": "Reeglid"
 		},
@@ -803,6 +862,48 @@
 			"designations": "Tekstid",
 			"display": "Nimetus (display)",
 			"order-number": "Jnr"
+		},
+		"ucum": {
+			"defined-unit": {
+				"code": "Kood",
+				"codeUC": "Kood (suurtähtedega)",
+				"kind": "Liik",
+				"printSymbol": "Print Symbol",
+				"names": "Nimed",
+				"property": "Tunnus",
+				"metric": "Meetermõõdustik",
+				"class": "Klass",
+				"description": "Kirjeldus",
+				"special": "Eri"
+			},
+			"prefix": {
+				"code": "Kood",
+				"codeUC": "Kood (suurtähtedega)",
+				"kind": "Liik",
+				"printSymbol": "Print Symbol",
+				"names": "Nimed",
+				"description": "Kirjeldus"
+			},
+			"base-unit": {
+				"code": "Kood",
+				"codeUC": "Kood (suurtähtedega)",
+				"kind": "Liik",
+				"printSymbol": "Print Symbol",
+				"names": "Nimed",
+				"property": "Tunnus",
+				"dimension": "Dimensioon",
+				"description": "Kirjeldus"
+			}
+		},
+		"ecosystem": {
+			"active": "Aktiivne",
+			"code": "Kood",
+			"description": "Kirjeldus",
+			"format-version": "Vormingu versioon",
+			"name": "Nimi",
+			"plural": "Ökosüsteemid",
+			"servers": "Serverid",
+			"singular": "Ökosüsteem"
 		}
 	},
 	"language": {
@@ -821,7 +922,20 @@
 		"app": {
 			"header": "TermX",
 			"theme": {
-						"dark": "Tume režiim"
+				"dark": "Tume režiim"
+			},
+			"accessibility": {
+				"title": "Ligipääsetavus",
+				"appearance": "Välimus",
+				"appearance-white": "Hele",
+				"appearance-dark": "Tume",
+				"appearance-ncez": "NCEZ",
+				"font-size": "Fondi suurus",
+				"font-normal": "Tavaline",
+				"font-large": "Suur",
+				"font-extra-large": "Väga suur",
+				"apply": "Rakenda",
+				"reset": "Lähtesta"
 			}
 		},
 		"value-set-version-modal": {
@@ -904,7 +1018,10 @@
 					"load-all-roots": "Laadi kõik juured",
 					"load-more-matches": "Laadi veel vasteid",
 					"load-all-matches": "Laadi kõik vasted",
-					"validate": "Valideeri koodisüsteemi"
+					"validate": "Valideeri koodisüsteemi",
+					"properties": "Tunnused",
+					"designation-languages": "Tekstide keeled",
+					"filter-disabled": "Filtri kasutamiseks lülitu lameda loendi vaatesse"
 				},
 				"delete-property-usages": "Eemalda tunnus mõistetelt",
 				"edit-header": "Metaandmed",
@@ -935,7 +1052,8 @@
 						"open-fhir": "Ava FHIR URL"
 					}
 				},
-				"view-header": "Vaata koodisüsteemi"
+				"view-header": "Vaata koodisüsteemi",
+				"details-header": "Koodisüsteemi detailid"
 			},
 			"list": {
 				"add-code-system": "Lisa koodisüsteem",
@@ -945,11 +1063,11 @@
 					"header": "Loo koopia",
 					"source-code-system": "Lähtekoodisüsteem:",
 					"target-code-system": "Sihtkoodisüsteem:",
-				"target-uri": "Siht URI:"
-			},
-			"import-fhir": "Impordi välist FHIR definitsiooni",
-			"import-ucum": "Impordi UCUM essence XML",
-			"last-version": "Viimane versioon",
+					"target-uri": "Siht URI:"
+				},
+				"import-fhir": "Impordi välist FHIR definitsiooni",
+				"import-ucum": "Impordi UCUM essence XML",
+				"last-version": "Viimane versioon",
 				"manual": "Manuaalne",
 				"open-fhir": "Ava FHIR URL",
 				"status": "Staatus",
@@ -957,7 +1075,16 @@
 				"uri": "URI",
 				"versions-expiration-date": "Kuni {{expirationDate}}",
 				"versions-release-date": "Alates {{releaseDate}}",
-				"versions-version": "Versiooni nimi: {{version}}"
+				"versions-version": "Versiooni nimi: {{version}}",
+				"supplement": {
+					"header": "Loo supplement koodisüsteem",
+					"source-code-system": "Aluskoodisüsteem:",
+					"target-code-system": "Supplement koodisüsteemi ID:",
+					"target-uri": "Supplement koodisüsteemi URI:",
+					"create-supplement": "Loo supplement"
+				},
+				"create-supplement": "Loo supplement",
+				"space": "Ruum"
 			},
 			"summary": {
 				"add-concept": "Lisa mõiste",
@@ -994,6 +1121,24 @@
 					"version": "Versioon"
 				},
 				"versions": "Versioonid"
+			},
+			"coding-refresh": {
+				"action": "Värskenda viiteid",
+				"header": "Värskenda viiteid teistele koodisüsteemidele",
+				"allowed-statuses": "Lubatud siht-staatused",
+				"allowed-statuses-desc": "Viimase versiooni valimisel arvestatakse ainult versioone, mis vastavad mõnele neist staatustest.",
+				"preview-btn": "Eelvaata muudatusi",
+				"apply-btn": "Rakenda",
+				"preview-desc": "{{count}} viidet uuendatakse:",
+				"property": "Tunnus",
+				"target": "Siht",
+				"current": "Praegune versioon",
+				"candidate": "Uus versioon",
+				"up-to-date": "Kõik viited on ajakohased",
+				"up-to-date-desc": "Ei leitud tunnuse väärtusi, mis viitaksid vanemale versioonile.",
+				"applied": "Viited uuendatud",
+				"queued": "Viited järjekorda võetud uuendamiseks",
+				"validator-desc": "Skanni selle koodisüsteemi versiooni tunnuste väärtusi ja uuenda viited nende siht-koodisüsteemide uusimale saadaolevale versioonile."
 			}
 		},
 		"code-system-association": {
@@ -1132,7 +1277,8 @@
 						"entity-version": "Mõiste versioon"
 					}
 				},
-				"view-header": "Vaata versiooni"
+				"view-header": "Vaata versiooni",
+				"details-header": "Versiooni detailid"
 			},
 			"summary": {
 				"all-tasks": "Kõik ülesanded",
@@ -1161,7 +1307,8 @@
 					"assignee": "Teostaja",
 					"header": "Lisa {{type}} ülesanne",
 					"success-msg": "Ülesanne loodud"
-				}
+				},
+				"add-task": "Lisa ülesanne"
 			}
 		},
 		"contacts": {
@@ -1210,14 +1357,17 @@
 		"global-search": {
 			"dashboard": {
 				"all": "Kõik",
-				"filter": "Filter",
+				"filter": {
+					"space": "Ruum"
+				},
 				"code-systems": "Koodisüsteemid",
 				"concepts": "Mõisted",
 				"header": "Otsing",
 				"map-sets": "Vastendustabelid",
 				"measurement-unit": "Mõõtühik",
 				"snomed": "SNOMED",
-				"value-sets": "Loendid"
+				"value-sets": "Loendid",
+				"ucum": "UCUM"
 			}
 		},
 		"implementation-guide": {
@@ -1259,26 +1409,43 @@
 						"property-name": "Nimetus",
 						"property-value": "Väärtus",
 						"system": "Süsteem",
-						"version": "Versioon"
+						"version": "Versioon",
+						"version-tooltip": "Süsteemi versioon, mille alusel järeldamine teostatakse",
+						"system-tooltip": "Süsteem, milles koostamine teostatakse. See tuleb esitada, välja arvatud juhul, kui toiming käivitatakse koodisüsteemi instantsil",
+						"properties-tooltip": "Üks või mitu tunnust, mis sisaldavad koodiks koostatavat infot",
+						"exact-tooltip": "Kas toimingut kasutab inimene ('false') või masin ('true'). Kui toimingut kasutab inimene, võib terminoloogiaserver tagastada täielike või osaliste vastete loendi. Masina puhul tagastab server täielikud vasted. Vaikeväärtus on 'false'"
 					},
 					"lookup": {
 						"code": "Kood",
 						"date": "Kuupäev",
 						"properties": "Tunnus",
 						"system": "Süsteem",
-						"version": "Versioon"
+						"version": "Versioon",
+						"code-tooltip": "Otsitav kood. Kui kood on esitatud, tuleb esitada ka süsteem",
+						"system-tooltip": "Otsitava koodi süsteem",
+						"version-tooltip": "Süsteemi versioon, kui see oli lähteandmetes esitatud",
+						"date-tooltip": "Kuupäev, mille kohta info tagastatakse. Tavaliselt on see praegune seis (mis on ka vaikeväärtus), kuid mõnel juhul<br> vajavad süsteemid sellele infole ligipääsu sellisena, nagu see oleks olnud minevikus.<br> Tüüpiline näide on olukord, kus koodi valik on piiratud koodidega, mis olid saadaval patsiendi ravimise ajal,<br> mitte siis, kui kirjet redigeeritakse. Pane tähele, et sobiva kuupäeva valik on teostuspoliitika küsimus.",
+						"properties-tooltip": "Tunnus, mille klient soovib väljundis tagastada. Kui tunnuseid pole täpsustatud, valib server, mida tagastada.<br> Kõigi koodisüsteemide jaoks on määratud järgmised tunnused: url, name, version (koodisüsteemi info) ja koodi info:<br> display, definition, designation, parent ja child, ning nimetuste jaoks lang.X, kus X on nimetuse keele kood.<br> Osa tunnuseid tagastatakse selgesõnaliselt nimega parameetritena (kui nimed kattuvad) ja ülejäänud (välja arvatud lang.X) property parameetrirühmas"
 					},
 					"subsumes": {
 						"code-a": "CodeA",
 						"code-b": "CodeB",
 						"system": "Süsteem",
-						"version": "Versioon"
+						"version": "Versioon",
+						"code-a-tooltip": "Testitav kood 'A'. Kui kood on esitatud, tuleb esitada ka süsteem",
+						"code-b-tooltip": "Testitav kood 'B'. Kui kood on esitatud, tuleb esitada ka süsteem",
+						"system-tooltip": "Koodisüsteem, milles hõlmamise (subsumption) testimine teostatakse. See tuleb esitada, välja arvatud juhul, kui toiming käivitatakse koodisüsteemi instantsil",
+						"version-tooltip": "Koodisüsteemi versioon, kui see oli lähteandmetes esitatud"
 					},
 					"validate-code": {
 						"code": "Kood",
 						"display": "Nimetus (display)",
 						"url": "URL",
-						"version": "Versioon"
+						"version": "Versioon",
+						"code-tooltip": "Valideeritav kood",
+						"display-tooltip": "Koodiga seotud nimetus (display), kui see on esitatud. Kui nimetus on esitatud, tuleb esitada ka kood. <br> Kui nimetust ei esitata, ei saa server nimetuse väärtust valideerida, kuid võib valida tagastada soovitusliku nimetuse väljundi laienduses. <br> See, kas nimetused on tõstutundlikud, sõltub koodisüsteemist",
+						"url-tooltip": "Koodisüsteemi URL. Server peab koodisüsteemi teadma (nt see on serveri koodisüsteemides selgesõnaliselt määratud või server tunneb seda kaudselt)",
+						"version-tooltip": "Koodisüsteemi versioon, kui see oli lähteandmetes esitatud"
 					}
 				},
 				"concept-map": {
@@ -1287,7 +1454,10 @@
 						"concepts": "Mõisted",
 						"name": "Nimetus",
 						"system": "Süsteem",
-						"version": "Versioon"
+						"version": "Versioon",
+						"concepts-tooltip": "Sulundustabelisse (closure table) lisatavad mõisted",
+						"name-tooltip": "Nimi, mis määratleb hõlmamispõhise sulundustabeli (closure table) konkreetse konteksti",
+						"version-tooltip": "Taassünkroniseerimise päring - päring saata kõik uued kirjed alates nimetatud versioonist, mille server saatis"
 					},
 					"translate": {
 						"code": "Kood",
@@ -1295,13 +1465,21 @@
 						"system": "Süsteem (URL)",
 						"target-system": "Sihtsüsteem",
 						"uri": "URL",
-						"version": "Versioon"
+						"version": "Versioon",
+						"code-tooltip": "Tõlgitav kood. Kui kood on esitatud, tuleb esitada ka süsteem",
+						"concept-map-version-tooltip": "Identifikaator, mida kasutatakse tõlkimisel kasutatava vastendustabeli konkreetse versiooni tuvastamiseks.<br> See on vastendustabeli autori hallatav suvaline väärtus, mis ei pea olema globaalselt unikaalne.<br> Näiteks võib see olla ajatempel (nt yyyymmdd), kui hallatav versioon pole saadaval.",
+						"system-tooltip": "Tõlgitava koodi süsteem",
+						"target-system-tooltip": "määratleb siht-koodisüsteemi, milles vastendust otsitakse. See parameeter on alternatiiviks target parameetrile - vaja on ainult ühte.<br> Mis tahes tõlke otsimine siht-koodisüsteemi kontekstist sõltumata (nt siht-loend) võib viia ebaturvaliste tulemusteni<br> ning serveri otsustada on, millal seda toetada",
+						"uri-tooltip": " Vastendustabeli kanooniline URL. Server peab vastendustabelit teadma (nt see on serveri vastendustabelites selgesõnaliselt määratud<br> või on määratud kaudselt mõne serverile teadaoleva koodisüsteemi kaudu.",
+						"version-tooltip": "Süsteemi versioon, kui see oli lähteandmetes esitatud"
 					}
 				},
 				"value-set": {
 					"expand": {
 						"url": "URL",
-						"value-set-version": "Loendi versioon"
+						"value-set-version": "Loendi versioon",
+						"url-tooltip": " Loendi kanooniline viide. Server peab loendit teadma (nt see on serveri loendites selgesõnaliselt määratud või on määratud kaudselt mõne serverile teadaoleva koodisüsteemi kaudu",
+						"value-set-version-tooltip": " Identifikaator, mida kasutatakse laienduse genereerimisel kasutatava loendi konkreetse versiooni tuvastamiseks. See on loendi autori hallatav suvaline väärtus, mis ei pea olema globaalselt unikaalne. Näiteks võib see olla ajatempel (nt yyyymmdd), kui hallatav versioon pole saadaval."
 					},
 					"validate-code": {
 						"code": "Kood",
@@ -1309,7 +1487,13 @@
 						"system": "Süsteem",
 						"system-version": "Süsteemi versioon",
 						"url": "URL",
-						"value-set-version": "Loendi versioon"
+						"value-set-version": "Loendi versioon",
+						"code-tooltip": " Valideeritav kood. Kui kood on esitatud, tuleb esitada süsteem või kontekst (kui kontekst on esitatud, peab server tagama, et kood pole ilma süsteemita mitmetähenduslik)",
+						"display-tooltip": "Koodiga seotud nimetus (display), kui see on esitatud. Kui nimetus on esitatud, tuleb esitada ka kood. Kui nimetust ei esitata, ei saa server nimetuse väärtust valideerida, kuid võib valida tagastada soovitusliku nimetuse väljundis display parameetri kaudu. See, kas nimetused on tõstutundlikud, sõltub koodisüsteemist",
+						"system-tooltip": "Valideeritava koodi süsteem",
+						"system-version-tooltip": "Süsteemi versioon, kui see oli lähteandmetes esitatud",
+						"url-tooltip": "Loendi kanooniline URL. Server peab loendit teadma (nt see on serveri loendites selgesõnaliselt määratud või on määratud kaudselt mõne serverile teadaoleva koodisüsteemi kaudu",
+						"value-set-version-tooltip": "Identifikaator, mida kasutatakse koodi valideerimisel kasutatava loendi konkreetse versiooni tuvastamiseks. See on loendi autori hallatav suvaline väärtus, mis ei pea olema globaalselt unikaalne. Näiteks võib see olla ajatempel (nt yyyymmdd), kui hallatav versioon pole saadaval."
 					}
 				}
 			},
@@ -1443,7 +1627,11 @@
 				"loinc": "LOINC",
 				"orphanet": "Orphanet",
 				"ucum": "UCUM"
-			}
+			},
+			"example": "Näide",
+			"resource-json": " ressursi JSON url",
+			"example-valueSet": "Esmalt tuleb importida loendi jaoks kasutatavad koodisüsteemi ressursid",
+			"example-conceptMap": "Esmalt tuleb importida vastendustabeli jaoks kasutatavad koodisüsteemi ressursid"
 		},
 		"landing": {
 			"resources": {
@@ -1540,7 +1728,8 @@
 					"value-set": "Loend",
 					"value-set-version": "Loendi versioon"
 				},
-				"view-header": "Vaata"
+				"view-header": "Vaata",
+				"details-header": "Vastendustabeli detailid"
 			},
 			"list": {
 				"add-map-set": "Lisa vastendustabel",
@@ -1567,7 +1756,8 @@
 				"map-set": "Vastendustabel",
 				"opened-tasks": "Avatud ülesanded",
 				"related-artifacts": "Seotud artefaktid",
-				"versions": "Versioonid"
+				"versions": "Versioonid",
+				"add-task": "Lisa ülesanne"
 			}
 		},
 		"map-set-association": {
@@ -1682,7 +1872,17 @@
 		},
 		"ucum": {
 			"menu": {
-				"export": "Ekspordi"
+				"export": "Ekspordi",
+				"title": "UCUM",
+				"prefixes": "Eesliited",
+				"base-units": "Põhiühikud",
+				"defined-units": "Defineeritud ühikud",
+				"analyse": "Analüüsi",
+				"validate": "Valideeri",
+				"convert": "Teisenda",
+				"canonicalise": "Kanoniseeri",
+				"operations": "Toimingud",
+				"components": "Komponendid"
 			},
 			"export-modal": {
 				"header": "Ekspordi UCUM ühikud",
@@ -1692,6 +1892,61 @@
 			"import-modal": {
 				"file": "Fail",
 				"header": "Impordi UCUM essence XML"
+			},
+			"defined-unit": {
+				"list": {
+					"title": "Defineeritud ühikud"
+				},
+				"view": {
+					"title": "Ühiku detailid"
+				}
+			},
+			"prefix": {
+				"list": {
+					"title": "Eesliited"
+				},
+				"view": {
+					"title": "Eesliite detailid"
+				}
+			},
+			"base-unit": {
+				"list": {
+					"title": "Põhiühikud"
+				},
+				"view": {
+					"title": "Põhiühiku detailid"
+				}
+			},
+			"operations": {
+				"analyse": {
+					"title": "Analüüsi UCUM koodi",
+					"code": "Kood",
+					"btn": "Analüüsi",
+					"result": "Tulemus",
+					"error": "Viga"
+				},
+				"validate": {
+					"title": "Valideeri UCUM koodi",
+					"code": "Kood",
+					"btn": "Valideeri",
+					"result": "Tulemus"
+				},
+				"convert": {
+					"title": "Teisenda UCUM koodi",
+					"value": "Väärtus",
+					"sourceCode": "Lähtekood",
+					"targetCode": "Sihtkood",
+					"btn": "Teisenda",
+					"result": "Tulemus",
+					"error": "Viga"
+				},
+				"canonicalise": {
+					"title": "Kanoniseeri UCUM koodi",
+					"code": "Kood",
+					"btn": "Kanoniseeri",
+					"result": "Tulemus",
+					"error": "Viga"
+				}
 			}
 		},
 		"measurement-unit": {
@@ -1827,9 +2082,10 @@
 						"Privilege": "Õigus",
 						"Sequence": "Numeratsioon",
 						"Server": "Terminoloogiaserver",
-                        "Release": "Väljalase",
-                        "Checklist": "Kontrollide nimekiri",
-                        "Users": "Kasutajad"
+						"Release": "Väljalase",
+						"Checklist": "Kontrollide nimekiri",
+						"Users": "Kasutajad",
+						"ChecklistRule": "ChecklistRule"
 					}
 				},
 				"table": {
@@ -1858,7 +2114,8 @@
 			"provenance": "Ajalugu",
 			"summary": "Kokkuvõte",
 			"checklist": "Kontrollide nimekiri",
-			"metadata": "Metaandmed"
+			"metadata": "Metaandmed",
+			"resources": "Ressursid"
 		},
 		"resource-form": {
 			"add-other-title": "Lisa muu pealkiri",
@@ -2058,6 +2315,11 @@
 				"import-refset-concepts": "Import refset mõisted",
 				"refsets": "Refset-id",
 				"taxonomy": "Taksonoomia"
+			},
+			"task": {
+				"card-header": "Ülesanded",
+				"modal-header": "Loo mõiste ülesanne",
+				"comment": "Kommentaar"
 			}
 		},
 		"space": {
@@ -2094,7 +2356,12 @@
 			"diff": {
 				"not-render": "Suuri ressursse vaikimisi ei renderdata",
 				"sync-tooltip": "Allikas: {{source}}\n Siht: {{target}}"
-			}
+			},
+			"msdevops-integration": "Azure DevOps integratsioon",
+			"change-source-server": "Muuda ressursside lähteserverit",
+			"reload-diff-matrix": "Lae erinevuste maatriks uuesti",
+			"sync-resources": "Sünkroniseeri kõik ressursid (antud installatsioonist sihtserverisse)",
+			"clear-sync-resources": "Kustuta ja sünkroniseeri kõik ressursid (antud installatsioonist sihtserverisse)"
 		},
 		"structure-definition": {
 			"form": {
@@ -2156,7 +2423,8 @@
 				"import-url": "URL",
 				"manual": "Loo käsitsi",
 				"open-fhir": "Ava FHIR-is",
-				"title": "Struktuuri definitsioonid"
+				"title": "Struktuuri definitsioonid",
+				"last-version": "Viimane versioon"
 			},
 			"summary": {
 				"add-task": "Add task",
@@ -2167,7 +2435,11 @@
 				"related-artifacts": "Related artifacts",
 				"versions": "Versions",
 				"viewer": "Preview",
-				"recalculate-references": "Recalculate"
+				"recalculate-references": "Recalculate",
+				"duplicate-version-modal": {
+					"header": "Tee struktuuri definitsiooni versioonist koopia",
+					"version": "Uus versioon"
+				}
 			},
 			"version-summary": {
 				"version-info": "Version info",
@@ -2176,7 +2448,16 @@
 			"view": {
 				"binding": "Seotud loendiga",
 				"fixed": "Fikseeritud"
-			}
+			},
+			"code": "Kood",
+			"url": "URL",
+			"name": "Nimi",
+			"title": "Pealkiri",
+			"publisher": "Väljaandja",
+			"content-type": "Sisu tüüp",
+			"description": "Kirjeldus",
+			"parent": "Vanem",
+			"experimental": "Eksperimentaalne"
 		},
 		"structure-definition-version": {
 			"form": {
@@ -2258,7 +2539,16 @@
 			"auth-config": {
 				"access-token-url": "Access Token URL",
 				"client-id": "Client ID",
-				"client-secret": "Client Secret"
+				"client-secret": "Client Secret",
+				"auth-type": "Autentimise tüüp",
+				"auth-type-none": "Puudub",
+				"auth-type-basic": "Basic",
+				"auth-type-oauth2": "OAuth 2.0",
+				"auth-type-apikey": "API võti",
+				"username": "Kasutajanimi",
+				"password": "Parool",
+				"api-key": "API võti",
+				"scope": "Skoop"
 			},
 			"edit-header": "Muuda server",
 			"headers": {
@@ -2269,7 +2559,31 @@
 				"fhir": "FHIR server",
 				"snomed": "SNOMED server",
 				"terminology": "Terminoloogiaserver"
-			}
+			},
+			"authoritative": "Autoriteetsed ressursid",
+			"export-ecosystem": "Ekspordi FHIR Ecosystem vormingusse",
+			"import-ecosystem": "Impordi FHIR Ecosystem failist",
+			"fhir-ecosystem": "FHIR Ecosystem",
+			"tab": {
+				"summary": "Kokkuvõte",
+				"metadata": "Metaandmed",
+				"resources": "Ressursid"
+			},
+			"test": "Testi",
+			"view-header": "Serveri detailid",
+			"authoritative-code-systems": "Autoriteetsed koodisüsteemid",
+			"authoritative-value-sets": "Autoriteetsed loendid",
+			"authoritative-concept-maps": "Autoriteetsed vastendustabelid",
+			"authoritative-structure-definitions": "Autoriteetsed struktuuri definitsioonid",
+			"authoritative-structure-maps": "Autoriteetsed struktuuri transformatsioonid",
+			"authoritative-description-code-systems": "Määra, milliste koodisüsteemide jaoks see server on autoriteetne.",
+			"authoritative-description-value-sets": "Määra, milliste loendite jaoks see server on autoriteetne.",
+			"authoritative-description-concept-maps": "Määra, milliste vastendustabelite jaoks see server on autoriteetne.",
+			"authoritative-description-structure-definitions": "Määra, milliste struktuuri definitsioonide jaoks see server on autoriteetne.",
+			"authoritative-description-structure-maps": "Määra, milliste struktuuri transformatsioonide jaoks see server on autoriteetne.",
+			"authoritative-preview-btn": "Eelvaade",
+			"authoritative-preview": "Sobivad ressursid",
+			"structure-maps": "Struktuuri transformatsioonid"
 		},
 		"tools": {
 			"terminology-service-api": {
@@ -2279,7 +2593,8 @@
 			},
 			"termx-service-api": {
 				"content": "TermX Service API-d võimaldavad kliinilise terminoloogia sisu ja ressursside automaatset vahetamist.",
-				"header": "TermX Service API"
+				"header": "TermX Service API",
+				"no-data": "API-de vaatamise tööriistad ei ole seadistatud."
 			}
 		},
 		"transformation-definition": {
@@ -2332,6 +2647,12 @@
 				"type.definition": "Definitsioonid",
 				"type.mapping": "Mapping",
 				"type.mapping-main": "Mapping"
+			},
+			"import": {
+				"import-map": {
+					"title": "See ressurss imporditi ImportMap'ist!",
+					"description": "Kui pead muudatusi tegema, võid selle kas kustutada ja käsitsi uuesti luua või salvestada transformatsiooni definitsiooni!"
+				}
 			}
 		},
 		"value-set": {
@@ -2349,7 +2670,8 @@
 					"export-fhir-xml": "Ekspordi FHIR XML",
 					"open-fhir": "Ava FHIR URL"
 				},
-				"view-header": "Vaata loend"
+				"view-header": "Vaata loend",
+				"details-header": "Loendi detailid"
 			},
 			"list": {
 				"add-value-set": "Lisa loend",
@@ -2376,7 +2698,8 @@
 				"related-artifacts": "Seotud artefaktid",
 				"total-concepts": "Mõisted kokku",
 				"value-set": "Loend",
-				"versions": "Versioonid"
+				"versions": "Versioonid",
+				"add-task": "Lisa ülesanne"
 			}
 		},
 		"value-set-version": {
@@ -2527,7 +2850,11 @@
 			"header": {
 				"add-subpage": "Lisa alamlehekülg",
 				"copy-raw": "Kopeeri binaarne fail",
-				"modified": "<b>{{user}}</b> muutis seda lehte {{date}}"
+				"modified": "<b>{{user}}</b> muutis seda lehte {{date}}",
+				"export-page-pdf": "Ekspordi lehekülg PDF-i",
+				"export-page-html": "Ekspordi lehekülg HTML-i",
+				"export-space-pdf": "Ekspordi ruum PDF-i",
+				"export-space-html": "Ekspordi ruum HTML-i"
 			},
 			"history": {
 				"header": {
@@ -2557,7 +2884,8 @@
 					"created": "Loodud {{date}}",
 					"header": "Hiljuti muudetud",
 					"updated": "Uuendatud {{date}}"
-				}
+				},
+				"export": "Ekspordi"
 			},
 			"setup": {
 				"add-header": "Lisa lehekülg",
@@ -2604,6 +2932,28 @@
 					}
 				}
 			}
+		},
+		"concept-drawer": {
+			"add-all": "Lisa kõik",
+			"add-selected": "Lisa valitud",
+			"code-system-required": "Koodisüsteem on kohustuslik"
+		},
+		"implementation-guide-github": {
+			"ig-initialize": "Initsialiseeri juurutusjuhend allikast",
+			"ig-not-initialized": "Juurutusjuhend ei ole initsialiseeritud",
+			"branch-not-exists": "Haru ei eksisteeri",
+			"github-base-branch": "Alusharu",
+			"create-branch": "Loo haru",
+			"github-clean": "Kõik on ajakohane!",
+			"github-commit-message": "Commit teade",
+			"github-empty": "Pole midagi commit'ida",
+			"github-push": "Lükka muudatused asukohta"
+		},
+		"ecosystem": {
+			"add-btn": "Lisa ökosüsteem",
+			"add-header": "Lisa ökosüsteem",
+			"edit-header": "Muuda ökosüsteemi",
+			"select-servers": "Vali serverid..."
 		}
 	}
 }

--- a/app/src/assets/i18n/lt.json
+++ b/app/src/assets/i18n/lt.json
@@ -2,8 +2,8 @@
   "core": {
     "back": "Grįžti",
     "shortcut": {
-        "help-title": "Klavišų kombinacijos",
-        "help": "Rodyti klavišų kombinacijas"
+      "help-title": "Klavišų kombinacijos",
+      "help": "Rodyti klavišų kombinacijas"
     },
     "btn": {
       "add": "Pridėti",
@@ -233,35 +233,35 @@
         "single": "vienas",
         "version": "Versija"
       },
-      "empty-github-url": "",
-      "fhir-version": "",
+      "empty-github-url": "Pradinis tuščias IG Github projektas",
+      "fhir-version": "FHIR versija",
       "github-branch": "Branch",
-      "github-url": "",
+      "github-url": "Visas Github projekto URL",
       "group": {
-        "description": "",
-        "multiple": "",
-        "name": ""
+        "description": "Aprašas",
+        "multiple": "Grupės",
+        "name": "Pavadinimas"
       },
-      "multiple": "",
-      "package-id": "",
+      "multiple": "Versijos",
+      "package-id": "Paketo ID",
       "page": {
-        "group": "",
-        "multiple": "",
-        "name": "",
-        "page": "",
-        "space": "",
-        "type": ""
+        "group": "Grupė",
+        "multiple": "Puslapiai",
+        "name": "Pavadinimas",
+        "page": "Puslapis",
+        "space": "Sritis",
+        "type": "Tipas"
       },
       "resource": {
-        "group": "",
-        "multiple": "",
-        "name": "",
-        "reference": "",
-        "type": "",
-        "version": ""
+        "group": "Grupė",
+        "multiple": "Ištekliai",
+        "name": "Pavadinimas",
+        "reference": "Nuoroda",
+        "type": "Tipas",
+        "version": "Versija"
       },
-      "single": "",
-      "template": "",
+      "single": "Versija",
+      "template": "Šablonas",
       "version": "Versija"
     },
     "map-set": {
@@ -697,7 +697,9 @@
       "shared": "Bendrasis",
       "singular": "Erdvė",
       "servers": "Terminologijos serveriai",
-      "viewers": "Turintys peržiūros teisę"
+      "viewers": "Turintys peržiūros teisę",
+      "global-search": "Visuotinė paieška",
+      "msdevops": "Azure DevOps kodo saugykla"
     },
     "structure-definition": {
       "code": "Kodas",
@@ -866,7 +868,8 @@
         "filters": "Filtrai",
         "properties": "Savybės",
         "value-set": "Reikšmių rinkinys (value set)",
-        "value-set-version": "Reikšmių rinkinio (value set) versija"
+        "value-set-version": "Reikšmių rinkinio (value set) versija",
+        "supplement-of": "Papildo"
       },
       "rules": "Taisyklės"
     },
@@ -919,7 +922,20 @@
     "app": {
       "header": "TermX",
       "theme": {
-            "dark": "Tamsus režimas"
+        "dark": "Tamsus režimas"
+      },
+      "accessibility": {
+        "title": "Pritaikymas neįgaliesiems",
+        "appearance": "Išvaizda",
+        "appearance-white": "Šviesi",
+        "appearance-dark": "Tamsi",
+        "appearance-ncez": "NCEZ",
+        "font-size": "Šrifto dydis",
+        "font-normal": "Įprastas",
+        "font-large": "Didelis",
+        "font-extra-large": "Labai didelis",
+        "apply": "Taikyti",
+        "reset": "Atstatyti"
       }
     },
     "association-type": {
@@ -1069,6 +1085,24 @@
           "version": "Versija"
         },
         "versions": "Versijos"
+      },
+      "coding-refresh": {
+        "action": "Atnaujinti nuorodas",
+        "header": "Atnaujinti nuorodas į kitas kodų sistemas",
+        "allowed-statuses": "Leidžiami paskirties statusai",
+        "allowed-statuses-desc": "Renkant naujausią versiją įvertinamos tik versijos, atitinkančios vieną iš šių statusų.",
+        "preview-btn": "Peržiūrėti pakeitimus",
+        "apply-btn": "Taikyti",
+        "preview-desc": "Bus atnaujinta nuorodų: {{count}}",
+        "property": "Savybė",
+        "target": "Paskirtis",
+        "current": "Dabartinė versija",
+        "candidate": "Nauja versija",
+        "up-to-date": "Visos nuorodos atnaujintos",
+        "up-to-date-desc": "Nerasta savybių reikšmių, nurodančių į senesnę versiją.",
+        "applied": "Nuorodos atnaujintos",
+        "queued": "Nuorodos įtrauktos į atnaujinimo eilę",
+        "validator-desc": "Patikrinti šios kodų sistemos versijos savybių reikšmes ir atnaujinti nuorodas į naujausią prieinamą jų paskirties kodų sistemų versiją."
       }
     },
     "code-system-association": {
@@ -1307,12 +1341,11 @@
     "global-search": {
       "dashboard": {
         "all": "Visi",
-        "filter": "Filtras",
-        "code-systems": "Kodų sistemos (code systems)",
-        "concepts": "Terminai",
         "filter": {
           "space": "Space"
         },
+        "code-systems": "Kodų sistemos (code systems)",
+        "concepts": "Terminai",
         "header": "Ieškoti",
         "map-sets": "Terminijos ryšių rinkiniai (map sets)",
         "measurement-unit": "Matavimo vienetas",
@@ -2264,7 +2297,8 @@
       "resource-import-success-message": "Ištekliaus importavimas sėkmingas",
       "resources": "Ištekliai",
       "select-context": "Pasirinkite kontekstą",
-      "sync-resources": "Sync all resources (from current installation to target server)"
+      "sync-resources": "Sync all resources (from current installation to target server)",
+      "msdevops-integration": "Azure DevOps integracija"
     },
     "structure-definition": {
       "form": {
@@ -2442,7 +2476,16 @@
       "auth-config": {
         "access-token-url": "Prieigos duomenų URL (Access Token URL)",
         "client-id": "Kliento ID",
-        "client-secret": "Kliento raktas (client secret)"
+        "client-secret": "Kliento raktas (client secret)",
+        "auth-type": "Autentifikavimo tipas",
+        "auth-type-none": "Nėra",
+        "auth-type-basic": "Bazinis",
+        "auth-type-oauth2": "OAuth 2.0",
+        "auth-type-apikey": "API raktas",
+        "username": "Naudotojo vardas",
+        "password": "Slaptažodis",
+        "api-key": "API raktas",
+        "scope": "Sritis"
       },
       "edit-header": "Redaguoti serverį",
       "export-ecosystem": "Export to FHIR Ecosystem format",
@@ -2778,7 +2821,7 @@
         "concept": "Terminas",
         "contents": "Turinys",
         "cs": "Kodų sistema (code system)",
-        "csc": "",
+        "csc": "Kodų sistemos terminai",
         "def": "Struktūros apibrėžimas",
         "ms": "Terminijos ryšių rinkiniai (map set)",
         "none": "Nėra",
@@ -2787,7 +2830,7 @@
         "tags": "Gairės",
         "usages": "Rodyklės",
         "vs": "Reikšmių rinkinys (value set)",
-        "vsc": ""
+        "vsc": "Reikšmių rinkinio (value set) terminai"
       },
       "edit": {
         "header": {
@@ -2827,7 +2870,11 @@
       "header": {
         "add-subpage": "Pridėti priklausantį puslapį",
         "copy-raw": "Kopijuoti neapdorotus duomenis",
-        "modified": "Šį puslapį {{date}} redagavo <b>{{user}}</b>."
+        "modified": "Šį puslapį {{date}} redagavo <b>{{user}}</b>.",
+        "export-page-pdf": "Eksportuoti puslapį į PDF",
+        "export-page-html": "Eksportuoti puslapį į HTML",
+        "export-space-pdf": "Eksportuoti sritį į PDF",
+        "export-space-html": "Eksportuoti sritį į HTML"
       },
       "history": {
         "header": {
@@ -2857,7 +2904,8 @@
           "created": "Sukurta {{date}}",
           "header": "Neseniai pakeista",
           "updated": "Atnaujinta {{date}}"
-        }
+        },
+        "export": "Eksportuoti"
       },
       "setup": {
         "add-header": "Pridėti puslapį",


### PR DESCRIPTION
## Summary
Fills all keys that were **missing or empty** relative to `en.json` for three supported UI languages:

| Lang | Filled |
|---|---|
| lt | 69 |
| cs | 113 (14 of them sourced from the Czech deployment project, the rest translated to match existing cs.json conventions) |
| et | 287 |

After this, lt/cs/et have **0 missing/empty keys** vs `en`. Each file keeps its native formatting (lt/cs 2-space, et tabs) so the diff is additions, not a reformat. Placeholders (`{{x}}`) and per-language terminology conventions were preserved.

ru is not a supported UI language in termx-web (`UI_LANGS` has no `ru`), so no ru file.

> Note: most strings are machine-translated following each file's existing terminology — a native-speaker pass is recommended, especially for cs (the Czech deployment snapshot only covered 14 of the gaps).