### PR TITLE
fix(code-system): exclude value sets from Related artifacts using the correct type value

### DIFF
--- a/app/src/app/resources/code-system/containers/summary/code-system-summary.component.ts
+++ b/app/src/app/resources/code-system/containers/summary/code-system-summary.component.ts
@@ -34,7 +34,8 @@ export class CodeSystemSummaryComponent implements OnInit {
   protected versions?: CodeSystemVersion[];
   protected valueSetImpacts: CodeSystemArtifactImpact[] = [];
   // Value sets are shown by the dedicated value-set widget below, so hide them from "Related artifacts".
-  protected readonly relatedArtifactExcludeTypes = ['vs'];
+  // The related-artifact `type` carries the RelatedArtifactType *value* ("ValueSet"), not the enum key ("vs").
+  protected readonly relatedArtifactExcludeTypes = ['ValueSet'];
   protected showOnlyOpenedTasks?: boolean = true;
   protected loader = new LoadingManager();
 


### PR DESCRIPTION
## Problem

After #117 deployed, value sets **still appeared in both** the "Related artifacts" and "Value sets" cards on the code system summary — the de-duplication didn't take effect.

Root cause: #117 passed `excludeTypes = ['vs']`, but `RelatedArtifactType.vs = "ValueSet"` — `vs` is the enum *key*, and the serialized `type` value the API returns (and the widget filters on) is `"ValueSet"`. So the exclusion filter never matched and was a silent no-op. The heading rename in #117 shipped correctly, which is why the regression looked like "nothing changed" for the value-set list.

## Fix

Exclude by the actual type value: `relatedArtifactExcludeTypes = ['ValueSet']`. Added a comment noting the key-vs-value distinction so it isn't reintroduced.

## Verification

- `ng build` (development) — clean.
- Confirmed against live `tehik.termx.dev`: the related-artifacts rows render with `type === "ValueSet"`, which `['vs']` could never match.
