### PR TITLE
Sort code system versions by semantic version, latest first

### DIFF
--- a/app/src/app/resources/_lib/code-system/util/code-system-util.ts
+++ b/app/src/app/resources/_lib/code-system/util/code-system-util.ts
@@ -6,4 +6,37 @@ export class CodeSystemUtil {
   public static getLastVersion(versions: CodeSystemVersion[]): CodeSystemVersion {
     return versions?.filter(v => ['draft', 'active'].includes(v.status!)).sort((a, b) => compareValues(a.releaseDate, b.releaseDate))?.[0];
   }
+
+  // Latest first, using semantic-version ordering so 1.0.10 sorts above 1.0.9 (not lexicographically).
+  public static sortVersions(versions: CodeSystemVersion[]): CodeSystemVersion[] {
+    return [...(versions ?? [])].sort((a, b) => CodeSystemUtil.compareVersions(b.version, a.version));
+  }
+
+  // Ascending comparison of version strings. Splits on '.', '-' and '+', comparing numeric
+  // segments as numbers and everything else as a natural (numeric-aware) string compare, so
+  // mixed schemes like 1.0.10, 2017.3 or 6.0.0-draft all order sensibly.
+  private static compareVersions(v1 = '', v2 = ''): number {
+    const segments = (v: string): (number | string)[] =>
+      v.split(/[.\-+]/).map(s => /^\d+$/.test(s) ? Number(s) : s);
+    const a = segments(v1);
+    const b = segments(v2);
+    for (let i = 0; i < Math.max(a.length, b.length); i++) {
+      const x = a[i];
+      const y = b[i];
+      if (x === undefined) {
+        return -1; // shorter version is "smaller" (1.0 < 1.0.1)
+      }
+      if (y === undefined) {
+        return 1;
+      }
+      if (x === y) {
+        continue;
+      }
+      if (typeof x === 'number' && typeof y === 'number') {
+        return x - y;
+      }
+      return String(x).localeCompare(String(y), undefined, {numeric: true});
+    }
+    return 0;
+  }
 }

--- a/app/src/app/resources/code-system/containers/summary/code-system-summary.component.ts
+++ b/app/src/app/resources/code-system/containers/summary/code-system-summary.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit, ViewChild, inject } from '@angular/core';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { LoadingManager, FilterPipe } from '@termx-health/core-util';
-import {CodeSystem, CodeSystemArtifactImpact, CodeSystemVersion} from 'term-web/resources/_lib';
+import {CodeSystem, CodeSystemArtifactImpact, CodeSystemUtil, CodeSystemVersion} from 'term-web/resources/_lib';
 import {forkJoin} from 'rxjs';
 import {CodeSystemUnlinkedConceptsComponent} from 'term-web/resources/code-system/containers/summary/widgets/code-system-unlinked-concepts.component';
 import {CodeSystemService} from 'term-web/resources/code-system/services/code-system.service';
@@ -53,7 +53,7 @@ export class CodeSystemSummaryComponent implements OnInit {
   public link(codeSystemVersion: string, entityVersionIds: number[]): void {
     this.loader.wrap('link', this.codeSystemService.linkEntityVersions(this.codeSystem.id, codeSystemVersion, entityVersionIds))
       .subscribe(() => {
-        this.codeSystemService.searchVersions(this.codeSystem.id, {limit: -1}).subscribe(versions => this.versions = versions.data);
+        this.codeSystemService.searchVersions(this.codeSystem.id, {limit: -1}).subscribe(versions => this.versions = CodeSystemUtil.sortVersions(versions.data));
         this.unlinkedConceptsComponent.loadUnlinkedConcepts();
       });
   }
@@ -71,7 +71,7 @@ export class CodeSystemSummaryComponent implements OnInit {
       forkJoin([this.codeSystemService.load(id), this.codeSystemService.searchVersions(id, {limit: -1}), this.codeSystemService.loadValueSetImpacts(id)]))
       .subscribe(([cs, versions, impacts]) => {
         this.codeSystem = cs;
-        this.versions = versions.data;
+        this.versions = CodeSystemUtil.sortVersions(versions.data);
         this.valueSetImpacts = impacts;
       });
   }


### PR DESCRIPTION
## Problem
The code system **Versions** panel rendered versions unordered — e.g. `1.0.6, 1.0.0, 1.0.1, 1.0.2, 1.0.7`.

## Cause
`CodeSystemVersionRepository.query()` (the list query) has no `ORDER BY`, so Postgres returns rows in heap order, and the frontend assigned them as-is (`limit: -1`, no sort).

## Fix
Sort client-side in `CodeSystemUtil.sortVersions()`, latest first, with a segment-wise semantic-version comparator:
- `1.0.10` > `1.0.9` (numeric, not lexicographic)
- `1.1.0` > `1.0.10`
- non-numeric segments fall back to a natural (numeric-aware) compare, so `2017.3`, `6.0.0-draft` etc. still order sensibly

Applied at both version-load sites in the summary. The existing `latestVersion()` helper in `semantic-version-select` was **not** reused — it concatenates digits (`1.0.10`→`1010`) and misranks `1.1.0` below `1.0.10`.