### PR TITLE
feat(code-system): de-duplicate value sets on the summary page

### DIFF
--- a/app/src/app/resources/code-system/containers/summary/code-system-summary.component.html
+++ b/app/src/app/resources/code-system/containers/summary/code-system-summary.component.html
@@ -111,14 +111,14 @@
           resourceType="CodeSystem"></tw-resource-tasks-widget>
         </m-card>
 
-        <!-- Related artifacts-->
+        <!-- Related artifacts (value sets are surfaced by the dedicated value-set widget below) -->
         <m-card>
           <m-title *m-card-header mTitle="web.code-system.summary.related-artifacts"></m-title>
-          <tw-resource-related-artifact-widget [resourceId]="codeSystem?.id" resourceType="CodeSystem"></tw-resource-related-artifact-widget>
+          <tw-resource-related-artifact-widget [resourceId]="codeSystem?.id" resourceType="CodeSystem" [excludeTypes]="relatedArtifactExcludeTypes"></tw-resource-related-artifact-widget>
         </m-card>
 
         <m-card>
-          <m-title *m-card-header mTitle="web.code-system.summary.value-set-impacts"></m-title>
+          <m-title *m-card-header mTitle="web.code-system.summary.value-sets"></m-title>
           @if (!(valueSetImpacts?.length > 0)) {
             <span class="m-text-secondary">-</span>
           }

--- a/app/src/app/resources/code-system/containers/summary/code-system-summary.component.ts
+++ b/app/src/app/resources/code-system/containers/summary/code-system-summary.component.ts
@@ -33,6 +33,8 @@ export class CodeSystemSummaryComponent implements OnInit {
   protected codeSystem?: CodeSystem;
   protected versions?: CodeSystemVersion[];
   protected valueSetImpacts: CodeSystemArtifactImpact[] = [];
+  // Value sets are shown by the dedicated value-set widget below, so hide them from "Related artifacts".
+  protected readonly relatedArtifactExcludeTypes = ['vs'];
   protected showOnlyOpenedTasks?: boolean = true;
   protected loader = new LoadingManager();
 

--- a/app/src/app/resources/resource/components/resource-related-artifact-widget.component.ts
+++ b/app/src/app/resources/resource/components/resource-related-artifact-widget.component.ts
@@ -16,19 +16,33 @@ export class ResourceRelatedArtifactWidgetComponent implements OnChanges {
 
   @Input() public resourceId: string;
   @Input() public resourceType: 'CodeSystem' | 'ValueSet' | 'MapSet' | 'Concept' | 'StructureDefinition';
+  // Artifact types to hide, e.g. when another widget on the same page already surfaces them
+  // (the code system summary shows value sets in its dedicated impacts widget).
+  @Input() public excludeTypes?: RelatedArtifact['type'][];
 
   protected relatedArtifacts: RelatedArtifact[];
   protected loader = new LoadingManager();
+  private allArtifacts: RelatedArtifact[];
 
   public ngOnChanges(changes: SimpleChanges): void {
     if ((changes['resourceId'] || changes['resourceType']) && isDefined(this.resourceId) && isDefined(this.resourceType)) {
       this.loadArtifacts();
+    } else if (changes['excludeTypes']) {
+      this.applyExclusions();
     }
   }
 
   public loadArtifacts(): void {
     this.loader.wrap('load', this.relatedArtifactService.findRelatedArtifacts(this.resourceType, this.resourceId))
-      .subscribe(ra => this.relatedArtifacts = ra);
+      .subscribe(ra => {
+        this.allArtifacts = ra;
+        this.applyExclusions();
+      });
+  }
+
+  private applyExclusions(): void {
+    const exclude = this.excludeTypes ?? [];
+    this.relatedArtifacts = (this.allArtifacts ?? []).filter(a => !exclude.includes(a.type));
   }
 
   public openArtifact(artifact: RelatedArtifact): void {

--- a/app/src/assets/i18n/cs.json
+++ b/app/src/assets/i18n/cs.json
@@ -1149,6 +1149,7 @@
         },
         "opened-tasks": "Otevřené úkoly",
         "related-artifacts": "Související artefakty",
+        "value-sets": "Množiny hodnot",
         "value-set-impacts": "Dopady na množiny hodnot",
         "value-set-impacts.source": "Zdroj pravidla",
         "value-set-impacts.current": "Aktuální verze systému kódů",

--- a/app/src/assets/i18n/en.json
+++ b/app/src/assets/i18n/en.json
@@ -1120,6 +1120,7 @@
 				},
 				"opened-tasks": "Opened tasks",
 				"related-artifacts": "Related artifacts",
+				"value-sets": "Value sets",
 				"value-set-impacts": "Value set impacts",
 				"value-set-impacts.source": "Rule source",
 				"value-set-impacts.current": "Current code system version",

--- a/app/src/assets/i18n/et.json
+++ b/app/src/assets/i18n/et.json
@@ -1100,6 +1100,7 @@
 				},
 				"opened-tasks": "Avatud ülesanded",
 				"related-artifacts": "Seotud artefaktid",
+				"value-sets": "Väärtushulgad",
 				"value-set-impacts": "Väärtushulkade mõjud",
 				"value-set-impacts.source": "Reegli allikas",
 				"value-set-impacts.current": "Koodisüsteemi praegune versioon",

--- a/app/src/assets/i18n/lt.json
+++ b/app/src/assets/i18n/lt.json
@@ -1064,6 +1064,7 @@
         },
         "opened-tasks": "Aktyvios užduotys",
         "related-artifacts": "Susiję artefaktai",
+        "value-sets": "Reikšmių rinkiniai",
         "value-set-impacts": "Reikšmių rinkinių poveikis",
         "value-set-impacts.source": "Taisyklės šaltinis",
         "value-set-impacts.current": "Dabartinė kodų sistemos versija",


### PR DESCRIPTION
## Problem

On the code system summary page (e.g. `/resources/code-systems/rhk10/summary`) value sets that reference the code system were listed **twice**:

- **Related artifacts** — one plain `ValueSet │ name` nav link per value set (alongside supplements, map sets, wiki pages, spaces).
- **Value set impacts** — one row per value set *version*, with staleness status (affected/current), the rule source vs current CS version, a reason, and a link straight to the affected version.

The impacts card is a strict *superset* of the value-set information, so every value set appeared redundantly in both cards.

## Fix

Make the impacts card the single home for value sets, and let "Related artifacts" cover only the types nothing else surfaces:

- `resource-related-artifact-widget`: add an optional `excludeTypes` input that filters the rendered list. The shared `/related-artifacts` API and all other consumers are untouched — the exclusion is purely presentational.
- CS summary: pass `excludeTypes = ['vs']`, so Related artifacts now shows supplements / map sets / pages / spaces only.
- Rename the card heading **"Value set impacts" → "Value sets"** (`web.code-system.summary.value-sets`, added to en/et/cs/lt) so value sets remain easy to find; the warning/check icon still signals staleness.

The two cards now map cleanly to the two distinct intents — *discovery* ("what else relates to this CS") vs *maintenance* ("which value sets went stale") — with no overlap.

## Notes / verify

- If a value set can appear in `findValueSets` (references the CS) but produce **no** impact row (e.g. its only referencing version is retired), it would no longer show on the summary. Worth confirming both queries key off the same "references this CS" set; they appear to.
- Pairs with the backend perf fix (termx-server #412) that made the impacts endpoint fast, so it is now the cheap primary surface for value sets.

## Verification

- `ng build` (development) — clean, no template/type errors.
- i18n JSON validated for en/et/cs/lt.
