### PR TITLE
Bump @termx-health/ui to 21.0.6 (text-contrast fix)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@termx-health/markdown-parser": "^21.0.4",
         "@termx-health/quill": "^21.0.4",
         "@termx-health/structure-definition-viewer": "5.0.7",
-        "@termx-health/ui": "^21.0.5",
+        "@termx-health/ui": "^21.0.6",
         "@termx-health/util": "^21.0.4",
         "angular-auth-oidc-client": "^21.0.0",
         "codemirror": "^6.0.1",
@@ -6828,9 +6828,9 @@
       "integrity": "sha512-RPd/WDlkaY7StEoeKKoZuY9bCcivsuMRpniznGAMaX0Ub2ZyjzV9a7JrfSq+/9teqiCOmewzkgaJ66l3DIIx1A=="
     },
     "node_modules/@termx-health/ui": {
-      "version": "21.0.5",
-      "resolved": "https://npm.pkg.github.com/download/@termx-health/ui/21.0.5/058b0f96c20a4b38f53ef3fefcaf8d46e24e0a66",
-      "integrity": "sha512-QQ6aA3jt+HPZT7swViyMKkmiPmDo5gjCJJbW8VdiMNKYKTOuHYdPApr9QR7RYIUujdldiD7xYhPmhWtcRWLimA==",
+      "version": "21.0.6",
+      "resolved": "https://npm.pkg.github.com/download/@termx-health/ui/21.0.6/53743ed95f3018616c636ec2277a5829bc8c489a",
+      "integrity": "sha512-zJaFbtP/nccwtCkpkWwqNAqHgZOawYvjWe/f652y01qxP5+vzPdhoLHQFQ2Pq/TqNl1d2dpJqbRChkm1Up/dpQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@termx-health/core-util": "^21.0.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@termx-health/markdown-parser": "^21.0.4",
     "@termx-health/quill": "^21.0.4",
     "@termx-health/structure-definition-viewer": "5.0.7",
-    "@termx-health/ui": "^21.0.5",
+    "@termx-health/ui": "^21.0.6",
     "@termx-health/util": "^21.0.4",
     "angular-auth-oidc-client": "^21.0.0",
     "codemirror": "^6.0.1",


### PR DESCRIPTION
Pulls in `@termx-health/ui@21.0.6`, which fixes the low-contrast neutral text flagged by the customer accessibility audit — secondary text (`#8c8c8c → #595959`), input/select placeholders (`#bfbfbf → #767676`) and the "No data" empty state (`→ #757575`), all now ≥ 4.5:1 on white (WCAG 2.1 AA).

Lockfile-only change (spec was already `^21.0.5`).