### PR TITLE
Add editable slug field to page setup modal

### DIFF
--- a/app/src/app/wiki/page/components/wiki-page-setup-modal.component.html
+++ b/app/src/app/wiki/page/components/wiki-page-setup-modal.component.html
@@ -9,6 +9,13 @@
         <m-form-item mName="name" mLabel="entities.page-content.name" required>
           <m-input name="name" [(ngModel)]="pageContent.name" autofocus required></m-input>
         </m-form-item>
+        <m-form-item mName="slug" [mLabel]="slugLabel">
+          <ng-template #slugLabel>
+            <label>{{'entities.page-content.slug' | translate}}</label>
+            <m-icon mCode="exclamation-circle" style="margin-left: 0.5rem" m-tooltip mTitle="web.wiki-page.setup.slug-tooltip"></m-icon>
+          </ng-template>
+          <m-input name="slug" [(ngModel)]="pageContent.slug" placeholder="{{'web.wiki-page.setup.slug-placeholder' | translate}}"></m-input>
+        </m-form-item>
         <m-form-item mName="description" [mLabel]="descriptionLabel">
           <ng-template #descriptionLabel>
             <label>{{'entities.page-content.description' | translate}}</label>

--- a/app/src/assets/i18n/en.json
+++ b/app/src/assets/i18n/en.json
@@ -2943,6 +2943,8 @@
 				"description-tooltip": "Short summary used as the page meta description on the published static site (SEO)",
 				"edit-header": "Configure",
 				"relation-header": "",
+				"slug-placeholder": "Derived from the name",
+				"slug-tooltip": "The page's URL identifier. Leave blank to derive it from the name. Changing it changes the page URL; existing links won't redirect.",
 				"usages": ""
 			},
 			"sidebar": {

--- a/app/src/assets/i18n/et.json
+++ b/app/src/assets/i18n/et.json
@@ -2921,7 +2921,9 @@
 				"edit-header": "Muuda lehekülge",
 				"relation-header": "Seosed teiste lehekülgedega",
 				"usages": "Viited",
-				"description-tooltip": "Lühikokkuvõte, mida kasutatakse avaldatud staatilise saidi metakirjeldusena (SEO)"
+				"description-tooltip": "Lühikokkuvõte, mida kasutatakse avaldatud staatilise saidi metakirjeldusena (SEO)",
+				"slug-placeholder": "Tuletatakse nimest",
+				"slug-tooltip": "Lehekülje URL-i identifikaator. Jäta tühjaks, et see nimest tuletada. Muutmine muudab lehekülje URL-i; olemasolevad lingid ei suunata ümber."
 			},
 			"sidebar": {
 				"delete-confirm": "Kas oled kindel? NB! Ka selle kausta all olevad lehed kustutatakse!",

--- a/app/src/assets/i18n/lt.json
+++ b/app/src/assets/i18n/lt.json
@@ -2930,7 +2930,9 @@
         "edit-header": "Keisti nustatymus",
         "relation-header": "Ryšiai",
         "usages": "Panaudojimai",
-        "description-tooltip": "Trumpa santrauka, naudojama kaip puslapio meta aprašymas paskelbtoje statinėje svetainėje (SEO)"
+        "description-tooltip": "Trumpa santrauka, naudojama kaip puslapio meta aprašymas paskelbtoje statinėje svetainėje (SEO)",
+        "slug-placeholder": "Sudaroma iš pavadinimo",
+        "slug-tooltip": "Puslapio URL identifikatorius. Palikite tuščią, kad būtų sudarytas iš pavadinimo. Pakeitus pasikeičia puslapio URL; esamos nuorodos nebus peradresuotos."
       },
       "sidebar": {
         "delete-confirm": "Tikrai šalinti? Visi priklausantys puslapiai taip pat bus pašalinti!",


### PR DESCRIPTION
## Why

Companion to termx-server#427, which freezes a page-content's `slug` so a rename no longer changes its URL. With the slug stable, authors need a way to view and deliberately set it.

## What

Adds a **Slug** input to the wiki page setup modal, bound to `pageContent.slug`:
- Left blank on create → the server derives it from the name.
- A tooltip explains it's the page's URL identifier and that changing it changes the URL (existing links won't redirect).
- i18n keys (`slug-tooltip`, `slug-placeholder`) added for en / et / lt.