### PR TITLE
feat(fhir): hierarchical + searchable CodeSystem content viewer (ported from tx)

### DIFF
--- a/app/src/app/fhir/code-system/code-system-hierarchy.ts
+++ b/app/src/app/fhir/code-system/code-system-hierarchy.ts
@@ -1,0 +1,289 @@
+/**
+ * CodeSystem tree eligibility and hierarchy mode (FHIR hierarchyMeaning + fallbacks).
+ *
+ * Ported verbatim from terminology-explorer
+ * (frontend/projects/tx-viewer/src/app/terminology/resource/code-system-hierarchy.ts).
+ * Pure/framework-agnostic — keep it a straight copy so the two stay in sync.
+ */
+
+export const HIERARCHY_MODES = ['is-a', 'part-of', 'grouped-by'] as const;
+export type HierarchyMode = (typeof HIERARCHY_MODES)[number];
+
+const VALID_MEANINGS = new Set<string>(HIERARCHY_MODES);
+
+/** Priority when inferring from multiple property signals (no hierarchyMeaning). */
+const INFER_MODE_PRIORITY: HierarchyMode[] = ['grouped-by', 'is-a', 'part-of'];
+
+const IS_A_CODES = new Set(['is-a', 'isA']);
+const PART_OF_CODES = new Set(['part-of', 'partOf']);
+const GROUPED_BY_CODES = new Set(['grouped-by', 'groupedBy']);
+
+export function propertyCodeToMode(code: string | undefined): HierarchyMode | null {
+  if (!code) {
+    return null;
+  }
+  if (IS_A_CODES.has(code)) {
+    return 'is-a';
+  }
+  if (PART_OF_CODES.has(code)) {
+    return 'part-of';
+  }
+  if (GROUPED_BY_CODES.has(code)) {
+    return 'grouped-by';
+  }
+  return null;
+}
+
+function pickModeFromSet(found: Set<HierarchyMode>): HierarchyMode | null {
+  for (const m of INFER_MODE_PRIORITY) {
+    if (found.has(m)) {
+      return m;
+    }
+  }
+  return null;
+}
+
+function collectModesFromProperties(concept: {property?: Array<{code?: string}>}): Set<HierarchyMode> {
+  const found = new Set<HierarchyMode>();
+  for (const p of concept.property || []) {
+    const m = propertyCodeToMode(p.code);
+    if (m) {
+      found.add(m);
+    }
+  }
+  return found;
+}
+
+function hasNestedConcepts(concepts: any[] | undefined, recurseKey = 'concept'): boolean {
+  if (!concepts?.length) {
+    return false;
+  }
+  for (const c of concepts) {
+    const children = c[recurseKey];
+    if (children?.length) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function walkConceptsDeep(
+  concepts: any[] | undefined,
+  recurseKey: string,
+  visit: (c: any) => void
+): void {
+  if (!concepts?.length) {
+    return;
+  }
+  for (const c of concepts) {
+    visit(c);
+    walkConceptsDeep(c[recurseKey], recurseKey, visit);
+  }
+}
+
+/**
+ * Scan concept trees for hierarchical property codes or nested children.
+ */
+export function inferHierarchyModeFromConcepts(
+  concepts: any[] | undefined,
+  recurseKey = 'concept'
+): HierarchyMode | null {
+  if (!concepts?.length) {
+    return null;
+  }
+  if (hasNestedConcepts(concepts, recurseKey)) {
+    return 'grouped-by';
+  }
+  const found = new Set<HierarchyMode>();
+  walkConceptsDeep(concepts, recurseKey, c => {
+    for (const m of collectModesFromProperties(c)) {
+      found.add(m);
+    }
+  });
+  return pickModeFromSet(found);
+}
+
+/**
+ * From CodeSystem resource (summary or full): hierarchyMeaning, property definitions, optional concept[].
+ */
+export function resolveHierarchyModeFromCodeSystem(codeSystem: {
+  hierarchyMeaning?: string;
+  property?: Array<{code?: string}>;
+  concept?: any[];
+} | null | undefined): HierarchyMode | null {
+  if (!codeSystem) {
+    return null;
+  }
+  const hm = codeSystem.hierarchyMeaning;
+  if (hm && VALID_MEANINGS.has(hm)) {
+    return hm as HierarchyMode;
+  }
+  const fromDefs = new Set<HierarchyMode>();
+  for (const p of codeSystem.property || []) {
+    const m = propertyCodeToMode(p.code);
+    if (m) {
+      fromDefs.add(m);
+    }
+  }
+  const picked = pickModeFromSet(fromDefs);
+  if (picked) {
+    return picked;
+  }
+  return inferHierarchyModeFromConcepts(codeSystem.concept, 'concept');
+}
+
+/**
+ * Full resolution when the full concept list is available (after full CodeSystem read).
+ */
+export function resolveHierarchyModeWithConcepts(
+  codeSystem: {hierarchyMeaning?: string; property?: Array<{code?: string}>} | null | undefined,
+  concepts: any[]
+): HierarchyMode | null {
+  const hm = codeSystem?.hierarchyMeaning;
+  if (hm && VALID_MEANINGS.has(hm)) {
+    return hm as HierarchyMode;
+  }
+  if (concepts.length > 0) {
+    const fromConcepts = inferHierarchyModeFromConcepts(concepts, 'concept');
+    if (fromConcepts) {
+      return fromConcepts;
+    }
+  }
+  return resolveHierarchyModeFromCodeSystem({...codeSystem, concept: undefined});
+}
+
+/**
+ * Whether the CodeSystem content UI should offer tree view (before or without full concept load).
+ */
+export function codeSystemSupportsTreeView(codeSystem: {
+  hierarchyMeaning?: string;
+  property?: Array<{code?: string}>;
+  concept?: any[];
+  count?: number;
+} | null | undefined): boolean {
+  return resolveHierarchyModeFromCodeSystem(codeSystem) !== null;
+}
+
+export function getParentPropertyCodes(mode: HierarchyMode): string[] {
+  switch (mode) {
+    case 'is-a':
+      return ['is-a', 'isA'];
+    case 'part-of':
+      return ['part-of', 'partOf'];
+    case 'grouped-by':
+      return ['grouped-by', 'groupedBy'];
+    default:
+      return [];
+  }
+}
+
+function readParentKey(concept: any, propertyCodes: string[]): string | undefined {
+  const prop = concept.property?.find((p: any) => propertyCodes.includes(p.code));
+  if (!prop) {
+    return undefined;
+  }
+  return prop.valueCode ?? prop.valueCoding?.code;
+}
+
+/**
+ * Attach concepts under parent codes when parent exists in the set (is-a / grouped-by flat links).
+ */
+export function buildHierarchyByParentRef(
+  flatConcepts: any[],
+  propertyCodes: string[],
+  childKey = 'concept'
+): any[] {
+  if (!flatConcepts.length) {
+    return flatConcepts;
+  }
+  const nodes = flatConcepts.map(c => ({...c, [childKey]: [] as any[]}));
+  const byCode = new Map(nodes.map(n => [String(n.code), n]));
+  const isChild = new Set<string>();
+
+  for (const n of nodes) {
+    const pk = readParentKey(n, propertyCodes);
+    if (pk && byCode.has(String(pk)) && String(pk) !== String(n.code)) {
+      byCode.get(String(pk))![childKey].push(n);
+      isChild.add(String(n.code));
+    }
+  }
+
+  return nodes.filter(n => !isChild.has(String(n.code)));
+}
+
+/**
+ * Build tree by grouping under parent keys (synthetic parents when parent concept missing) — part-of style.
+ */
+export function buildHierarchyBySyntheticParents(
+  flatConcepts: any[],
+  propertyCodes: string[],
+  childKey = 'concept'
+): any[] {
+  const groupMap = new Map<string, any[]>();
+  const roots: any[] = [];
+
+  for (const concept of flatConcepts) {
+    const pk = readParentKey(concept, propertyCodes);
+    if (pk) {
+      if (!groupMap.has(pk)) {
+        groupMap.set(pk, []);
+      }
+      groupMap.get(pk)!.push({...concept, [childKey]: []});
+    } else {
+      roots.push({...concept, [childKey]: []});
+    }
+  }
+
+  groupMap.forEach((children, groupKey) => {
+    const first = children[0];
+    const prop = first.property?.find((p: any) => propertyCodes.includes(p.code));
+    const display = prop?.valueCoding?.display || groupKey;
+    roots.push({
+      code: groupKey,
+      display,
+      [childKey]: children
+    });
+  });
+
+  return roots;
+}
+
+/**
+ * Apply hierarchy mode to concepts (may already be nested for grouped-by).
+ */
+export function buildHierarchyForMode(concepts: any[], mode: HierarchyMode, childKey = 'concept'): any[] {
+  if (!concepts.length) {
+    return concepts;
+  }
+  if (mode === 'grouped-by') {
+    if (hasNestedConcepts(concepts, childKey)) {
+      return concepts;
+    }
+    const codes = getParentPropertyCodes('grouped-by');
+    const hasLink = concepts.some(c => readParentKey(c, codes));
+    if (hasLink) {
+      const tree = buildHierarchyByParentRef(concepts, codes, childKey);
+      return tree.length ? tree : concepts.map(c => ({...c, [childKey]: []}));
+    }
+    return concepts.map(c => ({...c, [childKey]: c[childKey] ? [...c[childKey]] : []}));
+  }
+  if (mode === 'is-a') {
+    const codes = getParentPropertyCodes('is-a');
+    if (!concepts.some(c => readParentKey(c, codes))) {
+      return concepts.map(c => ({...c, [childKey]: c[childKey] ? [...c[childKey]] : []}));
+    }
+    const tree = buildHierarchyByParentRef(concepts, codes, childKey);
+    return tree.length ? tree : concepts.map(c => ({...c, [childKey]: []}));
+  }
+  if (mode === 'part-of') {
+    const codes = getParentPropertyCodes('part-of');
+    if (!concepts.some(c => readParentKey(c, codes))) {
+      return concepts.map(c => ({...c, [childKey]: c[childKey] ? [...c[childKey]] : []}));
+    }
+    if (hasNestedConcepts(concepts, childKey)) {
+      return concepts;
+    }
+    return buildHierarchyBySyntheticParents(concepts, codes, childKey);
+  }
+  return concepts;
+}

--- a/app/src/app/fhir/code-system/fhir-code-system-concepts.component.html
+++ b/app/src/app/fhir/code-system/fhir-code-system-concepts.component.html
@@ -1,0 +1,55 @@
+<div style="display: flex; align-items: center; gap: .5rem; margin-bottom: .75rem; flex-wrap: wrap;">
+  <m-input [(ngModel)]="filterContent" (ngModelChange)="onSearch()" name="concept-search"
+    placeholder="Search code, display or definition" style="flex-grow: 1; min-width: 220px;"/>
+
+  @if (treeAvailable) {
+    <m-button [mDisplay]="viewMode === 'tree' ? 'primary' : 'text'" (click)="setView('tree')">Tree</m-button>
+    <m-button [mDisplay]="viewMode === 'list' ? 'primary' : 'text'" (click)="setView('list')">List</m-button>
+  }
+
+  @if (viewMode === 'tree') {
+    <m-button mDisplay="text" (click)="expandAll()">
+      <m-icon mCode="caret-down"></m-icon>&nbsp;Expand all
+    </m-button>
+    <m-button mDisplay="text" (click)="collapseAll()">
+      <m-icon mCode="caret-up"></m-icon>&nbsp;Collapse all
+    </m-button>
+  }
+</div>
+
+@if (flattenedNodes.length === 0) {
+  <div class="m-text-secondary" style="padding: 1rem 0;">No concepts found</div>
+} @else {
+  <cdk-virtual-scroll-viewport [itemSize]="itemSize"
+    style="height: min(60vh, 640px); border: 1px solid var(--color-borders, #e5e7eb); border-radius: 4px; background: var(--color-bg-container, #fff);">
+    <div *cdkVirtualFor="let node of flattenedNodes; trackBy: trackByCode"
+      [style.height.px]="itemSize"
+      [style.padding-left.px]="node.level * 20 + 12"
+      style="display: flex; align-items: center; gap: .5rem; padding-right: 12px; border-bottom: 1px solid var(--color-borders, #f0f0f0); white-space: nowrap; overflow: hidden;">
+
+      @if (node.expandable) {
+        <span (click)="toggle(node.concept.code)"
+          style="cursor: pointer; user-select: none; width: 16px; flex-shrink: 0; text-align: center; color: var(--color-text-secondary, #666);">
+          {{ node.expanded ? '▾' : '▸' }}
+        </span>
+      } @else {
+        <span style="width: 16px; flex-shrink: 0;"></span>
+      }
+
+      <a [routerLink]="['/fhir/CodeSystem', codeSystem.id, 'lookup']" [queryParams]="{ _code: node.concept.code }"
+        style="font-weight: 600; flex-shrink: 0;">{{ node.concept.code }}</a>
+
+      @if (node.concept.display) {
+        <span class="m-text-secondary" style="flex-shrink: 0;">—</span>
+        <span style="overflow: hidden; text-overflow: ellipsis;" [title]="node.concept.display">{{ node.concept.display }}</span>
+      }
+      @if (node.concept.definition) {
+        <span class="m-text-secondary" style="overflow: hidden; text-overflow: ellipsis;" [title]="node.concept.definition">· {{ node.concept.definition }}</span>
+      }
+    </div>
+  </cdk-virtual-scroll-viewport>
+
+  <div class="m-text-secondary" style="margin-top: .35rem; font-size: 12px;">
+    {{ flattenedNodes.length }} row(s) shown@if (viewMode === 'tree') {&nbsp;· expand nodes to see children}
+  </div>
+}

--- a/app/src/app/fhir/code-system/fhir-code-system-concepts.component.ts
+++ b/app/src/app/fhir/code-system/fhir-code-system-concepts.component.ts
@@ -1,0 +1,184 @@
+import {ChangeDetectorRef, Component, Input, OnChanges, SimpleChanges, inject} from '@angular/core';
+import {RouterLink} from '@angular/router';
+import {FormsModule} from '@angular/forms';
+import {ScrollingModule} from '@angular/cdk/scrolling';
+import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
+import {Subject} from 'rxjs';
+import {debounceTime} from 'rxjs/operators';
+import {MuiInputModule, MuiButtonModule, MuiIconModule} from '@termx-health/ui';
+import {
+  buildHierarchyForMode,
+  codeSystemSupportsTreeView,
+  resolveHierarchyModeWithConcepts,
+} from 'term-web/fhir/code-system/code-system-hierarchy';
+
+interface FlatNode {
+  concept: any;
+  level: number;
+  expandable: boolean;
+  expanded: boolean;
+}
+
+/**
+ * CodeSystem "Content" viewer: hierarchical tree + flat list with search, over a CDK
+ * virtual-scroll viewport so large code systems (e.g. rhk10, 37k concepts) stay responsive.
+ *
+ * The hierarchy resolution is the ported terminology-explorer solution
+ * ({@link ./code-system-hierarchy}); only the rendering is reimplemented on marina UI.
+ */
+@Component({
+  selector: 'tw-fhir-code-system-concepts',
+  templateUrl: './fhir-code-system-concepts.component.html',
+  imports: [FormsModule, ScrollingModule, RouterLink, MuiInputModule, MuiButtonModule, MuiIconModule],
+})
+export class FhirCodeSystemConceptsComponent implements OnChanges {
+  private cdr = inject(ChangeDetectorRef);
+
+  @Input() public codeSystem?: any;
+
+  protected viewMode: 'tree' | 'list' = 'list';
+  protected treeAvailable = false;
+  protected filterContent = '';
+  protected readonly itemSize = 40;
+
+  protected flattenedNodes: FlatNode[] = [];
+
+  private readonly recurseKey = 'concept';
+  private treeConcepts: any[] = [];       // hierarchy-shaped concepts
+  private flatConcepts: any[] = [];       // every concept flattened to one level (list mode)
+  private filteredTree: any[] = [];       // tree after the active search filter
+  private expandedKeys = new Set<string>();
+  private search$ = new Subject<void>();
+
+  constructor() {
+    this.search$.pipe(debounceTime(300), takeUntilDestroyed()).subscribe(() => this.applyFilter());
+  }
+
+  public ngOnChanges(changes: SimpleChanges): void {
+    if (changes['codeSystem'] && this.codeSystem) {
+      this.init();
+    }
+  }
+
+  private init(): void {
+    const raw: any[] = this.codeSystem.concept || [];
+    const mode = resolveHierarchyModeWithConcepts(this.codeSystem, raw);
+    this.treeConcepts = mode && raw.length ? buildHierarchyForMode([...raw], mode, this.recurseKey) : raw;
+    this.flatConcepts = this.flattenAll(this.treeConcepts);
+    this.treeAvailable = codeSystemSupportsTreeView(this.codeSystem);
+    // Default to tree only when the code system declares a hierarchy meaning; otherwise list.
+    this.viewMode = this.treeAvailable && this.codeSystem.hierarchyMeaning ? 'tree' : 'list';
+    this.filterContent = '';
+    this.expandedKeys.clear();
+    this.applyFilter();
+  }
+
+  private flattenAll(concepts: any[]): any[] {
+    const out: any[] = [];
+    const walk = (list: any[]): void => {
+      for (const c of list) {
+        out.push(c);
+        const kids = c[this.recurseKey];
+        if (kids?.length) {
+          walk(kids);
+        }
+      }
+    };
+    walk(concepts || []);
+    return out;
+  }
+
+  protected setView(mode: 'tree' | 'list'): void {
+    if (this.viewMode === mode) {
+      return;
+    }
+    this.viewMode = mode;
+    this.applyFilter();
+  }
+
+  protected onSearch(): void {
+    this.search$.next();
+  }
+
+  private applyFilter(): void {
+    const term = this.filterContent.trim().toLowerCase();
+    if (this.viewMode === 'list') {
+      const list = term ? this.flatConcepts.filter(c => this.matches(c, term)) : this.flatConcepts;
+      this.flattenedNodes = list.map(c => ({concept: c, level: 0, expandable: false, expanded: false}));
+    } else {
+      this.filteredTree = term ? this.filterTree(this.treeConcepts, term) : this.treeConcepts;
+      // Auto-expand matches while searching; restore manual state when the box is cleared.
+      this.expandedKeys = term ? new Set(this.allParentKeys(this.filteredTree)) : this.expandedKeys;
+      this.flattenedNodes = this.flattenVisible(this.filteredTree, 0);
+    }
+    this.cdr.markForCheck();
+  }
+
+  private matches(c: any, term: string): boolean {
+    return !!(
+      c.code?.toString().toLowerCase().includes(term) ||
+      c.display?.toString().toLowerCase().includes(term) ||
+      c.definition?.toString().toLowerCase().includes(term)
+    );
+  }
+
+  private filterTree(concepts: any[], term: string): any[] {
+    return concepts.reduce((acc: any[], c: any) => {
+      const kids = c[this.recurseKey] ? this.filterTree(c[this.recurseKey], term) : [];
+      if (this.matches(c, term) || kids.length) {
+        acc.push({...c, [this.recurseKey]: kids});
+      }
+      return acc;
+    }, []);
+  }
+
+  private flattenVisible(concepts: any[], level: number): FlatNode[] {
+    const nodes: FlatNode[] = [];
+    for (const c of concepts) {
+      const kids = c[this.recurseKey];
+      const expandable = kids?.length > 0;
+      const expanded = this.expandedKeys.has(c.code);
+      nodes.push({concept: c, level, expandable, expanded});
+      if (expandable && expanded) {
+        nodes.push(...this.flattenVisible(kids, level + 1));
+      }
+    }
+    return nodes;
+  }
+
+  private allParentKeys(concepts: any[]): string[] {
+    const keys: string[] = [];
+    const walk = (list: any[]): void => {
+      for (const c of list) {
+        const kids = c[this.recurseKey];
+        if (kids?.length) {
+          keys.push(c.code);
+          walk(kids);
+        }
+      }
+    };
+    walk(concepts);
+    return keys;
+  }
+
+  protected toggle(code: string): void {
+    if (this.expandedKeys.has(code)) {
+      this.expandedKeys.delete(code);
+    } else {
+      this.expandedKeys.add(code);
+    }
+    this.flattenedNodes = this.flattenVisible(this.filteredTree, 0);
+  }
+
+  protected expandAll(): void {
+    this.expandedKeys = new Set(this.allParentKeys(this.filteredTree));
+    this.flattenedNodes = this.flattenVisible(this.filteredTree, 0);
+  }
+
+  protected collapseAll(): void {
+    this.expandedKeys = new Set<string>();
+    this.flattenedNodes = this.flattenVisible(this.filteredTree, 0);
+  }
+
+  protected trackByCode = (_index: number, node: FlatNode): string => node.concept.code;
+}

--- a/app/src/app/fhir/code-system/fhir-code-system-lookup.component.ts
+++ b/app/src/app/fhir/code-system/fhir-code-system-lookup.component.ts
@@ -32,16 +32,29 @@ export class FhirCodeSystemLookupComponent {
   };
 
   protected toPropertyRows = (properties: any[]): any[] => {
-    return properties && properties.length > 0 ? properties.map(p => ({
-      code: this.findParameter(p.part, 'code')?.valueString,
-      description: this.findParameter(p.part, 'description')?.valueString,
-      value: this.findParameter(p.part, 'value')?.valueCode ||
-        this.findParameter(p.part, 'value')?.valueCoding ||
-        this.findParameter(p.part, 'value')?.valueString ||
-        this.findParameter(p.part, 'value')?.valueInteger ||
-        this.findParameter(p.part, 'value')?.valueBoolean ||
-        this.findParameter(p.part, 'value')?.valueDateTime ||
-        this.findParameter(p.part, 'value')?.valueDecimal
-    })) : undefined;
+    return properties && properties.length > 0 ? properties.map(p => {
+      const codePart = this.findParameter(p.part, 'code');
+      return {
+        // FHIR $lookup returns property.code as type `code` (valueCode); older servers used valueString.
+        code: codePart?.valueCode ?? codePart?.valueString,
+        description: this.findParameter(p.part, 'description')?.valueString,
+        value: this.extractValueX(this.findParameter(p.part, 'value'))
+      };
+    }) : undefined;
   };
+
+  // Pick the populated value[x], testing presence rather than truthiness so falsy values
+  // (e.g. inactive=false, conceptOrder=0) are not dropped.
+  private extractValueX(part: any): any {
+    if (!part) {
+      return undefined;
+    }
+    const keys = ['valueCode', 'valueCoding', 'valueString', 'valueInteger', 'valueBoolean', 'valueDateTime', 'valueDecimal'];
+    for (const key of keys) {
+      if (part[key] !== undefined) {
+        return part[key];
+      }
+    }
+    return undefined;
+  }
 }

--- a/app/src/app/fhir/code-system/fhir-code-system.component.html
+++ b/app/src/app/fhir/code-system/fhir-code-system.component.html
@@ -39,20 +39,11 @@
     </div>
   }
 
-  <div>
-    <h2>Content</h2>
-    <p>This code system <m-tag>{{codeSystem.url}}</m-tag> defines the following codes:</p>
-    <m-table [mData]="codeSystem.concept">
-      <tr *mTableHead>
-        <th>Code</th>
-        <th>Display</th>
-        <th>Definition</th>
-      </tr>
-      <tr *mTableRow="let c">
-        <td><a [routerLink]="['/fhir/CodeSystem', this.codeSystem.id, 'lookup']" [queryParams]="{ _code: c.code }">{{c.code}}</a></td>
-        <td>{{c.display}}</td>
-        <td>{{c.definition}}</td>
-      </tr>
-    </m-table>
-  </div>
+  @if (codeSystem.concept?.length > 0) {
+    <div>
+      <h2>Content</h2>
+      <p>This code system <m-tag>{{codeSystem.url}}</m-tag> defines the following codes:</p>
+      <tw-fhir-code-system-concepts [codeSystem]="codeSystem"></tw-fhir-code-system-concepts>
+    </div>
+  }
 </div>

--- a/app/src/app/fhir/code-system/fhir-code-system.component.ts
+++ b/app/src/app/fhir/code-system/fhir-code-system.component.ts
@@ -1,14 +1,15 @@
 import { Component, Input, OnChanges, SimpleChanges, inject } from '@angular/core';
-import { Router, RouterLink } from '@angular/router';
+import { Router } from '@angular/router';
 import {FhirValueSetLibService} from 'term-web/fhir/_lib';
 import { MuiTableModule, MuiTagModule, MuiCoreModule } from '@termx-health/ui';
 
 import { LocalDatePipe } from '@termx-health/core-util';
+import { FhirCodeSystemConceptsComponent } from 'term-web/fhir/code-system/fhir-code-system-concepts.component';
 
 @Component({
     selector: 'tw-fhir-code-system',
     templateUrl: './fhir-code-system.component.html',
-    imports: [MuiTableModule, MuiTagModule, MuiCoreModule, RouterLink, LocalDatePipe]
+    imports: [MuiTableModule, MuiTagModule, MuiCoreModule, LocalDatePipe, FhirCodeSystemConceptsComponent]
 })
 export class FhirCodeSystemComponent implements OnChanges {
   private valueSetService = inject(FhirValueSetLibService);


### PR DESCRIPTION
## Problem

The FHIR CodeSystem "Narrative" content viewer lost its hierarchical tree + search during the Angular 21 migration (`1db9de06`), which replaced the recursive `*ngFor`/`ngTemplateOutlet` template with a flat table instead of migrating it. That flat table iterated only the **top-level** `concept[]`, so for a nested code system like **rhk10** (`hierarchyMeaning: is-a`, 37,504 concepts) only the **22 root chapters** were reachable — the other ~37,482 nested concepts were invisible, with no search.

## Fix — port the terminology-explorer solution

- **`code-system-hierarchy.ts`** — the explorer's pure, framework-agnostic hierarchy resolver, ported verbatim (kept a straight copy so the two stay in sync). Resolves the hierarchy mode from `hierarchyMeaning` with property/nesting fallbacks, and builds a tree from **both** pre-nested `concept.concept` **and** flat is-a / part-of / grouped-by parent links.
- **`fhir-code-system-concepts` component** — tree/list toggle, debounced search (code/display/definition, auto-expanding matches), expand/collapse-all, rendered over a **CDK virtual-scroll viewport** so large code systems stay responsive. Defaults to tree when the CS declares a hierarchy, else list. Rebuilt on marina UI — the explorer's own `@helexlab/hlx-ui` components are not portable.
- Wired into the CodeSystem narrative, replacing the flat `concept[]` table.

### Also in this PR

`fix(fhir): show property code and falsy values in CodeSystem $lookup` — the lookup Properties table read each property's `code` part as `valueString`, but FHIR `$lookup` returns `property.code` as type `code` (`valueCode`), so the Code column was always empty; the `value[x]` resolution also used a `||` chain that dropped falsy values (`inactive=false`, `conceptOrder=0`). Now reads `valueCode` (fallback `valueString`) and picks `value[x]` by presence.

## Verification

- `ng build` clean.
- Ran locally against the live tehik backend and verified on rhk10 (37,504 concepts): the Content tab renders the collapsed is-a tree (22 roots), Tree/List toggle, expand/collapse-all and search all work over virtual scroll; the `$lookup` Properties table now shows codes and falsy values.

Note: this restores a client-side tree over the full inline concept read (rhk10 is an 11 MB response). The durable scale fix is server-side paged concept retrieval — separate, larger work.
