### PR TITLE
fix(global-search): accessible selected state for space filters

### DIFF
--- a/app/src/app/global-search/containers/global-search-dashboard.component.html
+++ b/app/src/app/global-search/containers/global-search-dashboard.component.html
@@ -4,11 +4,11 @@
     <m-card mTitle="web.global-search.dashboard.header">
       @if (spaceButtons.length) {
         <div class="tw-global-search__spaces">
-          <m-button mDisplay="text" [class.active]="!activeSpace" (mClick)="searchBySpace()">
+          <m-button [mDisplay]="!activeSpace ? 'primary' : 'text'" [class.active]="!activeSpace" (mClick)="searchBySpace()">
             {{'web.global-search.dashboard.all' | translate}}
           </m-button>
           @for (s of spaceButtons; track s.code) {
-            <m-button mDisplay="text" [class.active]="activeSpace === s.code" (mClick)="searchBySpace(s.code)">
+            <m-button [mDisplay]="activeSpace === s.code ? 'primary' : 'text'" [class.active]="activeSpace === s.code" (mClick)="searchBySpace(s.code)">
               {{s.code}}
             </m-button>
           }

--- a/app/src/app/global-search/containers/global-search-dashboard.component.ts
+++ b/app/src/app/global-search/containers/global-search-dashboard.component.ts
@@ -37,11 +37,6 @@ interface Filter {
       flex-wrap: wrap;
       gap: 0.25rem;
       margin-bottom: 0.5rem;
-
-      .active {
-        font-weight: bold;
-        color: var(--color-primary);
-      }
     }
   `],
   standalone: false


### PR DESCRIPTION
## Problem

On `/global-search`, the space quick-filter chips ("All" and each space code) marked the active one only via `color: var(--color-primary)` on the `m-button` host. The inner Ant text button keeps its own `rgba(0,0,0,0.85)` colour, so the primary colour never reached the text — the selected chip was **visually indistinguishable** from the others. That's a WCAG **1.4.1 (Use of Colour)** failure plus a contrast gap.

## Fix

Render the active chip as a filled **primary** button (`mDisplay="primary"`) and the rest as `text`. White text on `--color-primary` (`#1464C0`) measures **5.81:1 — passes WCAG AA**, and the selection is now conveyed by shape, not colour alone. Removed the now-redundant `.active` colour override.

Verified live in the browser (contrast measured on the rendered element).