### PR TITLE
Make skin primaryColor theme ng-zorro controls, and populate ee-gov

### DIFF
--- a/app/src/app/core/skin/ant-primary-palette.ts
+++ b/app/src/app/core/skin/ant-primary-palette.ts
@@ -1,0 +1,64 @@
+import {TinyColor} from '@ctrl/tinycolor';
+import {generate} from '@ant-design/colors';
+
+/**
+ * ng-zorro is compiled with ant-design's **variable** theme (see `styles/styles.less`), so every
+ * primary-coloured control resolves `var(--ant-primary-*)` at runtime instead of a colour baked in
+ * at LESS compile time. That is what lets a skin's `primaryColor` reach ant controls at all —
+ * before it, `SkinConfig.primaryColor` only moved `--color-primary` (marina-ui + our own CSS) and
+ * ant buttons/checkboxes/pickers kept the compiled default, so every skin needed a hand-written
+ * `.ant-*` override block.
+ *
+ * The derivation mirrors ant-design v4's own `registerTheme`: the 1–10 palette comes from
+ * `@ant-design/colors`, hover is shade 5, active is shade 7, and the `-deprecated-*` entries are
+ * the legacy LESS-function equivalents that older components still reference.
+ */
+export const ANT_PRIMARY_VARS = [
+  '--ant-primary-color',
+  '--ant-primary-color-hover',
+  '--ant-primary-color-active',
+  '--ant-primary-color-outline',
+  '--ant-primary-1', '--ant-primary-2', '--ant-primary-3', '--ant-primary-4',
+  '--ant-primary-5', '--ant-primary-6', '--ant-primary-7',
+  '--ant-primary-color-deprecated-l-35',
+  '--ant-primary-color-deprecated-l-20',
+  '--ant-primary-color-deprecated-t-20',
+  '--ant-primary-color-deprecated-t-50',
+  '--ant-primary-color-deprecated-f-12',
+  '--ant-primary-color-active-deprecated-f-30',
+  '--ant-primary-color-active-deprecated-d-02',
+] as const;
+
+/**
+ * Build the full `--ant-primary-*` set from one base colour.
+ * Returns an empty object for a colour ant-design can't parse, so a bad skin value leaves the
+ * compiled defaults in place rather than blanking the palette.
+ */
+export function antPrimaryPalette(base: string): Record<string, string> {
+  const parsed = new TinyColor(base);
+  if (!parsed.isValid) {
+    return {};
+  }
+  const p = generate(base);
+  const shade1 = new TinyColor(p[0]);
+  return {
+    '--ant-primary-color': base,
+    '--ant-primary-color-hover': p[4],
+    '--ant-primary-color-active': p[6],
+    '--ant-primary-color-outline': parsed.clone().setAlpha(0.2).toRgbString(),
+    '--ant-primary-1': p[0],
+    '--ant-primary-2': p[1],
+    '--ant-primary-3': p[2],
+    '--ant-primary-4': p[3],
+    '--ant-primary-5': p[4],
+    '--ant-primary-6': p[5],
+    '--ant-primary-7': p[6],
+    '--ant-primary-color-deprecated-l-35': parsed.clone().lighten(35).toHexString(),
+    '--ant-primary-color-deprecated-l-20': parsed.clone().lighten(20).toHexString(),
+    '--ant-primary-color-deprecated-t-20': parsed.clone().tint(20).toHexString(),
+    '--ant-primary-color-deprecated-t-50': parsed.clone().tint(50).toHexString(),
+    '--ant-primary-color-deprecated-f-12': parsed.clone().setAlpha(0.12).toRgbString(),
+    '--ant-primary-color-active-deprecated-f-30': shade1.clone().setAlpha(0.3).toRgbString(),
+    '--ant-primary-color-active-deprecated-d-02': shade1.clone().darken(2).toHexString(),
+  };
+}

--- a/app/src/app/core/skin/skin.service.ts
+++ b/app/src/app/core/skin/skin.service.ts
@@ -3,6 +3,7 @@ import {Injectable, inject} from '@angular/core';
 import {environment} from 'environments/environment';
 import {SkinConfig} from 'environments/environment.base';
 import {catchError, firstValueFrom, of} from 'rxjs';
+import {ANT_PRIMARY_VARS, antPrimaryPalette} from './ant-primary-palette';
 import {BUILTIN_SKINS, SkinDefinition} from './skin';
 
 /** Fields an external/inline skin is allowed to set. Anything else is ignored. */
@@ -27,8 +28,11 @@ export class SkinService {
   private appliedVarKeys: string[] = [];
 
   private static readonly STORAGE_KEY = 'tw-skin';
-  // Inline CSS custom properties this service sets; cleared before each apply so switching skins resets cleanly.
-  private static readonly RESET_PROPS = ['--color-primary', '--primary-color', '--skin-header-color'];
+  // Inline CSS custom properties this service sets; cleared before each apply so switching skins
+  // resets cleanly. Clearing the ant vars falls back to the defaults in styles/theme.less.
+  private static readonly RESET_PROPS = [
+    '--color-primary', '--primary-color', '--skin-header-color', ...ANT_PRIMARY_VARS
+  ];
 
   public get skin(): SkinDefinition {
     return this._skin;
@@ -102,6 +106,11 @@ export class SkinService {
     if (skin.primaryColor) {
       root.style.setProperty('--color-primary', skin.primaryColor);
       root.style.setProperty('--primary-color', skin.primaryColor);
+      // ng-zorro is compiled with ant's variable theme, so driving the --ant-primary-* palette is
+      // what makes buttons/checkboxes/pickers/menus follow the skin. Without it a skin only
+      // recoloured marina-ui surfaces and every skin needed its own hand-written .ant-* block.
+      Object.entries(antPrimaryPalette(skin.primaryColor))
+        .forEach(([k, v]) => root.style.setProperty(k, v));
     }
     if (skin.headerColor) {
       root.style.setProperty('--skin-header-color', skin.headerColor);

--- a/app/src/app/core/skin/skin.ts
+++ b/app/src/app/core/skin/skin.ts
@@ -42,10 +42,29 @@ const CS_GOV: SkinDefinition = {
   // stylesheets: ['assets/skins/cs-gov/gov-design-system.css'],
 };
 
-/** Estonian government skin — scaffold. TODO: official ee-gov design tokens + logos. */
+/**
+ * Estonian government skin — design tokens from TEHIK's AKK (Andmekirjelduskeskkond) deployment,
+ * which until now carried them as a compiled-in theme in its own shell application.
+ *
+ * The primary is AKK's brand cyan-blue at the nearest shade that meets WCAG AA: the original
+ * `#0083ba` reaches only 4.24:1 on white, below the 4.5:1 needed for normal text, and the primary
+ * is used for headings and card titles. `#007cb0` keeps the hue (197.7°) and saturation (100%)
+ * and drops lightness 36.5% → 34%, giving 4.66:1 — visually near-identical, and consistent with
+ * the contrast floor marina-ui already holds itself to for secondary text and placeholders.
+ *
+ * Deliberately not carried over from AKK: `--page-header-height: 0` and
+ * `--header-border-bottom-width: 0` suppress TermX's own header because that shell supplies its
+ * own navbar — a standalone TermX would lose its header. Institutional logos and the MTA corporate
+ * stylesheet stay with the deployment; serve them via `stylesheets`/`logo` (see docs/skins.md).
+ */
 const EE_GOV: SkinDefinition = {
   id: 'ee-gov',
-  primaryColor: '#0050a0',
+  primaryColor: '#007cb0',
+  cssVars: {
+    '--color-background': '#dbdfe2',
+    '--border-radius': '0.3em',
+    '--border-radius-component': '6px',
+  },
 };
 
 /** Lithuanian government skin — scaffold. TODO: official lt-gov design tokens + logos. */

--- a/app/src/styles/styles.less
+++ b/app/src/styles/styles.less
@@ -1,4 +1,7 @@
-@import "ng-zorro-antd/ng-zorro-antd.less";
+// ng-zorro's **variable** theme: components emit `var(--ant-primary-*)` instead of a colour baked
+// in at LESS compile time, so a skin's primaryColor can reach ant controls at runtime. Defaults for
+// those vars are set in theme.less; SkinService overrides them when a skin defines a primary colour.
+@import "ng-zorro-antd/ng-zorro-antd.variable.less";
 @import "@termx-health/ui/mui.styles.less";
 @import "@termx-health/ui/src/style/themes/default";
 @import "@termx-health/markdown-parser/markdown.styles.less";
@@ -6,7 +9,11 @@
 @import "diff2html/bundles/css/diff2html.min.css";
 @import "prismjs/themes/prism.css";
 
-@primary-color: #1464C0;
+// Must stay last: LESS resolves root-scope variables last-declaration-wins, and both the ant
+// variable theme and marina-ui's default theme assign @primary-color. Pointing it at the CSS
+// variable (rather than a literal) is what makes the whole ant cascade runtime-switchable —
+// it also flows into marina-ui's `--color-primary: @primary-color` mapping.
+@primary-color: ~'var(--ant-primary-color)';
 
 @import "theme";
 

--- a/app/src/styles/theme.less
+++ b/app/src/styles/theme.less
@@ -2,6 +2,32 @@ html {
   font-size: 14px;
 }
 
+// TermX's default ant-design primary palette. ng-zorro is compiled with the variable theme, whose
+// own :root block defaults to ant's stock blue — these restore TermX blue as the baseline so a
+// deployment with no skin renders exactly as before. SkinService replaces the whole set at runtime
+// when a skin defines primaryColor; keep in sync with antPrimaryPalette() in core/skin.
+// Derived per ant-design v4 registerTheme: 1–10 from @ant-design/colors, hover = 5, active = 7.
+:root {
+  --ant-primary-color: #1464C0;
+  --ant-primary-color-hover: #3581cc;
+  --ant-primary-color-active: #084799;
+  --ant-primary-color-outline: rgba(20, 100, 192, 0.2);
+  --ant-primary-1: #e6f6ff;
+  --ant-primary-2: #b3d9f2;
+  --ant-primary-3: #85bce6;
+  --ant-primary-4: #5b9ed9;
+  --ant-primary-5: #3581cc;
+  --ant-primary-6: #1464c0;
+  --ant-primary-7: #084799;
+  --ant-primary-color-deprecated-l-35: #93c0f4;
+  --ant-primary-color-deprecated-l-20: #4d97ed;
+  --ant-primary-color-deprecated-t-20: #4383cd;
+  --ant-primary-color-deprecated-t-50: #8ab2e0;
+  --ant-primary-color-deprecated-f-12: rgba(20, 100, 192, 0.12);
+  --ant-primary-color-active-deprecated-f-30: rgba(230, 246, 255, 0.3);
+  --ant-primary-color-active-deprecated-d-02: #dcf2ff;
+}
+
 // Skin: header background can be overridden per-skin via --skin-header-color
 // (set at runtime by SkinService). Falls back to the marina-ui default.
 .m-header {
@@ -43,28 +69,6 @@ html[data-skin="cs-gov"] .m-header {
       var(--skin-accent, #F7B935) 33.33% 66.66%,
       var(--skin-accent-3, #C2CD21) 66.66% 100%);
   }
-}
-
-// Skin: 'cs-gov' — ng-zorro/marina controls are themed at LESS compile time (@primary-color),
-// so they don't follow the runtime skin. Re-point the primary-coloured controls to NCEZ navy
-// so buttons/checkboxes/switches/radios match the navy header instead of the default blue.
-@cs-gov-navy: #183C62;
-@cs-gov-navy-hover: #2A5183;
-html[data-skin="cs-gov"] {
-  .ant-btn-primary {
-    background-color: @cs-gov-navy;
-    border-color: @cs-gov-navy;
-
-    &:hover, &:focus {
-      background-color: @cs-gov-navy-hover;
-      border-color: @cs-gov-navy-hover;
-    }
-  }
-  .ant-checkbox-checked .ant-checkbox-inner { background-color: @cs-gov-navy; border-color: @cs-gov-navy; }
-  .ant-checkbox-checked::after { border-color: @cs-gov-navy; }
-  .ant-switch-checked { background-color: @cs-gov-navy; }
-  .ant-radio-checked .ant-radio-inner { border-color: @cs-gov-navy; }
-  .ant-radio-inner::after { background-color: @cs-gov-navy; }
 }
 
 // Skin: 'black' — a curated dark palette via marina-ui CSS variables (NOT the

--- a/docs/skins.md
+++ b/docs/skins.md
@@ -36,7 +36,7 @@ An external skin is a JSON object with these (all optional) fields:
 ```jsonc
 {
   "id": "acme",
-  "primaryColor": "#0a7d3c",          // sets --color-primary / --primary-color
+  "primaryColor": "#0a7d3c",          // themes ng-zorro controls + --color-primary (see below)
   "headerColor": "#0a7d3c",           // sets the app header background
   "headerText": "ACME Terminology",   // shown next to the app title
   "logo": "/assets/skins/acme/logo.svg",
@@ -50,6 +50,20 @@ External skins are **CSS + branding + tokens only** — they cannot ship JavaScr
 web components (that is reserved for built-in skins). A malformed or unreachable skin file falls
 back to `main` without breaking the app.
 
+## How `primaryColor` reaches ng-zorro controls
+
+ng-zorro is compiled with ant-design's **variable** theme (`styles/styles.less`), so components
+resolve `var(--ant-primary-*)` at runtime rather than a colour baked in at LESS compile time.
+`SkinService` derives the full palette from `primaryColor` — the 1–10 shades plus hover, active and
+outline, matching ant-design v4's own `registerTheme` — and sets those variables on `<html>`.
+
+That means one `primaryColor` themes buttons, checkboxes, radios, switches, tabs, menus, steps,
+pickers, trees and pagination together; a skin does **not** need hand-written `.ant-*` overrides.
+Semantic colours are untouched by design — a `dangerous` button stays red under every skin.
+
+Defaults live in `styles/theme.less` (`:root`), so a deployment with no skin renders unchanged.
+Keep them in sync with `antPrimaryPalette()` in `app/src/app/core/skin/ant-primary-palette.ts`.
+
 ## Adding assets
 
 Mount skin assets anywhere served under `/assets/` (e.g. `app/src/assets/skins/<id>/` in source,
@@ -59,10 +73,10 @@ which builds to `/assets/skins/<id>/`). Reference them with paths relative to th
 
 - **`main`** — default TermX look (no-op).
 - **`black`** — curated dark palette (marina-ui CSS variables; see `styles/theme.less`).
-- **`cs-gov`** — Czech NCEZ / MZČR branding (logos under `assets/skins/cs-gov/`, primary `#1464C0`).
+- **`cs-gov`** — Czech NCEZ / MZČR branding (logos under `assets/skins/cs-gov/`, primary `#183C62`).
   Branding-only by default; to enable the full gov.cz design-system look, serve its CSS and add it
   to the skin's `stylesheets` (see the registry in `app/src/app/core/skin/skin.ts`).
-- **`ee-gov`, `lt-gov`** — Estonian / Lithuanian scaffolds (primary color only; official design
-  tokens + logos TODO).
+- **`ee-gov`, `lt-gov`** — Estonian / Lithuanian scaffolds: primary colour only, so they theme the
+  controls but ship no official logos or design tokens yet.
 
 To add or change a built-in skin, edit `app/src/app/core/skin/skin.ts`.

--- a/docs/skins.md
+++ b/docs/skins.md
@@ -76,7 +76,11 @@ which builds to `/assets/skins/<id>/`). Reference them with paths relative to th
 - **`cs-gov`** — Czech NCEZ / MZČR branding (logos under `assets/skins/cs-gov/`, primary `#183C62`).
   Branding-only by default; to enable the full gov.cz design-system look, serve its CSS and add it
   to the skin's `stylesheets` (see the registry in `app/src/app/core/skin/skin.ts`).
-- **`ee-gov`, `lt-gov`** — Estonian / Lithuanian scaffolds: primary colour only, so they theme the
-  controls but ship no official logos or design tokens yet.
+- **`ee-gov`** — Estonian government tokens, from TEHIK's AKK deployment: brand cyan-blue primary
+  plus its page background and corner radii. The primary is AKK's `#0083ba` nudged to `#007cb0`,
+  the nearest shade of the same hue that meets WCAG AA on white (4.66:1 vs 4.24:1) — the primary
+  is used for headings and links, so it has to clear the text threshold. Institutional logos and
+  the deployment's own corporate stylesheet are not bundled; add them via `logo` / `stylesheets`.
+- **`lt-gov`** — Lithuanian scaffold: primary colour only, no official tokens or logos yet.
 
 To add or change a built-in skin, edit `app/src/app/core/skin/skin.ts`.

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@angular/platform-browser": "^21.0.0",
     "@angular/platform-browser-dynamic": "^21.0.0",
     "@angular/router": "^21.0.0",
+    "@ant-design/colors": "^7.2.1",
     "@codemirror/lang-markdown": "^6.2.0",
     "@ctrl/tinycolor": "^4.2.0",
     "@ngx-translate/core": "^17.0.0",


### PR DESCRIPTION
Two commits, in order: the mechanism, then the first real user of it. Both come out of `termx-agent/tehik/classifier-frontend-changes.md`.

---

# 1. Make `primaryColor` actually theme ng-zorro controls

## The problem

`SkinConfig.primaryColor` only moved `--color-primary`, which marina-ui and our own CSS read. ng-zorro was compiled with ant-design's **default** theme, so every control took its colour from the `@primary-color` LESS variable **at build time** and ignored the skin.

- **`ee-gov` and `lt-gov` did nothing visible** — they set only `primaryColor`, so their buttons stayed TermX blue.
- **`cs-gov` only worked** because `theme.less` carried a hand-written block re-pointing six `.ant-*` selectors at a hardcoded navy. Its own comment admitted why:
  > `// ng-zorro/marina controls are themed at LESS compile time (@primary-color), so they don't follow the runtime skin.`
- Every new skin needed that block, and it covered buttons/checkboxes/switches/radios but **not** menus, steps, pickers, trees, select or pagination. On the compiled CSS the primary colour appears in **~356** rules across all of those.

## The fix

Compile ng-zorro with ant's **variable** theme so components resolve `var(--ant-primary-*)` at runtime, and derive that palette from the skin in `SkinService`. The derivation mirrors ant-design v4's own `registerTheme`: 1–10 from `@ant-design/colors`, hover = shade 5, active = shade 7, plus the `-deprecated-*` entries older components still reference (all 18 are referenced by ng-zorro's CSS).

Defaults for TermX blue live in `theme.less`, so **a deployment with no skin renders exactly as before**.

One subtlety worth a reviewer's eye: `@primary-color` must stay the **last** root-scope assignment in `styles.less`. LESS resolves those last-declaration-wins, and both ant's variable theme and marina-ui's default theme assign it — a first attempt that only swapped the import left 144 literal colours in place and just **1** `var()` reference, because our literal was still winning. Pointing it at the CSS variable is what lets the cascade through, and it also flows into marina-ui's own `--color-primary: @primary-color` mapping.

**Deletes the `cs-gov` block** — the generic path reproduces it exactly.

### Verification (computed styles, not screenshots)

| Skin | `--ant-primary-color` | primary button | verdict |
|---|---|---|---|
| default (`main`) | `#1464C0` | `rgb(20, 100, 192)` | **unchanged** |
| `black` (no primaryColor) | `#1464C0` | `rgb(20, 100, 192)` | unchanged; dark palette intact |
| `ee-gov` | `#0050a0` → now `#007cb0` | follows | **now works** (previously inert) |
| `cs-gov` | `#183C62` | `rgb(24, 60, 98)` | matches the deleted block exactly |

Also: `cs-gov` checkbox/switch/radio all resolve `rgb(24, 60, 98)`; a **`dangerous` primary button stays red** (`rgb(255, 77, 79)`) under every skin — the trap a naive `.ant-btn-primary { background: var(--color-primary) }` would have hit, which ant's own CSS scopes correctly; switching back to `main` leaves **0** inline `--ant-primary-*` properties behind.

---

# 2. Populate `ee-gov` with TEHIK's AKK tokens

`ee-gov` was a scaffold with a guessed primary and nothing else. TEHIK's AKK deployment has been carrying the real Estonian tokens as a compiled-in theme inside its own shell app, where no other installation can use them.

**Ported:** brand primary, page background `#dbdfe2`, corner radii.

**Deliberately not ported:** `--page-header-height: 0` and `--header-border-bottom-width: 0`. Those suppress TermX's own header because that shell supplies its own navbar — a standalone TermX with `ee-gov` would lose its header. Institutional logos and the MTA corporate stylesheet stay with the deployment (`logo` / `stylesheets`), and are a licensing decision that isn't ours to make.

## The primary is adjusted for contrast — please sanity-check this call

AKK's `#0083ba` measures **4.24:1 on white**, under the 4.5:1 WCAG AA requires for normal text — and the primary is used for headings and links. `#007cb0` keeps the hue (197.7°) and saturation (100%) and drops lightness 36.5% → 34%, giving **4.66:1**. Visually near-identical, and consistent with the contrast floor marina-ui already documents for secondary text and placeholders.

Shipping `#0083ba` verbatim would have put a known AA failure into mainstream right after the recent a11y work, so I adjusted rather than copied. If TEHIK needs the exact brand value it's a one-line change — worth deciding explicitly rather than by default.

### Verification (against a running backend)

With `ee-gov` active, a **real** resource-list link and a **real** primary button both compute `rgb(0, 124, 176)`, and the page background `rgb(219, 223, 226)`.

---

## Notes

- `@ant-design/colors` was already in the tree via ng-zorro but undeclared; now explicit. `@ctrl/tinycolor` was already declared.
- `ng build` green. `ng lint`: **698 problems on this branch, 698 on `main`** — all pre-existing, neither new file flagged.
- Fixed a stale line in `docs/skins.md` that listed `cs-gov`'s primary as `#1464C0`; it is `#183C62`.
- Not verified: privilege-gated screens (the local backend authenticates as guest with no privileges). The probes target the shared control classes those screens use, and default-skin values are unchanged, so the risk is low.