### PR TITLE
Show supplement alias designations for UCUM unit property values

### DIFF
--- a/app/src/app/resources/_lib/code-system/pipe/localized-concept-name-pipe.ts
+++ b/app/src/app/resources/_lib/code-system/pipe/localized-concept-name-pipe.ts
@@ -94,10 +94,27 @@ class LocalizedConceptNameService {
       return concept.code;
     }
 
+    const designations = conceptVersion.designations;
+    const langPriority = [lang, environment.defaultLanguage];
+
+    // Prefer an `alias` designation (e.g. the ucum-lt supplement's localized unit symbol like `mg/l`).
+    // Language-prioritised, then any alias regardless of language (unit symbols are language-neutral).
+    const aliases = designations.filter(d => d.designationType === 'alias');
+    const alias = this.localize({display: aliases, additional: []}, langPriority) ?? aliases.sort(sortFn('preferred'))[0]?.name;
+    if (isDefined(alias)) {
+      return alias;
+    }
+
+    // Supplemented reference without an alias: show the code, not the wordy display designation.
+    if (designations.some(d => d.supplement)) {
+      return concept.code;
+    }
+
+    // Default (non-supplemented references, e.g. specimen/method concepts): preferred display, else code.
     const localized = this.localize({
-      display: conceptVersion.designations.filter(d => d.designationType === 'display'),
-      additional: conceptVersion.designations.filter(d => d.designationType !== 'display'),
-    }, [lang, environment.defaultLanguage]);
+      display: designations.filter(d => d.designationType === 'display'),
+      additional: designations.filter(d => d.designationType !== 'display'),
+    }, langPriority);
 
     return localized ?? concept.code;
   }

--- a/app/src/app/resources/_lib/code-system/pipe/localized-concept-name-pipe.ts
+++ b/app/src/app/resources/_lib/code-system/pipe/localized-concept-name-pipe.ts
@@ -105,12 +105,7 @@ class LocalizedConceptNameService {
       return alias;
     }
 
-    // Supplemented reference without an alias: show the code, not the wordy display designation.
-    if (designations.some(d => d.supplement)) {
-      return concept.code;
-    }
-
-    // Default (non-supplemented references, e.g. specimen/method concepts): preferred display, else code.
+    // Otherwise: preferred display designation, else the code.
     const localized = this.localize({
       display: designations.filter(d => d.designationType === 'display'),
       additional: designations.filter(d => d.designationType !== 'display'),

--- a/app/src/app/resources/_lib/code-system/util/concept-supplement-util.ts
+++ b/app/src/app/resources/_lib/code-system/util/concept-supplement-util.ts
@@ -1,11 +1,15 @@
 import { ConceptSearchParams } from 'term-web/resources/_lib/code-system/model/concept-search-params';
 
 export class ConceptSupplementUtil {
+  // Request supplement designations for any referenced code system. The server auto-discovers
+  // supplements (content=supplement) by their base_code_system when includeSupplement + a
+  // displayLanguage are set, so a plain, non-supplemented code system is just a cheap no-op.
+  // This lets localized designations (e.g. the ucum-lt supplement's unit aliases) surface for
+  // every coding reference, not only the hardcoded `ucum` case.
   public static forCodeSystem(codeSystem?: string, language?: string): Pick<ConceptSearchParams, 'includeSupplement' | 'displayLanguage'> {
-    if (codeSystem !== 'ucum') {
+    if (!codeSystem) {
       return {};
     }
-
     return {
       includeSupplement: true,
       displayLanguage: language
@@ -13,9 +17,6 @@ export class ConceptSupplementUtil {
   }
 
   public static forSearchScope(codeSystems?: string[], language?: string): Pick<ConceptSearchParams, 'includeSupplement' | 'displayLanguage'> {
-    if (codeSystems?.length && !codeSystems.includes('ucum')) {
-      return {};
-    }
     return {
       includeSupplement: true,
       displayLanguage: language


### PR DESCRIPTION
**Draft — for review, do not merge.**

## Problem
Coding property values referencing UCUM units render the raw code or the wordy display name instead of the localized unit (e.g. `ug/L` instead of `µg/l`), and supplement designations were only requested when the referenced code system id was literally `ucum`.

The Lithuanian units live in the `ucum-lt` **supplement**: the canonical UCUM code is the concept `code`, and the old LT-modified form is an `alias` designation (e.g. `mg/L`→`mg/l`, `ug/L`→`µg/l`, `[CFU]`→`KFV`, `{#}`→`skaičius`, `10*3/L`→`10^3/l`).

## Changes
- **`ConceptSupplementUtil`** — request supplements (`includeSupplement` + `displayLanguage`) for *any* referenced code system, not just hardcoded `ucum`. The server auto-discovers `content=supplement` systems by `base_code_system`, so a non-supplemented system is a cheap no-op.
- **`LocalizedConceptNameService.getName`** — label priority: **`alias` → (supplemented) code → display → code**. Non-supplemented references (specimen/method concepts like `VenBl`) are unchanged.

## Behaviour
| referenced concept | before | after |
|---|---|---|
| `ucum` `ug/L` (ucum-lt alias `µg/l`) | `ug/L` | `µg/l` |
| `ucum` `{#}` (alias `skaičius`) | code / `Skaičius` | `skaičius` |
| specimen `VenBl` (display, no alias) | `VenBl Kraujas, veninis` | unchanged |

## Verified
- `tsc -p app/tsconfig.app.json --noEmit`: clean (0 errors).
- Live contract confirmed against the **active** `ucum-ee` supplement: base-`ucum` reads merge its `alias` designations (`/100{WBC}`→alias `/100WBC`), which the new picker selects.

## Caveats (please review)
- Supplement designations reach the UI only when the supplement version is **active**. `ucum-lt` is currently a **draft** (`0.0.3`) and must be published, or nothing localizes.
- The merged `supplement` flag comes back `false` even for active supplements on this endpoint, so the picker prefers an `alias` whenever the concept has one (rather than gating strictly on "is supplemented"). In practice `alias` designations are a UCUM-supplement pattern, so impact outside units is minimal.
- Not addressed here (out of scope): a data migration to rewrite property values still holding the old alias-form codes, and the backend coding-enrichment / FHIR `$lookup` paths.