### PR TITLE
Space: static-site generator config UI + wiki entry point

### DIFF
--- a/app/src/app/sys/_lib/space/model/space.ts
+++ b/app/src/app/sys/_lib/space/model/space.ts
@@ -14,6 +14,14 @@ export class Space {
   public defaultLanguage?: string;
   public languages?: string[];
   public siteUrl?: string;
+  public ssgSkin?: string;
+  public ssgThemeAccent?: string;
+  public ssgThemeSwitcher?: boolean;
+  public ssgFooterMessage?: string;
+  public ssgFooterCopyright?: string;
+  public ssgTxServer?: string;
+  public ssgSearch?: boolean;
+  public ssgLogo?: string;
   public packages?: Package[];
   public integration?: {
     github?: {

--- a/app/src/app/sys/space/containers/space/space-edit.component.html
+++ b/app/src/app/sys/space/containers/space/space-edit.component.html
@@ -70,6 +70,32 @@
             <m-form-item mName="siteUrl" mLabel="entities.space.site-url">
               <m-input name="siteUrl" [(ngModel)]="space.siteUrl" placeholder="https://example.org/"></m-input>
             </m-form-item>
+            <m-divider mText="entities.space.ssg-generator"></m-divider>
+            <m-alert mType="info" style="margin-bottom: 1rem">{{'web.space.ssg-generator-hint' | translate}}</m-alert>
+            <m-form-item mName="ssgSkin" mLabel="entities.space.ssg-skin">
+              <m-input name="ssgSkin" [(ngModel)]="space.ssgSkin" placeholder="default"></m-input>
+            </m-form-item>
+            <m-form-item mName="ssgThemeAccent" mLabel="entities.space.ssg-accent">
+              <m-input name="ssgThemeAccent" [(ngModel)]="space.ssgThemeAccent" placeholder="#2f6feb"></m-input>
+            </m-form-item>
+            <m-form-item mName="ssgThemeSwitcher" mLabel="entities.space.ssg-theme-switcher">
+              <m-checkbox name="ssgThemeSwitcher" [(ngModel)]="space.ssgThemeSwitcher"></m-checkbox>
+            </m-form-item>
+            <m-form-item mName="ssgFooterMessage" mLabel="entities.space.ssg-footer-message">
+              <m-input name="ssgFooterMessage" [(ngModel)]="space.ssgFooterMessage"></m-input>
+            </m-form-item>
+            <m-form-item mName="ssgFooterCopyright" mLabel="entities.space.ssg-footer-copyright">
+              <m-input name="ssgFooterCopyright" [(ngModel)]="space.ssgFooterCopyright"></m-input>
+            </m-form-item>
+            <m-form-item mName="ssgTxServer" mLabel="entities.space.ssg-tx-server">
+              <m-input name="ssgTxServer" [(ngModel)]="space.ssgTxServer" placeholder="https://example.org/api/fhir"></m-input>
+            </m-form-item>
+            <m-form-item mName="ssgSearch" mLabel="entities.space.ssg-search">
+              <m-checkbox name="ssgSearch" [(ngModel)]="space.ssgSearch"></m-checkbox>
+            </m-form-item>
+            <m-form-item mName="ssgLogo" mLabel="entities.space.ssg-logo">
+              <m-input name="ssgLogo" [(ngModel)]="space.ssgLogo"></m-input>
+            </m-form-item>
             <m-divider>
               <span>{{'web.space.github-integration' | translate}}</span>
               <m-checkbox style="padding-left: 10px" [(mChecked)]="githubEnabled"></m-checkbox>

--- a/app/src/app/wiki/page/components/wiki-space-overview.component.html
+++ b/app/src/app/wiki/page/components/wiki-space-overview.component.html
@@ -10,7 +10,11 @@
     <span style="margin-top: 1rem">{{totalPages}}</span>
   </div>
   @if (space) {
-    <m-dropdown style="margin-top: 1rem">
+    <div class="m-items-middle" style="margin-top: 1rem; gap: 0.5rem">
+    <m-button mDisplay="text" [routerLink]="['/spaces', space.id, 'edit']">
+      <m-icon mCode="setting"/>&nbsp;{{'web.wiki-page.overview.configure' | translate}}
+    </m-button>
+    <m-dropdown>
       <m-button *m-dropdown-container mDisplay="text" [mLoading]="loader.state['export']">
         <m-icon mCode="download"/>&nbsp;{{'web.wiki-page.overview.export' | translate}}
       </m-button>
@@ -21,6 +25,7 @@
         <m-icon mCode="download"/>&nbsp;{{'web.wiki-page.header.export-space-html' | translate}}
       </a>
     </m-dropdown>
+    </div>
   }
 </div>
 

--- a/app/src/assets/i18n/en.json
+++ b/app/src/assets/i18n/en.json
@@ -741,6 +741,15 @@
 			"servers": "Servers",
 			"site-url": "Site URL",
 			"ssg": "Static site",
+			"ssg-generator": "Static site generator",
+			"ssg-skin": "Theme skin",
+			"ssg-accent": "Accent color",
+			"ssg-theme-switcher": "Show theme switcher",
+			"ssg-footer-message": "Footer message",
+			"ssg-footer-copyright": "Footer copyright",
+			"ssg-tx-server": "Terminology server (FHIR)",
+			"ssg-search": "Enable search",
+			"ssg-logo": "Logo",
 			"viewers": "Viewers"
 		},
 		"ecosystem": {
@@ -2362,6 +2371,7 @@
 			"github-clean": "Everything is up to date!",
 			"github-commit-message": "Commit message",
 			"github-empty": "Nothing to commit",
+			"ssg-generator-hint": "A hand-written .mdbook/config.yml in the repository still overrides these values.",
 			"github-integration": "Github integration",
 			"import-github": "Import from GitHub",
 			"import-github-branch": "Branch",
@@ -2928,6 +2938,7 @@
 			"overview": {
 				"pages": "Pages",
 				"export": "Export",
+				"configure": "Configure",
 				"recently-modified": {
 					"created": "Created {{date}}",
 					"header": "Recently modified",

--- a/app/src/assets/i18n/et.json
+++ b/app/src/assets/i18n/et.json
@@ -709,7 +709,16 @@
 			"description": "Kirjeldus",
 			"languages": "Keeled",
 			"site-url": "Saidi URL",
-			"ssg": "Staatiline sait"
+			"ssg": "Staatiline sait",
+			"ssg-generator": "Staatilise saidi generaator",
+			"ssg-skin": "Teema kujundus",
+			"ssg-accent": "Rõhuvärv",
+			"ssg-theme-switcher": "Näita teemavahetajat",
+			"ssg-footer-message": "Jaluse sõnum",
+			"ssg-footer-copyright": "Jaluse autoriõigus",
+			"ssg-tx-server": "Terminoloogiaserver (FHIR)",
+			"ssg-search": "Luba otsing",
+			"ssg-logo": "Logo"
 		},
 		"structure-definition": {
 			"code": "Kood",
@@ -2346,6 +2355,7 @@
 			"github-clean": "Kõik on ajakohane!",
 			"github-commit-message": "Commit teade",
 			"github-empty": "Muudatused puuduvad",
+			"ssg-generator-hint": "Repositooriumis olev käsitsi kirjutatud .mdbook/config.yml alistab need väärtused.",
 			"github-integration": "GitHub integratsioon",
 			"github-pull": "Tõmba uuendused repositooriumist",
 			"github-pull-confirm": "Kas olete kindel, et soovite asendada praegused andmed repositooriumist pärit andmetega?",
@@ -2905,6 +2915,7 @@
 			},
 			"overview": {
 				"pages": "Leheküljed",
+				"configure": "Seadista",
 				"recently-modified": {
 					"created": "Loodud {{date}}",
 					"header": "Hiljuti muudetud",

--- a/app/src/assets/i18n/lt.json
+++ b/app/src/assets/i18n/lt.json
@@ -705,7 +705,16 @@
       "description": "Aprašymas",
       "languages": "Kalbos",
       "site-url": "Svetainės URL",
-      "ssg": "Statinė svetainė"
+      "ssg": "Statinė svetainė",
+      "ssg-generator": "Statinės svetainės generatorius",
+      "ssg-skin": "Temos apipavidalinimas",
+      "ssg-accent": "Akcento spalva",
+      "ssg-theme-switcher": "Rodyti temos perjungiklį",
+      "ssg-footer-message": "Poraštės žinutė",
+      "ssg-footer-copyright": "Poraštės autorių teisės",
+      "ssg-tx-server": "Terminologijos serveris (FHIR)",
+      "ssg-search": "Įjungti paiešką",
+      "ssg-logo": "Logotipas"
     },
     "structure-definition": {
       "code": "Kodas",
@@ -2278,6 +2287,7 @@
       "github-clean": "Viskas atnaujinta!",
       "github-commit-message": "Pranešimas apie pakeitimus",
       "github-empty": "Nėra pakeitimų",
+      "ssg-generator-hint": "Repozitorijoje esantis rankiniu būdu sukurtas .mdbook/config.yml nustelbia šias reikšmes.",
       "github-integration": "Github integravimas",
       "github-pull": "Įkelti pakeitimus iš",
       "github-pull-confirm": "Tikrai norite pakeisti esamus duomenis duomenimis iš kodo saugyklos?",
@@ -2914,6 +2924,7 @@
       },
       "overview": {
         "pages": "Puslapiai",
+        "configure": "Konfigūruoti",
         "recently-modified": {
           "created": "Sukurta {{date}}",
           "header": "Neseniai pakeista",


### PR DESCRIPTION
## Why

Companion to termx-server#(ssg) and mdbook#(ssg). Surfaces the mdbook generator settings on the space so the published static site is configured from the wiki, not a hand-written `.mdbook/config.yml`.

## What

- **Model:** `Space` gains the `ssg*` fields.
- **Space edit:** a "Static site generator" group in the existing static-site section — theme skin/accent, theme-switcher toggle, footer message/copyright, terminology server, search toggle, logo — with a hint that a repo's `config.yml` still overrides them.
- **Wiki root page:** the space overview gets a **Configure** action linking to the space settings, so the config is reachable from where you read the space.
- i18n for en / et / lt.

`ng build` passes (templates type-check, i18n keys resolve).