### PR TITLE
Translate the DELETE 405 message instead of hardcoding Estonian

### DIFF
--- a/app/src/app/core/marina/http-error-handler.ts
+++ b/app/src/app/core/marina/http-error-handler.ts
@@ -76,8 +76,8 @@ export class HttpErrorHandler implements HttpInterceptor {
 
     if (error.status === 405 && isDelete && isTermxTsEndpoint) {
       this.showError(
-        'Kustutamine ebaõnnestus',
-        'Mõiste koodis ei ole lubatud kasutada erimärke.'
+        this.i18nService.instant('core.error.delete-405.title'),
+        this.i18nService.instant('core.error.delete-405.message')
       );
       return;
     }

--- a/app/src/assets/i18n/en.json
+++ b/app/src/assets/i18n/en.json
@@ -38,6 +38,10 @@
 			"403": {
 				"title": "Access Denied",
 				"message": "You do not have access to resource."
+			},
+			"delete-405": {
+				"title": "Delete failed",
+				"message": "Special characters are not allowed in the concept code."
 			}
 		},
 		"confirm": "Are you sure?",

--- a/app/src/assets/i18n/et.json
+++ b/app/src/assets/i18n/et.json
@@ -34,6 +34,10 @@
 			"403": {
 				"title": "Juurdepääs keelatud",
 				"message": "Teil puudub juurdepääs ressursi pärimiseks."
+			},
+			"delete-405": {
+				"title": "Kustutamine ebaõnnestus",
+				"message": "Mõiste koodis ei ole lubatud kasutada erimärke."
 			}
 		},
 		"session-expiration-warning": "Sessioon aegub vähem kui 5 minuti pärast! Vajadusel salvesta!",


### PR DESCRIPTION
**M3** from the `tehik-termx-web` → `termx-web` comparison — the one finding that runs *opposite* to the rest: Estonian that leaked **into** mainstream, rather than TEHIK work missing from it.

`core/marina/http-error-handler.ts` — a generic HTTP error interceptor — showed two hardcoded Estonian strings:

```ts
if (error.status === 405 && isDelete && isTermxTsEndpoint) {
  this.showError(
    'Kustutamine ebaõnnestus',
    'Mõiste koodis ei ole lubatud kasutada erimärke.');
```

They arrived with the `ce85367a` koodivaramu merge and were never i18n'd, so **every non-Estonian deployment gets Estonian text for this case**. Two independent reviewers flagged it while auditing the merge.

## The fix

Move them behind `core.error.delete-405.{title,message}` via `i18nService.instant`, which is exactly what the `core.error.403` branch four lines below already does. No behaviour change beyond the language.

**The Estonian values are the original strings, byte-for-byte** (asserted against `origin/main`'s source), so Estonian users see no change at all. Other locales now get English instead of Estonian.

`en` and `et` only — `fallbackLang` is `en`, so `cs`/`de`/`fr`/`lt`/`nl` render English, which is strictly better than Estonian for them, and no unreviewed translations get committed. `core.error.403` is translated in all 7; these can follow whenever a translator passes through.

## Deliberately left alone

Both pre-existing, both arguably worth a follow-up, neither in scope for an i18n fix:

- The message says **"concept code"**, but the branch matches *any* `/ts/code-systems/` DELETE (the code comment says "covers code-systems, concepts, etc."). Deleting a **code system** whose id has special characters reports the wrong noun.
- Attributing **every** 405 here to special characters is a heuristic, not something read off the response. A genuine method-not-allowed would show the same message.

## Verification

- `ng build` (AOT) **green**, 0 errors.
- Estonian values asserted **verbatim** against the strings removed from `origin/main`.
- No hardcoded non-ASCII strings left in the handler.
- Both locale files parse; keys resolve.

Not driven in a browser: reproducing it needs a 405 on a DELETE to a `/ts/code-systems/` path, i.e. a concept id with characters that survive encoding and break routing. The change is a substitution of two literals for the same-shaped `i18nService.instant` calls already used in the sibling branch.

Context: `termx-agent/tehik/web-changes.md` (M3). Related: #115 (M1 + M2).