### PR TITLE
Wiki: authenticate attachment image/download URLs

### DIFF
--- a/app/src/app/wiki/_lib/texteditor/editors/markdown/plugins/image.plugin.ts
+++ b/app/src/app/wiki/_lib/texteditor/editors/markdown/plugins/image.plugin.ts
@@ -1,22 +1,13 @@
-import {environment} from 'environments/environment';
-import {tokenAttrValue} from 'term-web/wiki/_lib/texteditor/editors/markdown/plugins/plugin.util';
-
-// matches "files/:pageId/:fileName"
-const filesRe = /^files\/(\d*)\/(.+)/;
-
-const filesLink = (url: string): string => {
-  const [_, id, name] = url.match(filesRe);
-  return `${environment.termxApi}/pages/${id}/files/${name}`;
-};
+import {filesLink, filesRe, tokenAttrValue} from 'term-web/wiki/_lib/texteditor/editors/markdown/plugins/plugin.util';
 
 
-export function localImage(md): void {
+export function localImage(md, mdOptions?: {token?: string}): void {
   const defaultRender = md.renderer.rules.image;
 
   md.renderer.rules.image = function (tokens, idx, options, env, self): string {
     const [val, setVal] = tokenAttrValue(tokens[idx], 'src');
     if (filesRe.test(val)) {
-      setVal(filesLink(val));
+      setVal(filesLink(val, mdOptions?.token));
     }
     return defaultRender(tokens, idx, options, env, self);
   };

--- a/app/src/app/wiki/_lib/texteditor/editors/markdown/plugins/link.plugin.ts
+++ b/app/src/app/wiki/_lib/texteditor/editors/markdown/plugins/link.plugin.ts
@@ -1,5 +1,5 @@
 import {parsePageRelationLink} from 'term-web/wiki/_lib/page/utils/page-relation.utils';
-import {tokenAttrValue} from 'term-web/wiki/_lib/texteditor/editors/markdown/plugins/plugin.util';
+import {filesLink, filesRe, tokenAttrValue} from 'term-web/wiki/_lib/texteditor/editors/markdown/plugins/plugin.util';
 
 const transformHref = (href: string, ctx: {spaceId?: number}): string => {
   const [system, value] = href.split(':');
@@ -53,7 +53,9 @@ export function localLink(md, mdOptions): void {
 
   md.renderer.rules.link_open = function (tokens, idx, options, env, self): string {
     const [val, setVal] = tokenAttrValue(tokens[idx], 'href');
-    if (val.includes(':')) {
+    if (filesRe.test(val)) {
+      setVal(filesLink(val, mdOptions?.token)); // page attachment download
+    } else if (val.includes(':')) {
       setVal(processHref(val, mdOptions));
     }
     return renderer(tokens, idx, options, env, self);

--- a/app/src/app/wiki/_lib/texteditor/editors/markdown/plugins/plugin.util.ts
+++ b/app/src/app/wiki/_lib/texteditor/editors/markdown/plugins/plugin.util.ts
@@ -1,3 +1,17 @@
+import {environment} from 'environments/environment';
+
+// matches "files/:pageId/:fileName" (an internal page attachment reference)
+export const filesRe = /^files\/(\d*)\/(.+)/;
+
+// Resolves a "files/<id>/<name>" reference to the attachment endpoint. A browser <img>/download
+// can't send the auth header, so the current token is appended as a query parameter (the server
+// accepts ?token= on GET requests).
+export function filesLink(url: string, token?: string): string {
+  const [, id, name] = url.match(filesRe);
+  const base = `${environment.termxApi}/pages/${id}/files/${name}`;
+  return token ? `${base}?token=${encodeURIComponent(token)}` : base;
+}
+
 export function tokenAttrValue(token, attr): [string, (val: string) => void] {
   const attrIdx = token.attrs.findIndex(a => a[0] === attr);
   if (attrIdx === -1) {

--- a/app/src/app/wiki/_lib/texteditor/editors/markdown/wiki-markdown-view.component.ts
+++ b/app/src/app/wiki/_lib/texteditor/editors/markdown/wiki-markdown-view.component.ts
@@ -1,4 +1,7 @@
-import { Component, Input, inject } from '@angular/core';
+import { Component, Input, OnDestroy, OnInit, inject } from '@angular/core';
+import {of, Subscription} from 'rxjs';
+import {environment} from 'environments/environment';
+import {AuthService} from 'term-web/core/auth';
 import {PreferencesService} from 'term-web/core/preferences/preferences.service';
 import {codeSystemConceptMatrixPlugin} from 'term-web/wiki/_lib/texteditor/editors/markdown/plugins/code-system-concept-matrix.plugin';
 import {valueSetConceptMatrixPlugin} from 'term-web/wiki/_lib/texteditor/editors/markdown/plugins/value-set-concept-matrix.plugin';
@@ -23,8 +26,9 @@ import { MarinaMarkdownModule } from '@termx-health/markdown';
   `,
     imports: [MarinaMarkdownModule],
 })
-export class WikiMarkdownViewComponent {
+export class WikiMarkdownViewComponent implements OnInit, OnDestroy {
   private preferences = inject(PreferencesService);
+  private authService = inject(AuthService);
 
   @Input() public value?: string;
   @Input() public prerender?: boolean;
@@ -41,7 +45,22 @@ export class WikiMarkdownViewComponent {
       drawioPlugin
     ],
     options: {
-      spaceId: this.preferences.spaceId // todo: provide as @Input?
+      spaceId: this.preferences.spaceId, // todo: provide as @Input?
+      token: undefined as string | undefined // appended to page attachment URLs so <img>/downloads authenticate
     }
   };
+
+  private tokenSub?: Subscription;
+
+  public ngOnInit(): void {
+    // The current auth token, so attachment images/downloads can authenticate via ?token=.
+    const token$ = environment.yupiEnabled ? of('yupi') : this.authService.token;
+    this.tokenSub = token$.subscribe(token => {
+      this.plugins = {...this.plugins, options: {...this.plugins.options, token}};
+    });
+  }
+
+  public ngOnDestroy(): void {
+    this.tokenSub?.unsubscribe();
+  }
 }


### PR DESCRIPTION
## What

Make wiki **attachment** images and download links load in the browser. The renderer rewrote `files/<id>/<name>` references to the API URL, but a browser `<img>`/download can't send the `Authorization` header, so they 403'd.

Now the current auth token is appended to those URLs as `?token=` (the server accepts it on GET):
- `image.plugin` and `link.plugin` append the token to image `src` and download `href`.
- The wiki markdown view resolves the token once (`yupi` in dev, the OIDC access token otherwise) and passes it through the plugin options.

## Validation
- Image renders (`/pages/174/files/…?token=…`, `naturalWidth 854×1280`).
- CV download link resolves to `/pages/176/files/IgorBossenkoCV.pdf?token=…`.

Pairs with the termx-server change that accepts `?token=` on GET. (Independent of the still-open wiki-metadata PR #122 — different files.)
