### PR TITLE
Warn before the session expires

### DIFF
--- a/app/src/app/core/auth/auth.service.ts
+++ b/app/src/app/core/auth/auth.service.ts
@@ -6,10 +6,16 @@ import {MuiNotificationService} from '@termx-health/ui';
 import {EventTypes, OidcSecurityService, PublicEventsService} from 'angular-auth-oidc-client';
 import {environment} from 'environments/environment';
 import Cookies from 'js-cookie';
-import {catchError, filter, map, mergeMap, Observable, of, switchMap, tap} from 'rxjs';
+import {catchError, filter, interval, map, mergeMap, Observable, of, switchMap, take, tap} from 'rxjs';
+import {shouldWarnAboutExpiry} from './session-expiry';
 
 const COOKIE_OAUTH_TOKEN_KEY = 'termx-oauth-token';
 const REDIRECT_ORIGIN_URL = '__termx-redirect_origin_url';
+
+/** How often the session is checked for imminent expiry. */
+const SESSION_CHECK_INTERVAL_MS = 60_000;
+/** Warn when this little of the session is left. Matches the wording of core.session-expiration-warning. */
+const SESSION_WARNING_THRESHOLD_SEC = 300;
 
 export interface UserInfo {
   username: string;
@@ -30,6 +36,9 @@ export class AuthService {
     map(result => result.isAuthenticated)
   );
 
+  /** Set once per expiry window so the sticky warning isn't re-raised every check; cleared on refresh. */
+  private sessionWarningShown = false;
+
   public get token(): Observable<string> {
     return this.oidcSecurityService.getAccessToken();
   }
@@ -43,6 +52,7 @@ export class AuthService {
     this.updateAuthTokenCookie(oidcSecurityService);
     this.processAuthFinishEvents(eventService);
     this.processUserDataChangeEvents(eventService);
+    this.watchSessionExpiry();
   }
 
   public refresh(): Observable<UserInfo> {
@@ -216,5 +226,46 @@ export class AuthService {
           this.notificationService.error('core.session-expiration-error' , null, {duration: 0, closable: true});
         }
       });
+  }
+
+  /**
+   * Warns before the session dies, so a long edit isn't lost to a silent expiry.
+   *
+   * `core.session-expiration-error` (above) only fires once the session is already gone — by then
+   * unsaved work is unrecoverable. This polls the access token and raises a sticky warning while
+   * there is still time to act.
+   *
+   * Guests are skipped (they have no session to lose), and the warning is only raised when the
+   * refresh token cannot rescue the session — otherwise a silent refresh is about to happen and
+   * warning would be noise.
+   */
+  private watchSessionExpiry(): void {
+    interval(SESSION_CHECK_INTERVAL_MS).pipe(
+      switchMap(() => this.isAuthenticated.pipe(take(1))),
+      filter(isAuthenticated => isAuthenticated),
+      switchMap(() => this.oidcSecurityService.getPayloadFromAccessToken().pipe(take(1)))
+    ).subscribe(payload => this.checkSessionExpiry(payload?.['exp']));
+  }
+
+  private checkSessionExpiry(accessExp?: number): void {
+    const nowSec = Date.now() / 1000;
+    if (accessExp && accessExp - nowSec > SESSION_WARNING_THRESHOLD_SEC) {
+      // Comfortably alive — re-arm so a later expiry window warns again.
+      this.sessionWarningShown = false;
+      return;
+    }
+    if (this.sessionWarningShown) {
+      return;
+    }
+
+    this.oidcSecurityService.getRefreshToken().pipe(take(1)).subscribe(refreshToken => {
+      const warn = shouldWarnAboutExpiry({
+        accessExp, refreshToken, nowSec, thresholdSec: SESSION_WARNING_THRESHOLD_SEC
+      });
+      if (warn) {
+        this.sessionWarningShown = true;
+        this.notificationService.warning('core.session-expiration-warning', null, {duration: 0, closable: true});
+      }
+    });
   }
 }

--- a/app/src/app/core/auth/session-expiry.ts
+++ b/app/src/app/core/auth/session-expiry.ts
@@ -1,0 +1,58 @@
+/**
+ * Decision logic for the pre-expiry session warning, kept free of Angular and of the clock so it
+ * can be reasoned about (and exercised) directly. {@link AuthService.watchSessionExpiry} supplies
+ * the tokens and the current time.
+ */
+
+/** `exp` out of a JWT, or undefined when the token is absent, opaque or malformed. */
+export function readJwtExp(token?: string | null): number | undefined {
+  const payload = token?.split('.')[1];
+  if (!payload) {
+    return undefined;
+  }
+  try {
+    // base64url -> base64 before decoding; JWT payloads are not padded base64.
+    const exp = JSON.parse(atob(payload.replace(/-/g, '+').replace(/_/g, '/')))['exp'];
+    return typeof exp === 'number' ? exp : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export interface SessionExpiryState {
+  /** `exp` claim of the access token, in seconds. */
+  accessExp?: number;
+  /** Raw refresh token, if the flow issued one. */
+  refreshToken?: string | null;
+  /** Current time, in seconds. */
+  nowSec: number;
+  /** Warn once this little of the session is left, in seconds. */
+  thresholdSec: number;
+}
+
+/**
+ * Whether the user should be warned that their session is about to end.
+ *
+ * True only when the access token is inside the threshold **and** the refresh token cannot rescue
+ * the session — a silent refresh is about to happen otherwise, and warning would be noise.
+ *
+ * A refresh token we cannot read (opaque tokens are not JWTs) is treated as able to refresh: a
+ * sticky banner on every session would be worse than occasionally missing a warning.
+ */
+export function shouldWarnAboutExpiry(state: SessionExpiryState): boolean {
+  const {accessExp, refreshToken, nowSec, thresholdSec} = state;
+  if (!accessExp) {
+    return false;
+  }
+  if (accessExp - nowSec > thresholdSec) {
+    return false;
+  }
+  if (!refreshToken) {
+    return true;
+  }
+  const refreshExp = readJwtExp(refreshToken);
+  if (refreshExp === undefined) {
+    return false;
+  }
+  return refreshExp - nowSec <= thresholdSec;
+}


### PR DESCRIPTION
The last frontend item from `termx-agent/tehik/classifier-frontend-changes.md`.

## Why

`core.session-expiration-warning` has shipped **translated in all seven locales** since the koodivaramu merge and is referenced **nowhere in source** — the string exists, the feature doesn't:

```bash
$ grep -rn 'session-expiration-warning' app/src --include='*.ts' --include='*.html'
# (no matches — but the key is in cs/de/en/et/fr/lt/nl)
```

Its counterpart `core.session-expiration-error` *is* wired up, but only to `UserDataChanged` — it fires once the session is **already gone**, by which point unsaved work is unrecoverable. There was no warning while the user could still act.

TEHIK's AKK shell built that warning on top of its vendored copy of termx-web. This ports the generic half.

## What it does

Polls the access token every minute and raises the sticky warning when the session is inside 5 minutes — but **only when the refresh token can't rescue it**, since otherwise a silent refresh is imminent and the banner would be noise. Guests are skipped. The flag re-arms after a refresh, so a long session warns again on the next expiry window instead of once ever.

## Two deliberate changes from the AKK original

1. **Opaque refresh tokens.** AKK parsed with a bare `JSON.parse(atob(t.split('.')[1])).exp`, which **throws on a non-JWT refresh token** — inside a `subscribe`, once a minute. `readJwtExp` returns `undefined` instead, and an unreadable token is treated as *able* to refresh: a sticky banner on every session is worse than an occasionally missed warning. (Keycloak issues JWT refresh tokens, so AKK wouldn't have hit this; other providers issue opaque ones.)
2. **The introspect-and-logoff half is not ported.** It's bound to AKK's own `/auth/introspect` endpoint and its `localStorage` token handoff. Mainstream already handles the dead-session case reactively via `UserDataChanged`, and force-logging users out is a behaviour change that shouldn't ride along in this PR.

## Verification

`angular.json` has **no `test` target** (the three stray `.spec.ts` files can't run, and adding the harness doesn't belong in a feature PR). So the decision logic is a pure function in `session-expiry.ts` — no Angular, no clock — and I exercised the real shipped code across every branch:

| case | warn | expected |
|---|---|---|
| no access exp (guest / no token) | false | false |
| plenty of time left | false | false |
| expiring, no refresh token | **true** | true |
| expiring, refresh token still good | false | false |
| expiring, refresh token also expiring | **true** | true |
| expiring, opaque refresh token | false | false |
| expiring, malformed refresh JWT | false | false |
| already expired, no refresh | **true** | true |
| exactly at threshold boundary | **true** | true |
| one second past the boundary | false | false |

`readJwtExp`: valid → `42`; opaque / empty / null / no-`exp` → `undefined`. **10/10 pass.**

In the browser: app runs with the watchdog active, a full interval elapses with **zero** console errors and no notification for an unauthenticated session. The previously-dead i18n key resolves everywhere — `en` "Session expires in less than 5 minutes!", `et` "Sessioon aegub vähem kui 5 minuti pärast! Vajadusel salvesta!", `lt` "Sesija pasibaigs mažiau nei per 5 minutes!".

`ng build` green. `ng lint`: **698 problems on this branch, 698 on `main`** — all pre-existing, neither file flagged.

**Not verified:** the warning firing against a real expiring session — that needs an OIDC provider and a ~55-minute wait. The logic table above covers the decision; what's unexercised end-to-end is the plumbing between `getPayloadFromAccessToken()` and it, which is four lines.