### PR TITLE
Bump @termx-health/ui to 21.0.7 (accessibility fixes)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@termx-health/markdown-parser": "^21.0.4",
         "@termx-health/quill": "^21.0.4",
         "@termx-health/structure-definition-viewer": "5.0.7",
-        "@termx-health/ui": "^21.0.6",
+        "@termx-health/ui": "^21.0.7",
         "@termx-health/util": "^21.0.4",
         "angular-auth-oidc-client": "^21.0.0",
         "codemirror": "^6.0.1",
@@ -6828,9 +6828,9 @@
       "integrity": "sha512-RPd/WDlkaY7StEoeKKoZuY9bCcivsuMRpniznGAMaX0Ub2ZyjzV9a7JrfSq+/9teqiCOmewzkgaJ66l3DIIx1A=="
     },
     "node_modules/@termx-health/ui": {
-      "version": "21.0.6",
-      "resolved": "https://npm.pkg.github.com/download/@termx-health/ui/21.0.6/53743ed95f3018616c636ec2277a5829bc8c489a",
-      "integrity": "sha512-zJaFbtP/nccwtCkpkWwqNAqHgZOawYvjWe/f652y01qxP5+vzPdhoLHQFQ2Pq/TqNl1d2dpJqbRChkm1Up/dpQ==",
+      "version": "21.0.7",
+      "resolved": "https://npm.pkg.github.com/download/@termx-health/ui/21.0.7/6f863fd582d5988acec9e427e910b6d712c343bc",
+      "integrity": "sha512-ipdQWUFOG2eOs5Vf/feOvl/ruc/C6X9rxdcIXNjScDN9KxJ4INgrSNGa+nMG+jLpaMyawozBOJFTvEvlc2I3uQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@termx-health/core-util": "^21.0.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@termx-health/markdown-parser": "^21.0.4",
     "@termx-health/quill": "^21.0.4",
     "@termx-health/structure-definition-viewer": "5.0.7",
-    "@termx-health/ui": "^21.0.6",
+    "@termx-health/ui": "^21.0.7",
     "@termx-health/util": "^21.0.4",
     "angular-auth-oidc-client": "^21.0.0",
     "codemirror": "^6.0.1",


### PR DESCRIPTION
Pulls in `@termx-health/ui@21.0.7`, which fixes three WCAG error categories at the shared-component level:
- form controls now have programmatic labels (`aria-labelledby`)
- icon-only buttons now have accessible names
- page titles are exposed as headings (`h1`)

Verified in a local build: unlabelled controls 44→0, unnamed icon buttons 19→3. Lockfile-only change (spec was already `^21.0.6`).