### PR TITLE
Wiki space SEO metadata editor and import-from-GitHub UI

### DIFF
--- a/app/src/app/sys/_lib/space/model/space.ts
+++ b/app/src/app/sys/_lib/space/model/space.ts
@@ -10,6 +10,10 @@ export class Space {
   public globalSearch?: boolean;
   public acl?: {owners?: string, editors?: string, viewers?: string};
   public terminologyServers?: string[];
+  public description?: LocalizedName;
+  public defaultLanguage?: string;
+  public languages?: string[];
+  public siteUrl?: string;
   public packages?: Package[];
   public integration?: {
     github?: {

--- a/app/src/app/sys/space/containers/space/space-edit.component.html
+++ b/app/src/app/sys/space/containers/space/space-edit.component.html
@@ -49,6 +49,27 @@
                 </div>
               </m-list-item>
             </m-list>
+            <m-divider mText="entities.space.ssg"></m-divider>
+            <m-form-item mName="description" mLabel="entities.space.description">
+              <m-multi-language-input name="description" [(ngModel)]="space.description" mInputType="textarea"/>
+            </m-form-item>
+            <m-form-item mName="languages" mLabel="entities.space.languages">
+              <m-select name="languages" [(ngModel)]="space.languages" multiple>
+                @for (lang of contentLanguages; track lang) {
+                  <m-option [mLabel]="'language.' + lang" [mValue]="lang"></m-option>
+                }
+              </m-select>
+            </m-form-item>
+            <m-form-item mName="defaultLanguage" mLabel="entities.space.default-language">
+              <m-select name="defaultLanguage" [(ngModel)]="space.defaultLanguage">
+                @for (lang of (space.languages?.length ? space.languages : contentLanguages); track lang) {
+                  <m-option [mLabel]="'language.' + lang" [mValue]="lang"></m-option>
+                }
+              </m-select>
+            </m-form-item>
+            <m-form-item mName="siteUrl" mLabel="entities.space.site-url">
+              <m-input name="siteUrl" [(ngModel)]="space.siteUrl" placeholder="https://example.org/"></m-input>
+            </m-form-item>
             <m-divider>
               <span>{{'web.space.github-integration' | translate}}</span>
               <m-checkbox style="padding-left: 10px" [(mChecked)]="githubEnabled"></m-checkbox>
@@ -116,6 +137,12 @@
         }
 
         <ng-container *m-card-footer>
+          @if (mode === 'edit') {
+            <m-button (click)="openImport()">
+              <m-icon mCode="github"></m-icon>
+              {{'web.space.import-github' | translate}}
+            </m-button>
+          }
           <m-button mDisplay="primary" (click)="save()" [mLoading]="loading" [disabled]="loading">
             {{'core.btn.save' | translate}}
           </m-button>
@@ -124,3 +151,39 @@
     </m-spinner>
   </div>
 </m-form-row>
+
+<m-modal [(mVisible)]="importModalVisible" [mMaskClosable]="false">
+  <ng-container *m-modal-header>{{'web.space.import-github' | translate}}</ng-container>
+  <ng-container *m-modal-content>
+    <form>
+      <m-alert mType="warning">{{'web.space.import-github-warning' | translate}}</m-alert>
+      <m-form-item mName="importUrl" mLabel="web.space.import-github-url">
+        <m-input name="importUrl" [(ngModel)]="importReq.url" placeholder="https://github.com/owner/repo/tree/branch/dir"></m-input>
+      </m-form-item>
+      <m-form-item mName="importBranch" mLabel="web.space.import-github-branch">
+        <m-input name="importBranch" [(ngModel)]="importReq.branch" placeholder="(default branch)"></m-input>
+      </m-form-item>
+      <m-form-item mName="importDir" mLabel="web.space.import-github-dir">
+        <m-input name="importDir" [(ngModel)]="importReq.dir" placeholder="(auto-detected from pages.json)"></m-input>
+      </m-form-item>
+      <m-form-item mName="importToken" mLabel="web.space.import-github-token">
+        <m-input name="importToken" [(ngModel)]="importReq.token" placeholder="(only for private repos)"></m-input>
+      </m-form-item>
+      @if (importResult) {
+        <m-alert mType="success">
+          {{'web.space.import-github-done' | translate}} {{importResult.repo}}@{{importResult.branch}} — {{importResult.pages}} page(s)
+        </m-alert>
+      }
+      @if (importError) {
+        <m-alert mType="error">{{importError}}</m-alert>
+      }
+    </form>
+  </ng-container>
+  <div *m-modal-footer class="m-items-middle">
+    <m-button mDisplay="text" (click)="importModalVisible = false">{{'core.btn.close' | translate}}</m-button>
+    <m-button mDisplay="primary" [mLoading]="importLoading" [disabled]="importLoading || (!importReq.url && !importReq.owner)"
+      m-popconfirm mPopconfirmTitle="web.space.import-github-confirm" (mOnConfirm)="runImport()">
+      {{'web.space.import-github-run' | translate}}
+    </m-button>
+  </div>
+</m-modal>

--- a/app/src/app/sys/space/containers/space/space-edit.component.ts
+++ b/app/src/app/sys/space/containers/space/space-edit.component.ts
@@ -9,8 +9,9 @@ import {SpaceGithubService} from 'term-web/sys/space/services/space-github.servi
 import {SpaceMsDevOpsService} from 'term-web/sys/space/services/space-ms-dev-ops.service';
 import {PackageService} from 'term-web/sys/space/services/package.service';
 import {SpaceService} from 'term-web/sys/space/services/space.service';
+import {SpaceGithubImportService, WikiGithubImportRequest, WikiGithubImportResult} from 'term-web/sys/space/services/space-github-import.service';
 import {environment} from 'environments/environment';
-import { MuiFormModule, MuiSpinnerModule, MuiCardModule, MuiTextareaModule, MuiMultiLanguageInputModule, MuiCheckboxModule, MuiSelectModule, MuiDividerModule, MuiListModule, MuiCoreModule, MuiPopconfirmModule, MuiIconModule, MuiInputModule, MuiButtonModule } from '@termx-health/ui';
+import { MuiFormModule, MuiSpinnerModule, MuiCardModule, MuiTextareaModule, MuiMultiLanguageInputModule, MuiCheckboxModule, MuiSelectModule, MuiDividerModule, MuiListModule, MuiCoreModule, MuiPopconfirmModule, MuiIconModule, MuiInputModule, MuiButtonModule, MuiModalModule, MuiAlertModule } from '@termx-health/ui';
 import { TranslatePipe } from '@ngx-translate/core';
 import { MarinaUtilModule } from '@termx-health/util';
 
@@ -28,10 +29,11 @@ import { MarinaUtilModule } from '@termx-health/util';
       }
     }
   `],
-    imports: [MuiFormModule, MuiSpinnerModule, MuiCardModule, FormsModule, MuiTextareaModule, MuiMultiLanguageInputModule, MuiCheckboxModule, MuiSelectModule, MuiDividerModule, MuiListModule, MuiCoreModule, MuiPopconfirmModule, MuiIconModule, MuiInputModule, MuiButtonModule, TranslatePipe, MarinaUtilModule, ApplyPipe, KeysPipe]
+    imports: [MuiFormModule, MuiSpinnerModule, MuiCardModule, FormsModule, MuiTextareaModule, MuiMultiLanguageInputModule, MuiCheckboxModule, MuiSelectModule, MuiDividerModule, MuiListModule, MuiCoreModule, MuiPopconfirmModule, MuiIconModule, MuiInputModule, MuiButtonModule, MuiModalModule, MuiAlertModule, TranslatePipe, MarinaUtilModule, ApplyPipe, KeysPipe]
 })
 export class SpaceEditComponent implements OnInit {
   private spaceService = inject(SpaceService);
+  private spaceGithubImportService = inject(SpaceGithubImportService);
   private spaceGithubService = inject(SpaceGithubService);
   private spaceMsDevOpsService = inject(SpaceMsDevOpsService);
   private packageService = inject(PackageService);
@@ -48,9 +50,17 @@ export class SpaceEditComponent implements OnInit {
   public msDevOpsProviders: {[k: string]: string};
   public msDevOpsEnabled: boolean;
   protected readonly msDevOpsFeature = environment.msDevOpsEnabled;
+  protected readonly contentLanguages = environment.contentLanguages;
 
   public loading = false;
   public mode: 'add' | 'edit' = 'add';
+
+  // Import wiki content directly from a GitHub repo (no git integration required).
+  public importModalVisible = false;
+  public importLoading = false;
+  public importReq: WikiGithubImportRequest = {} as WikiGithubImportRequest;
+  public importResult?: WikiGithubImportResult;
+  public importError?: string;
 
   @ViewChild("form") public form?: NgForm;
 
@@ -120,6 +130,26 @@ export class SpaceEditComponent implements OnInit {
 
   private loadTerminologyServers(): void {
     this.serverService.search({limit: -1}).subscribe(r => this.terminologyServers = r.data);
+  }
+
+  public openImport(): void {
+    this.importReq = {spaceId: this.space.id} as WikiGithubImportRequest;
+    this.importResult = undefined;
+    this.importError = undefined;
+    this.importModalVisible = true;
+  }
+
+  public runImport(): void {
+    this.importResult = undefined;
+    this.importError = undefined;
+    this.importLoading = true;
+    this.importReq.spaceId = this.space.id;
+    this.spaceGithubImportService.importFromGithub(this.importReq)
+      .subscribe({
+        next: r => this.importResult = r,
+        error: e => this.importError = e?.error?.[0]?.message || e?.message || 'Import failed'
+      })
+      .add(() => this.importLoading = false);
   }
 
   protected sort(arr: any[]): any[] {

--- a/app/src/app/sys/space/services/space-github-import.service.ts
+++ b/app/src/app/sys/space/services/space-github-import.service.ts
@@ -1,0 +1,31 @@
+import {HttpClient} from '@angular/common/http';
+import {Injectable, inject} from '@angular/core';
+import {Observable} from 'rxjs';
+import {environment} from 'environments/environment';
+
+export interface WikiGithubImportRequest {
+  spaceId: number;
+  url?: string;
+  owner?: string;
+  repo?: string;
+  branch?: string;
+  dir?: string;
+  token?: string;
+}
+
+export interface WikiGithubImportResult {
+  repo: string;
+  branch: string;
+  dir: string;
+  pages: number;
+}
+
+@Injectable({providedIn: 'root'})
+export class SpaceGithubImportService {
+  private http = inject(HttpClient);
+  private baseUrl = `${environment.termxApi}/wiki-import`;
+
+  public importFromGithub(req: WikiGithubImportRequest): Observable<WikiGithubImportResult> {
+    return this.http.post<WikiGithubImportResult>(`${this.baseUrl}/github`, req);
+  }
+}

--- a/app/src/app/wiki/_lib/page/models/page-content.ts
+++ b/app/src/app/wiki/_lib/page/models/page-content.ts
@@ -7,6 +7,7 @@ export class PageContent {
   public lang?: string;
   public content?: string;
   public contentType?: 'markdown' | 'html';
+  public description?: string;
 
   public createdAt?: Date;
   public createdBy?: string;

--- a/app/src/app/wiki/page/components/wiki-page-setup-modal.component.html
+++ b/app/src/app/wiki/page/components/wiki-page-setup-modal.component.html
@@ -9,6 +9,13 @@
         <m-form-item mName="name" mLabel="entities.page-content.name" required>
           <m-input name="name" [(ngModel)]="pageContent.name" autofocus required></m-input>
         </m-form-item>
+        <m-form-item mName="description" [mLabel]="descriptionLabel">
+          <ng-template #descriptionLabel>
+            <label>{{'entities.page-content.description' | translate}}</label>
+            <m-icon mCode="exclamation-circle" style="margin-left: 0.5rem" m-tooltip mTitle="web.wiki-page.setup.description-tooltip"></m-icon>
+          </ng-template>
+          <m-textarea name="description" [(ngModel)]="pageContent.description"></m-textarea>
+        </m-form-item>
         <m-form-item mName="template" mLabel="entities.page.template">
           <m-select name="template" [(ngModel)]="page.settings.templateId">
             @for (template of templates; track template) {

--- a/app/src/app/wiki/page/components/wiki-page-setup-modal.component.ts
+++ b/app/src/app/wiki/page/components/wiki-page-setup-modal.component.ts
@@ -6,7 +6,7 @@ import {environment} from 'environments/environment';
 import {PreferencesService} from 'term-web/core/preferences/preferences.service';
 import {Page, PageContent, PageLink, Tag, TagLibService, Template, TemplateLibService} from 'term-web/wiki/_lib';
 import {PageService} from 'term-web/wiki/page/services/page.service';
-import { MuiModalModule, MuiFormModule, MuiInputModule, MuiSelectModule, MuiIconModule, MuiTooltipModule, MuiButtonModule } from '@termx-health/ui';
+import { MuiModalModule, MuiFormModule, MuiInputModule, MuiTextareaModule, MuiSelectModule, MuiIconModule, MuiTooltipModule, MuiButtonModule } from '@termx-health/ui';
 
 import { MarinaUtilModule } from '@termx-health/util';
 
@@ -18,6 +18,7 @@ import { MarinaUtilModule } from '@termx-health/util';
     FormsModule,
     MuiFormModule,
     MuiInputModule,
+    MuiTextareaModule,
     AutofocusDirective,
     MuiSelectModule,
     MuiIconModule,

--- a/app/src/assets/i18n/en.json
+++ b/app/src/assets/i18n/en.json
@@ -527,6 +527,7 @@
 		"page-content": {
 			"content": "Content",
 			"content-type": "Content type",
+			"description": "Description",
 			"lang": "Language",
 			"name": "Name"
 		},
@@ -724,9 +725,12 @@
 			"acl": "ACL",
 			"active": "Active",
 			"code": "Code",
+			"default-language": "Default language",
+			"description": "Description",
 			"editors": "Editors",
 			"global-search": "Global search",
 			"github": "Github",
+			"languages": "Languages",
 			"msdevops": "Azure DevOps repository",
 			"name": "Name",
 			"owners": "Owners",
@@ -735,6 +739,8 @@
 			"shared": "Shared",
 			"singular": "Space",
 			"servers": "Servers",
+			"site-url": "Site URL",
+			"ssg": "Static site",
 			"viewers": "Viewers"
 		},
 		"ecosystem": {
@@ -2357,6 +2363,15 @@
 			"github-commit-message": "Commit message",
 			"github-empty": "Nothing to commit",
 			"github-integration": "Github integration",
+			"import-github": "Import from GitHub",
+			"import-github-branch": "Branch",
+			"import-github-confirm": "Replace this space's pages with the repository's content?",
+			"import-github-dir": "Directory",
+			"import-github-done": "Imported",
+			"import-github-run": "Import",
+			"import-github-token": "Token",
+			"import-github-url": "GitHub URL",
+			"import-github-warning": "Import replaces this space's existing pages with the repository's content. Images and attachments are not imported.",
 			"msdevops-integration": "Azure DevOps integration",
 			"github-pull": "Pull diff from",
 			"github-pull-confirm": "Are you sure you want to replace current data with the data from repository?",
@@ -2925,6 +2940,7 @@
 				"content-header": "",
 				"content-type-tooltip": "Changing the content type can change the content value",
 				"copy-to-clipboard": "",
+				"description-tooltip": "Short summary used as the page meta description on the published static site (SEO)",
 				"edit-header": "Configure",
 				"relation-header": "",
 				"usages": ""

--- a/app/src/assets/i18n/et.json
+++ b/app/src/assets/i18n/et.json
@@ -496,7 +496,8 @@
 			"content": "Sisu",
 			"content-type": "Sisu tüüp",
 			"lang": "Keel",
-			"name": "Nimetus"
+			"name": "Nimetus",
+			"description": "Kirjeldus"
 		},
 		"page-link": {
 			"order-number": "Jnr",
@@ -703,7 +704,12 @@
 			"servers": "Terminoloogiaserver",
 			"viewers": "Vaatajad",
 			"global-search": "Üldotsing",
-			"msdevops": "Azure DevOps repositoorium"
+			"msdevops": "Azure DevOps repositoorium",
+			"default-language": "Vaikekeel",
+			"description": "Kirjeldus",
+			"languages": "Keeled",
+			"site-url": "Saidi URL",
+			"ssg": "Staatiline sait"
 		},
 		"structure-definition": {
 			"code": "Kood",
@@ -2371,7 +2377,16 @@
 			"change-source-server": "Muuda ressursside lähteserverit",
 			"reload-diff-matrix": "Lae erinevuste maatriks uuesti",
 			"sync-resources": "Sünkroniseeri kõik ressursid (antud installatsioonist sihtserverisse)",
-			"clear-sync-resources": "Kustuta ja sünkroniseeri kõik ressursid (antud installatsioonist sihtserverisse)"
+			"clear-sync-resources": "Kustuta ja sünkroniseeri kõik ressursid (antud installatsioonist sihtserverisse)",
+			"import-github": "Impordi GitHubist",
+			"import-github-branch": "Haru",
+			"import-github-confirm": "Kas asendada selle ruumi lehed hoidla sisuga?",
+			"import-github-dir": "Kataloog",
+			"import-github-done": "Imporditud",
+			"import-github-run": "Impordi",
+			"import-github-token": "Juurdepääsuluba",
+			"import-github-url": "GitHubi URL",
+			"import-github-warning": "Import asendab selle ruumi olemasolevad lehed hoidla sisuga. Pilte ja manuseid ei impordita."
 		},
 		"structure-definition": {
 			"form": {
@@ -2905,7 +2920,8 @@
 				"copy-to-clipboard": "Kopeeri {{val}}",
 				"edit-header": "Muuda lehekülge",
 				"relation-header": "Seosed teiste lehekülgedega",
-				"usages": "Viited"
+				"usages": "Viited",
+				"description-tooltip": "Lühikokkuvõte, mida kasutatakse avaldatud staatilise saidi metakirjeldusena (SEO)"
 			},
 			"sidebar": {
 				"delete-confirm": "Kas oled kindel? NB! Ka selle kausta all olevad lehed kustutatakse!",

--- a/app/src/assets/i18n/lt.json
+++ b/app/src/assets/i18n/lt.json
@@ -467,7 +467,8 @@
       "content": "Turinys",
       "content-type": "Turinio tipas",
       "lang": "Kalba",
-      "name": "Pavadinimas"
+      "name": "Pavadinimas",
+      "description": "Aprašymas"
     },
     "page-link": {
       "order-number": "Užsakymo numeris",
@@ -699,7 +700,12 @@
       "servers": "Terminologijos serveriai",
       "viewers": "Turintys peržiūros teisę",
       "global-search": "Visuotinė paieška",
-      "msdevops": "Azure DevOps kodo saugykla"
+      "msdevops": "Azure DevOps kodo saugykla",
+      "default-language": "Numatytoji kalba",
+      "description": "Aprašymas",
+      "languages": "Kalbos",
+      "site-url": "Svetainės URL",
+      "ssg": "Statinė svetainė"
     },
     "structure-definition": {
       "code": "Kodas",
@@ -2297,7 +2303,16 @@
       "resources": "Ištekliai",
       "select-context": "Pasirinkite kontekstą",
       "sync-resources": "Sync all resources (from current installation to target server)",
-      "msdevops-integration": "Azure DevOps integracija"
+      "msdevops-integration": "Azure DevOps integracija",
+      "import-github": "Importuoti iš GitHub",
+      "import-github-branch": "Šaka",
+      "import-github-confirm": "Pakeisti šios erdvės puslapius saugyklos turiniu?",
+      "import-github-dir": "Katalogas",
+      "import-github-done": "Importuota",
+      "import-github-run": "Importuoti",
+      "import-github-token": "Prieigos raktas",
+      "import-github-url": "GitHub URL",
+      "import-github-warning": "Importas pakeičia esamus šios erdvės puslapius saugyklos turiniu. Paveikslėliai ir priedai neimportuojami."
     },
     "structure-definition": {
       "form": {
@@ -2914,7 +2929,8 @@
         "copy-to-clipboard": "Kopijuoti",
         "edit-header": "Keisti nustatymus",
         "relation-header": "Ryšiai",
-        "usages": "Panaudojimai"
+        "usages": "Panaudojimai",
+        "description-tooltip": "Trumpa santrauka, naudojama kaip puslapio meta aprašymas paskelbtoje statinėje svetainėje (SEO)"
       },
       "sidebar": {
         "delete-confirm": "Tikrai šalinti? Visi priklausantys puslapiai taip pat bus pašalinti!",


### PR DESCRIPTION
## What

UI for the wiki→mdbook metadata and the new GitHub import.

- **Page setup** — a description field.
- **Space edit** — a "Static site" section (localized description, languages, default language, site URL).
- **Import from GitHub** — an action on the space screen (URL / branch / directory / token) with a replace-content warning and a confirmation step.
- **i18n** — English, Estonian and Lithuanian strings (also moves the new import keys to the correct `web.space` namespace).

Pairs with the termx-server PR (uses `/spaces`, `/pages`, `/wiki-import/github`). Not for merge yet.
